### PR TITLE
fix: Disable CSRF for the REST API

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -259,7 +259,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "codecov_auth.authentication.UserTokenAuthentication",
         "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
+        "codecov_auth.authentication.SessionAuthentication",
     ),
     "DEFAULT_PAGINATION_CLASS": "api.shared.pagination.StandardPageNumberPagination",
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),

--- a/codecov_auth/authentication/__init__.py
+++ b/codecov_auth/authentication/__init__.py
@@ -64,3 +64,9 @@ class InternalTokenAuthentication(authentication.TokenAuthentication):
             return (InternalUser(), InternalToken(token=key))
 
         raise exceptions.AuthenticationFailed("Invalid token.")
+
+
+class SessionAuthentication(authentication.SessionAuthentication):
+    def enforce_csrf(self, request):
+        # disable CSRF for the REST API
+        pass


### PR DESCRIPTION
This is already disabled for the GraphQL endpoint and I believe we weren't using it previously w/ our custom auth scheme.  It's just now that we're using the `SessionAuthentication` which calls `enforce_csrf`.  We'll override that as a noop for now.