### PR TITLE
fix: dont share default_values + log fix

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -313,7 +313,7 @@ class Commit(models.Model):
     report = ArchiveField(
         should_write_to_storage_fn=should_write_to_storage,
         json_encoder=ReportJSONEncoder,
-        default_value={},
+        default_value_class=dict,
     )
 
 
@@ -397,7 +397,7 @@ class Pull(models.Model):
     _flare = models.JSONField(db_column="flare", null=True)
     _flare_storage_path = models.URLField(db_column="flare_storage_path", null=True)
     flare = ArchiveField(
-        should_write_to_storage_fn=should_write_to_storage, default_value={}
+        should_write_to_storage_fn=should_write_to_storage, default_value_class=dict
     )
 
     def save(self, *args, **kwargs):

--- a/reports/models.py
+++ b/reports/models.py
@@ -78,7 +78,7 @@ class ReportDetails(BaseCodecovModel):
 
     files_array = ArchiveField(
         should_write_to_storage_fn=should_write_to_storage,
-        default_value=[],
+        default_value_class=list,
     )
 
 

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -67,9 +67,9 @@ class ArchiveField:
         should_write_to_storage_fn: Callable[[object], bool],
         rehydrate_fn: Callable[[object, object], Any] = lambda self, x: x,
         json_encoder=ReportEncoder,
-        default_value=None,
+        default_value_class=lambda: None,
     ):
-        self.default_value = default_value
+        self.default_value_class = default_value_class
         self.rehydrate_fn = rehydrate_fn
         self.should_write_to_storage_fn = should_write_to_storage_fn
         self.json_encoder = json_encoder
@@ -102,14 +102,14 @@ class ArchiveField:
                     ),
                 )
         else:
-            log.info(
+            log.debug(
                 "Both db_field and archive_field are None",
                 extra=dict(
                     object_id=obj.id,
                     commit=obj.get_commitid(),
                 ),
             )
-        return self.default_value
+        return self.default_value_class()
 
     def __get__(self, obj, objtype=None):
         cached_value = getattr(obj, self.cached_value_property_name, None)

--- a/utils/tests/unit/test_model_utils.py
+++ b/utils/tests/unit/test_model_utils.py
@@ -37,9 +37,7 @@ class TestArchiveField(object):
             self._archive_field_storage_path = archive_value
             self.should_write_to_gcs = should_write_to_gcs
 
-        archive_field = ArchiveField(
-            should_write_to_storage_fn=should_write_to_storage, default_value=None
-        )
+        archive_field = ArchiveField(should_write_to_storage_fn=should_write_to_storage)
 
     class ClassWithArchiveFieldMissingMethods:
         commit: Commit


### PR DESCRIPTION
Don't share default values. The present changes make it so we always
generate a new reference to a new object when returning the default value, rather than
the same pointer to all objects using `ArchiveField`.

In terms of logging reducing the level of the line that says both dbfield and
archive_field are None. It was spamming the logs

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
