### PR TITLE
Send destination url the proper way

### DIFF
--- a/upload/serializers.py
+++ b/upload/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from codecov_auth.models import Owner
@@ -17,6 +18,7 @@ class UploadSerializer(serializers.ModelSerializer):
     flags = FlagListField(required=False)
     ci_url = serializers.CharField(source="build_url", required=False, allow_null=True)
     version = serializers.CharField(write_only=True, required=False)
+    url = serializers.SerializerMethodField()
 
     class Meta:
         read_only_fields = (
@@ -26,6 +28,7 @@ class UploadSerializer(serializers.ModelSerializer):
             "state",
             "provider",
             "upload_type",
+            "url",
         )
         fields = read_only_fields + (
             "ci_url",
@@ -43,6 +46,11 @@ class UploadSerializer(serializers.ModelSerializer):
         repo = obj.report.commit.repository
         archive_service = ArchiveService(repo)
         return archive_service.create_presigned_put(obj.storage_path)
+
+    def get_url(self, obj: ReportSession):
+        repository = obj.report.commit.repository
+        commit = obj.report.commit
+        return f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/commit/{commit.commitid}"
 
     def create(self, validated_data):
         flag_names = (

--- a/upload/tests/test_serializers.py
+++ b/upload/tests/test_serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework.exceptions import ErrorDetail
 
 from codecov_auth.tests.factories import OwnerFactory
@@ -63,6 +64,7 @@ def test_upload_serializer_contains_expected_fields_no_flags(transactional_db, m
     )
     upload = get_fake_upload()
     serializer = UploadSerializer(instance=upload)
+    repo = upload.report.commit.repository
     expected_data = {
         "external_id": str(upload.external_id),
         "created_at": upload.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
@@ -75,6 +77,7 @@ def test_upload_serializer_contains_expected_fields_no_flags(transactional_db, m
         "job_code": upload.job_code,
         "env": upload.env,
         "name": upload.name,
+        "url": f"{settings.CODECOV_DASHBOARD_URL}/{repo.author.service}/{repo.author.username}/{repo.name}/commit/{upload.report.commit.commitid}",
     }
     assert serializer.data == expected_data
 
@@ -88,6 +91,7 @@ def test_upload_serializer_contains_expected_fields_with_flags(
     )
     upload = get_fake_upload_with_flags()
     serializer = UploadSerializer(instance=upload)
+    repo = upload.report.commit.repository
     expected_data = {
         "external_id": str(upload.external_id),
         "created_at": upload.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
@@ -100,6 +104,7 @@ def test_upload_serializer_contains_expected_fields_with_flags(
         "job_code": upload.job_code,
         "env": upload.env,
         "name": upload.name,
+        "url": f"{settings.CODECOV_DASHBOARD_URL}/{repo.author.service}/{repo.author.username}/{repo.name}/commit/{upload.report.commit.commitid}",
     }
     assert serializer.data == expected_data
 

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.http import HttpRequest, HttpResponseNotAllowed
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -83,17 +82,7 @@ class UploadViews(ListCreateAPIView, GetterMixin):
         metrics.incr("uploads.accepted", 1)
         self.activate_repo(repository)
 
-        # We'll be returning this to the user as part of the response
-        self.destination_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/commit/{commit.commitid}"
-
         return instance
-
-    def create(self, request, *args, **kwargs):
-        response = super().create(request, *args, **kwargs)
-        data = {"url": self.destination_url}
-        data.update(response.data)
-        response.data = data
-        return response
 
     def list(
         self,


### PR DESCRIPTION
didn't like how we were sending the destination url. Using the serializer instead

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
