### PR TITLE
chore: add debug log for files array saving

### DIFF
--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -118,6 +118,13 @@ class ArchiveField:
             archive_service = ArchiveService(repository=repository)
             old_file_path = getattr(obj, self.archive_field_name)
             table_name = obj._meta.db_table
+            # DEBUG https://github.com/codecov/platform-team/issues/119
+            # We don't expect this saving to be done here, actually
+            if table_name == "reports_reportdetails":
+                log.info(
+                    "Setting files_array from the API",
+                    extra=dict(commit=obj.get_commitid(), data=value),
+                )
             path = archive_service.write_json_data_to_storage(
                 commit_id=obj.get_commitid(),
                 table=table_name,


### PR DESCRIPTION
In an effort to understand why we're getting `SessionArray` data from GCS without 'meta' info
we'll add a temporary log line when saving data from the API.
Mostly because I don't think this should happen, so I don't expect to see that line.
But who knows...

Part of codecov/platform-team#119

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
