### PR TITLE
upload completion endpoint - manual notifs trigger

### DIFF
--- a/services/task/task.py
+++ b/services/task/task.py
@@ -336,3 +336,16 @@ class TaskService(object):
             "app.tasks.flush_repo.FlushRepo",
             kwargs=dict(repoid=repository_id),
         ).apply_async()
+
+    def manual_upload_completion_trigger(
+        self, repoid, commitid, report_code=None, current_yaml=None
+    ):
+        self._create_signature(
+            "app.tasks.upload.ManualUploadCompletionTrigger",
+            kwargs=dict(
+                commitid=commitid,
+                repoid=repoid,
+                report_code=report_code,
+                current_yaml=current_yaml,
+            ),
+        ).apply_async()

--- a/upload/tests/views/test_upload_completion.py
+++ b/upload/tests/views/test_upload_completion.py
@@ -1,0 +1,224 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from core.tests.factories import CommitFactory, RepositoryFactory
+from reports.tests.factories import CommitReportFactory, UploadFactory
+from upload.views.uploads import CanDoCoverageUploadsPermission
+
+
+def test_upload_completion_view_no_uploads(db, mocker):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    repository.save()
+    commit.save()
+
+    owner = repository.author
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse(
+        "new_upload.upload-complete",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(
+        url,
+    )
+    response_json = response.json()
+    assert response.status_code == 404
+    assert response_json == {
+        "uploads_total": 0,
+        "uploads_success": 0,
+        "uploads_processing": 0,
+        "uploads_error": 0,
+    }
+
+
+@patch("services.task.TaskService.manual_upload_completion_trigger")
+def test_upload_completion_view_processed_uploads(mocked_manual_trigger, db, mocker):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    report = CommitReportFactory(commit=commit)
+    upload1 = UploadFactory(report=report)
+    upload2 = UploadFactory(report=report)
+    repository.save()
+    commit.save()
+    report.save()
+    upload1.save()
+    upload2.save()
+
+    owner = repository.author
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse(
+        "new_upload.upload-complete",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(
+        url,
+    )
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json == {
+        "uploads_total": 2,
+        "uploads_success": 2,
+        "uploads_processing": 0,
+        "uploads_error": 0,
+    }
+    mocked_manual_trigger.assert_called_once_with(repository.repoid, commit.commitid)
+
+
+@patch("services.task.TaskService.manual_upload_completion_trigger")
+def test_upload_completion_view_still_processing_uploads(
+    mocked_manual_trigger, db, mocker
+):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    report = CommitReportFactory(commit=commit)
+    upload1 = UploadFactory(report=report)
+    upload2 = UploadFactory(report=report, state="")
+    repository.save()
+    commit.save()
+    report.save()
+    upload1.save()
+    upload2.save()
+
+    owner = repository.author
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse(
+        "new_upload.upload-complete",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(
+        url,
+    )
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json == {
+        "uploads_total": 2,
+        "uploads_success": 1,
+        "uploads_processing": 1,
+        "uploads_error": 0,
+    }
+    mocked_manual_trigger.assert_called_once_with(repository.repoid, commit.commitid)
+
+
+@patch("services.task.TaskService.manual_upload_completion_trigger")
+def test_upload_completion_view_errored_uploads(mocked_manual_trigger, db, mocker):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    report = CommitReportFactory(commit=commit)
+    upload1 = UploadFactory(report=report)
+    upload2 = UploadFactory(report=report, state="error")
+    repository.save()
+    commit.save()
+    report.save()
+    upload1.save()
+    upload2.save()
+
+    owner = repository.author
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse(
+        "new_upload.upload-complete",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(
+        url,
+    )
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json == {
+        "uploads_total": 2,
+        "uploads_success": 1,
+        "uploads_processing": 0,
+        "uploads_error": 1,
+    }
+    mocked_manual_trigger.assert_called_once_with(repository.repoid, commit.commitid)
+
+
+@patch("services.task.TaskService.manual_upload_completion_trigger")
+def test_upload_completion_view_errored_and_processing_uploads(
+    mocked_manual_trigger, db, mocker
+):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    report = CommitReportFactory(commit=commit)
+    upload1 = UploadFactory(report=report, state="")
+    upload2 = UploadFactory(report=report, state="error")
+    repository.save()
+    commit.save()
+    report.save()
+    upload1.save()
+    upload2.save()
+
+    owner = repository.author
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse(
+        "new_upload.upload-complete",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(
+        url,
+    )
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json == {
+        "uploads_total": 2,
+        "uploads_success": 0,
+        "uploads_processing": 1,
+        "uploads_error": 1,
+    }
+    mocked_manual_trigger.assert_called_once_with(repository.repoid, commit.commitid)

--- a/upload/urls.py
+++ b/upload/urls.py
@@ -4,6 +4,7 @@ from upload.views.commits import CommitViews
 from upload.views.empty_upload import EmptyUploadView
 from upload.views.legacy import UploadDownloadHandler, UploadHandler
 from upload.views.reports import ReportResultsView, ReportViews
+from upload.views.upload_completion import UploadCompletionView
 from upload.views.uploads import UploadViews
 
 urlpatterns = [
@@ -33,6 +34,11 @@ urlpatterns = [
         "<str:service>/<str:repo>/commits/<str:commit_sha>/empty-upload",
         EmptyUploadView.as_view(),
         name="new_upload.empty_upload",
+    ),
+    path(
+        "<str:service>/<str:repo>/commits/<str:commit_sha>/upload-complete",
+        UploadCompletionView.as_view(),
+        name="new_upload.upload-complete",
     ),
     path(
         "<str:service>/<str:repo>/commits",

--- a/upload/views/upload_completion.py
+++ b/upload/views/upload_completion.py
@@ -1,0 +1,73 @@
+import logging
+
+from rest_framework import status
+from rest_framework.generics import CreateAPIView
+from rest_framework.response import Response
+
+from codecov_auth.authentication.repo_auth import (
+    GlobalTokenAuthentication,
+    OrgLevelTokenAuthentication,
+    RepositoryLegacyTokenAuthentication,
+)
+from reports.models import ReportSession
+from services.task import TaskService
+from upload.views.base import GetterMixin
+from upload.views.uploads import CanDoCoverageUploadsPermission
+
+log = logging.getLogger(__name__)
+
+
+class UploadCompletionView(CreateAPIView, GetterMixin):
+    permission_classes = [CanDoCoverageUploadsPermission]
+    authentication_classes = [
+        GlobalTokenAuthentication,
+        OrgLevelTokenAuthentication,
+        RepositoryLegacyTokenAuthentication,
+    ]
+
+    def post(self, request, *args, **kwargs):
+        repo = self.get_repo()
+        commit = self.get_commit(repo)
+        uploads_queryset = ReportSession.objects.filter(
+            report__commit=commit,
+            report__code=None,
+        )
+        uploads_count = uploads_queryset.count()
+        if not uploads_queryset or uploads_count == 0:
+            log.info(
+                "Cannot trigger notifications as we didn't find any uploads for the provided commit",
+                extra=dict(
+                    repo=repo.name, commit=commit.commitid, pullid=commit.pullid
+                ),
+            )
+            return Response(
+                data={
+                    "uploads_total": 0,
+                    "uploads_success": 0,
+                    "uploads_processing": 0,
+                    "uploads_error": 0,
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        in_progress_uploads = 0
+        errored_uploads = 0
+        for upload in uploads_queryset:
+            # upload is still processing
+            if not upload.state:
+                in_progress_uploads += 1
+            elif upload.state == "error":
+                errored_uploads += 1
+
+        TaskService().manual_upload_completion_trigger(repo.repoid, commit.commitid)
+        return Response(
+            data={
+                "uploads_total": uploads_count,
+                "uploads_success": uploads_count
+                - in_progress_uploads
+                - errored_uploads,
+                "uploads_processing": in_progress_uploads,
+                "uploads_error": errored_uploads,
+            },
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
Create a new endpoint that marks the completion step for uploads. This endpoint should trigger a task that has all the logic for marking uploads as complete. The task hasn't been implemented yet, so I'll leave it as a TODO for now. will add it once it's implemented

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
