### PR TITLE
Add local testing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-Codecov API
------------
+## Codecov API
 
 > We believe that everyone should have access to quality software (like Sentry), that’s why we have always offered Codecov for free to open source maintainers.
 >
 > By making our code public, we’re not only joining the community that’s supported us from the start — but also want to make sure that every developer can contribute to and build on the Codecov experience.
 
-A private Django REST Framework API intended to serve Codecov's front end. 
+A private Django REST Framework API intended to serve Codecov's front end.
 
 ## Getting Started
 
@@ -21,7 +20,7 @@ Note, you'll need to install Rust to build `ribs` which is a dependency of `shar
 
 ### Running Standalone
 
-This project contains a `docker-compose.yml` file that is intended to run the api standalone. In this configuration it **does not** share codecov.io's development database; so don't expect parity there. 
+This project contains a `docker-compose.yml` file that is intended to run the api standalone. In this configuration it **does not** share codecov.io's development database; so don't expect parity there.
 
 To start the service, do
 
@@ -33,7 +32,7 @@ Once running, the api will be available at `http://localhost:5100`
 
 ### Running with codecov.io
 
-This service will startup when you run codecov.io normally. It is under that `api` block of codecov.io's `docker-compose.yml` file. 
+This service will startup when you run codecov.io normally. It is under that `api` block of codecov.io's `docker-compose.yml` file.
 
 ### Testing
 
@@ -42,13 +41,13 @@ The easiest way to run tests (that doesn't require installing postgres and other
     docker-compose up
     docker exec -it codecov-api_api_1 pytest -rf
 
-### Testing standalone
+### Testing Standalone
 
-If you would like to use pytest directly (Either through an IDE like PyCharm or with the CLI), you will need to change the settings file used by pytest. Run this command to have the tests executed (You will need an instance of postgres running locally):
+For testing locally, follow the next steps:
 
-    RUN_ENV=TESTING DJANGO_SETTINGS_MODULE=codecov.settings_test pytest
-
-Make sure to have all the requirements from `requirements.txt` installed.
+1. Install dependencies by running `pip install -r requirements.txt` - we recommend setting a virtual environment first
+2. Setup a redis and postgresql instance locally by running the `docker-compose -f docker-compose-local-testing.yml up`
+3. Run the following command: `RUN_ENV=TESTING DJANGO_SETTINGS_MODULE=codecov.settings_test pytest`
 
 ### Deploying
 
@@ -69,7 +68,8 @@ Steps 2 and 3 are important to limit interaction between features not yet merged
 This project should store no secrets or credentials in its source. If you need to add to / modify / setup secrets for this project, contact Eli and he'll get you started..
 
 ### Adding dependencies
-This repository uses `pip-tools` to manage dependencies, so make sure you've installed it with `pip install pip-tools`. To add or update dependencies, change `requirements.in`,  Then run
+
+This repository uses `pip-tools` to manage dependencies, so make sure you've installed it with `pip install pip-tools`. To add or update dependencies, change `requirements.in`, Then run
 
 ```
 pip-compile requirements.in
@@ -79,7 +79,7 @@ Do not change `requirements.txt` directly.
 
 ### Formatting
 
-This project uses `black` for formatting.      
+This project uses `black` for formatting.  
 You can run the linter using the command `make lint`.
 
 ### Migrations
@@ -88,4 +88,4 @@ We leverage Django's migration system to keep the state of our models in sync wi
 
 ## Contributing
 
-This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first. 
+This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first.

--- a/docker-compose-local-testing.yml
+++ b/docker-compose-local-testing.yml
@@ -9,10 +9,10 @@ services:
     networks:
       - codecovapi
     ports:
-      - "5436:5432"
+      - "5432:5432"
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_HOST_AUTH_METHOD: trust
+      - POSTGRES_PASSWORD: postgres
   redis:
     hostname: redis
     image: redis:4.0-alpine
@@ -21,7 +21,7 @@ services:
     networks:
       - codecovapi
     ports:
-      - "6400:6379"
+      - "6379:6379"
 
 volumes:
   postgres-volume:

--- a/docker-compose-local-testing.yml
+++ b/docker-compose-local-testing.yml
@@ -1,0 +1,32 @@
+version: "3"
+
+services:
+  postgres:
+    hostname: postgres
+    image: postgres:14.4-alpine
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
+    networks:
+      - codecovapi
+    ports:
+      - "5436:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  redis:
+    hostname: redis
+    image: redis:4.0-alpine
+    volumes:
+      - redis-volume:/data
+    networks:
+      - codecovapi
+    ports:
+      - "6400:6379"
+
+volumes:
+  postgres-volume:
+  redis-volume:
+
+networks:
+  codecovapi:
+    driver: bridge


### PR DESCRIPTION
### Purpose/Motivation
This PR is to add more explicit instructions for testing codecov-api local changes.

### What does this PR do?
- Adds a docker-compose file for serving necessary persistence containers for testing standalone codecov-api
- Adjusts readme.md to give instructions clearer instructions for local testing