### PR TITLE
chore: change logic to write data to storage

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -46,22 +46,19 @@ def get_config(*path, default=None):
 def should_write_data_to_storage_config_check(
     master_switch_key: str, is_codecov_repo: bool, repoid: int
 ) -> bool:
-    allowed_repo_ids = get_config(
-        "setup", "save_report_data_in_storage", "repo_ids", default=[]
-    )
-    is_in_allowed_repoids = repoid in allowed_repo_ids
     master_write_switch = get_config(
         "setup",
         "save_report_data_in_storage",
         master_switch_key,
         default=False,
     )
-    only_codecov = get_config(
-        "setup",
-        "save_report_data_in_storage",
-        "only_codecov",
-        default=True,
-    )
-    return master_write_switch and (
-        is_codecov_repo or is_in_allowed_repoids or not only_codecov
-    )
+    if master_write_switch == "restricted_access":
+        allowed_repo_ids = get_config(
+            "setup", "save_report_data_in_storage", "repo_ids", default=[]
+        )
+        is_in_allowed_repoids = repoid in allowed_repo_ids
+    elif master_write_switch == "general_access":
+        is_in_allowed_repoids = True
+    else:
+        is_in_allowed_repoids = False
+    return master_write_switch and (is_codecov_repo or is_in_allowed_repoids)

--- a/utils/tests/unit/test_config.py
+++ b/utils/tests/unit/test_config.py
@@ -9,7 +9,6 @@ from utils.config import should_write_data_to_storage_config_check
         (
             {
                 "repo_ids": [],
-                "only_codecov": True,
                 "report_details_files_array": True,
                 "commit_report": False,
             },
@@ -19,7 +18,6 @@ from utils.config import should_write_data_to_storage_config_check
         (
             {
                 "repo_ids": [],
-                "only_codecov": True,
                 "report_details_files_array": True,
                 "commit_report": False,
             },
@@ -29,7 +27,6 @@ from utils.config import should_write_data_to_storage_config_check
         (
             {
                 "repo_ids": [],
-                "only_codecov": True,
                 "report_details_files_array": True,
                 "commit_report": False,
             },
@@ -39,7 +36,6 @@ from utils.config import should_write_data_to_storage_config_check
         (
             {
                 "repo_ids": [1],
-                "only_codecov": True,
                 "report_details_files_array": True,
                 "commit_report": False,
             },
@@ -49,11 +45,46 @@ from utils.config import should_write_data_to_storage_config_check
         (
             {
                 "repo_ids": [1],
-                "only_codecov": True,
-                "report_details_files_array": True,
+                "report_details_files_array": True,  # True is the same as "codecov_access"
                 "commit_report": False,
             },
             ("report_details_files_array", False, 1),
+            False,
+        ),
+        (
+            {
+                "repo_ids": [1],
+                "report_details_files_array": "codecov_access",
+                "commit_report": False,
+            },
+            ("report_details_files_array", False, 1),
+            False,
+        ),
+        (
+            {
+                "repo_ids": [1],
+                "report_details_files_array": "codecov_access",
+                "commit_report": False,
+            },
+            ("report_details_files_array", True, 1),
+            True,
+        ),
+        (
+            {
+                "repo_ids": [],
+                "report_details_files_array": "general_access",
+                "commit_report": False,
+            },
+            ("report_details_files_array", False, 1),
+            True,
+        ),
+        (
+            {
+                "repo_ids": [1],
+                "report_details_files_array": "restricted_access",
+                "commit_report": False,
+            },
+            ("report_details_files_array", True, 1),
             True,
         ),
     ],


### PR DESCRIPTION
After moving `ReportDetails.files_array` and `Commit.report` to archive successfilly for Codecov
we want to do the same for some selected customers (in `repo_ids`) and then we will want
to start the process for new fields. Only for codecov.

The way things were before, if you have a field set to write to GCS it is valid for all codecov
repos AND all repos under `repo_ids`, while we would only want that for codecov repos.

So by changing the `master_write_switch` to strings we can have more power over each individual
field. Now we can use:
*  `True` or `codecov_access` to write *only* for codecov repos
*  `restricted_access` to write to all repos in `repo_ids` (+ codecov)
*  `general_access` to write to all repos

Because currently we're only writing for codecov repos the change will not affect any customers

Part of codecov/platform-team#100

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
