### PR TITLE
fix: Simplify commit uploads query for now

### DIFF
--- a/graphql_api/actions/commits.py
+++ b/graphql_api/actions/commits.py
@@ -28,19 +28,21 @@ def commit_uploads(commit: Commit) -> QuerySet[ReportSession]:
 
     sessions = commit.commitreport.sessions.prefetch_related("flags")
 
-    # sessions w/ flags and type 'uploaded'
-    uploaded = sessions.filter(upload_type="uploaded")
+    # # sessions w/ flags and type 'uploaded'
+    # uploaded = sessions.filter(upload_type="uploaded")
 
-    # carry forward flags that do not have an equivalent uploaded flag
-    carried_forward = sessions.filter(upload_type="carriedforward").exclude(
-        uploadflagmembership__flag_id__in=uploaded.values_list(
-            "uploadflagmembership__flag_id", flat=True
-        )
-    )
+    # # carry forward flags that do not have an equivalent uploaded flag
+    # carried_forward = sessions.filter(upload_type="carriedforward").exclude(
+    #     uploadflagmembership__flag_id__in=uploaded.values_list( <------------ FIXME: looks like `flag_id__in` is causing a seq scan in prod
+    #         "uploadflagmembership__flag_id", flat=True
+    #     )
+    # )
 
-    return (uploaded.prefetch_related("flags")).union(
-        carried_forward.prefetch_related("flags")
-    )
+    # return (uploaded.prefetch_related("flags")).union(
+    #     carried_forward.prefetch_related("flags")
+    # )
+
+    return sessions
 
 
 def repo_commits(

--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -351,6 +351,10 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                 "uploadType": "UPLOADED",
                 "flags": ["flag_a", "flag_b", "flag_c"],
             },
+            # TEMP: we're returning ALL uploads for now while we figure out a more
+            # performant way to make this query
+            {"id": 1, "uploadType": "CARRIEDFORWARD", "flags": ["flag_a"]},
+            {"id": 2, "uploadType": "CARRIEDFORWARD", "flags": ["flag_b"]},
             {"id": 3, "uploadType": "UPLOADED", "flags": ["flag_b"]},
             {"id": 4, "uploadType": "CARRIEDFORWARD", "flags": ["flag_d"]},
             {"id": 5, "uploadType": "UPLOADED", "flags": []},


### PR DESCRIPTION
Seeing degraded database performance in prod b/c of this query.  We'll return ALL uploads for a given commit until we can figure out a better way to query for just the uploads that comprise the commit's report.