### PR TITLE
Metrics based on source of upload in legacy endpoint

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -179,7 +179,6 @@ def parse_params(data):
         },  # file path to custom location of codecov.yml in repo
         "url": {"type": "string"},  # custom location where report is found
         "parent": {"type": "string"},
-        "package": {"type": "string"},
         "project": {"type": "string"},
         "server_uri": {"type": "string"},
         "root": {"type": "string"},  # deprecated
@@ -508,7 +507,6 @@ def validate_upload(upload_params, repository, redis):
         and not repository.activated
         and not bool(get_config("setup", "enterprise_license", default=False))
     ):
-
         owner = _determine_responsible_owner(repository)
 
         # If author is on per repo billing, check their repo credits


### PR DESCRIPTION
### Purpose/Motivation
This is being done to gather metrics on the source of an upload and its version.

### Links to relevant tickets
https://github.com/codecov/platform-team/issues/120

### What does this PR do?
- Add regex to package schema in query params schema
- Increment metric based on source of upload in upload legacy endpoint
