### PR TITLE
Replace "open source" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Codecov API
 
 > We believe that everyone should have access to quality software (like Sentry), that’s why we have always offered Codecov for free to open source maintainers.
 >
-> By open sourcing Codecov, we’re not only joining the community that’s supported us from the start — but also want to make sure that every developer can contribute to and build on the Codecov experience.
+> By making our code public, we’re not only joining the community that’s supported us from the start — but also want to make sure that every developer can contribute to and build on the Codecov experience.
 
 A private Django REST Framework API intended to serve Codecov's front end. 
 


### PR DESCRIPTION
### Purpose/Motivation
replaces "open source" in top disclaimer of readme

### What does this PR do?
Edits Readme



