### PR TITLE
Add impersonation to django admin log

### DIFF
--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -10,6 +10,7 @@ from django.shortcuts import redirect
 from django.utils.html import format_html
 
 from codecov.admin import AdminMixin
+from codecov_auth.helpers import History
 from codecov_auth.models import OrganizationLevelToken, Owner, OwnerProfile
 from codecov_auth.services.org_level_token_service import OrgLevelTokenService
 from plan.constants import USER_PLAN_REPRESENTATIONS
@@ -36,6 +37,11 @@ def impersonate_owner(self, request, queryset):
         owner.ownerid,
         domain=settings.COOKIES_DOMAIN,
         samesite=settings.COOKIE_SAME_SITE,
+    )
+    History.log(
+        Owner.objects.get(ownerid=owner.ownerid),
+        "Impersonation successful",
+        request.user,
     )
     return response
 

--- a/codecov_auth/helpers.py
+++ b/codecov_auth/helpers.py
@@ -1,4 +1,9 @@
+from traceback import format_stack
+
 import requests
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 
 from codecov_auth.constants import GITLAB_BASE_URL
 
@@ -28,3 +33,40 @@ def current_user_part_of_org(owner, org):
     # owner is a direct member of the org
     orgs_of_user = owner.organizations or []
     return org.ownerid in orgs_of_user
+
+
+# https://stackoverflow.com/questions/7905106/adding-a-log-entry-for-an-action-by-a-user-in-a-django-ap
+
+
+class History:
+    @staticmethod
+    def log(objects, message, user, action_flag=None, add_traceback=False):
+        """
+        Log an action in the admin log
+        :param objects: Objects being operated on
+        :param message: Message to log
+        :param user: User performing action
+        :param action_flag: Type of action being performed
+        :param add_traceback: Add the stack trace to the message
+        """
+        if action_flag is None:
+            action_flag = CHANGE
+
+        if type(objects) is not list:
+            objects = [objects]
+
+        if add_traceback:
+            message = f"{message}: {format_stack()}"
+
+        for obj in objects:
+            if not obj:
+                continue
+
+            LogEntry.objects.log_action(
+                user_id=user.pk,
+                content_type_id=ContentType.objects.get_for_model(obj).pk,
+                object_repr=str(obj),
+                object_id=obj.ownerid,
+                change_message=message,
+                action_flag=action_flag,
+            )

--- a/codecov_auth/middleware.py
+++ b/codecov_auth/middleware.py
@@ -80,7 +80,6 @@ class ImpersonationMiddleware(MiddlewareMixin):
                     impersonating_ownerid=impersonating_ownerid,
                 ),
             )
-
             if not current_user.is_staff:
                 log.warning(
                     "Impersonation unsuccessful",

--- a/codecov_auth/tests/unit/test_helpers.py
+++ b/codecov_auth/tests/unit/test_helpers.py
@@ -1,6 +1,11 @@
-import pytest
+from pprint import pprint
+from unittest.mock import patch
 
-from codecov_auth.helpers import current_user_part_of_org
+import pytest
+from django.contrib.admin.models import CHANGE, LogEntry
+
+from codecov_auth.helpers import History, current_user_part_of_org
+from codecov_auth.models import Owner, User
 
 from ..factories import OwnerFactory
 
@@ -30,3 +35,37 @@ def test_current_user_part_of_org_when_user_doesnt_have_org():
     current_user = OwnerFactory(organizations=[org.ownerid])
     current_user.save()
     assert current_user_part_of_org(current_user, current_user) is True
+
+
+@pytest.mark.django_db
+@patch("codecov_auth.helpers.format_stack")
+def test_log_entry(mocked_format_stack):
+    mocked_format_stack.return_value = "test"
+    orig_owner = OwnerFactory()
+    impersonated_owner = OwnerFactory()
+    History.log(
+        impersonated_owner,
+        "Impersonation successful",
+        orig_owner.user,
+        add_traceback=True,
+    )
+    log_entries = LogEntry.objects.all()
+    assert (
+        str(log_entries.first())
+        == f"Changed “{str(impersonated_owner)}” — Impersonation successful: test"
+    )
+
+
+@pytest.mark.django_db
+@patch("codecov_auth.helpers.format_stack")
+def test_log_entry_no_object(mocked_format_stack):
+    mocked_format_stack.return_value = "test"
+    orig_owner = OwnerFactory()
+    History.log(
+        None,
+        "Impersonation successful",
+        orig_owner.user,
+        add_traceback=True,
+    )
+    log_entries = LogEntry.objects.all()
+    assert log_entries.first() is None


### PR DESCRIPTION
### Purpose/Motivation


### Links to relevant tickets
https://github.com/codecov/platform-team/issues/116

### What does this PR do?
- Create helper function to log to admin log entry
- Log to admin log in impersonation middleware
- Add `__str__` method to User

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
