### PR TITLE
Fixed scheduled phases where there's more than 1 scheduled phase

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -198,8 +198,8 @@ class ScheduleDetailSerializer(serializers.Serializer):
     scheduled_phase = serializers.SerializerMethodField()
 
     def get_scheduled_phase(self, schedule):
-        if len(schedule["phases"]) == 2:
-            return StripeScheduledPhaseSerializer(schedule["phases"][1]).data
+        if len(schedule["phases"]) > 1:
+            return StripeScheduledPhaseSerializer(schedule["phases"][-1]).data
         else:
             # This error represents the phases object not having 2 phases; we are interested in the 2nd entry within phases
             # since it represents the scheduled phase

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -263,7 +263,7 @@ class AccountViewSetTests(APITestCase):
 
     @patch("services.billing.stripe.SubscriptionSchedule.retrieve")
     @patch("services.billing.stripe.Subscription.retrieve")
-    def test_retrieve_account_returns_null_schedule_details_when_there_arent_two_scheduled_phases(
+    def test_retrieve_account_returns_last_phase_when_more_than_one_scheduled_phases(
         self, mock_retrieve_subscription, mock_retrieve_schedule
     ):
         owner = OwnerFactory(
@@ -290,9 +290,14 @@ class AccountViewSetTests(APITestCase):
             "quantity": 6,
         }
         phases = [
-            {},
-            {},
-            {},
+            {
+                "start_date": 123689126536,
+                "plans": [{"plan": "test_plan_123", "quantity": 4}],
+            },
+            {
+                "start_date": 123689126636,
+                "plans": [{"plan": "test_plan_456", "quantity": 5}],
+            },
             {
                 "start_date": schedule_params["start_date"],
                 "plans": [
@@ -348,7 +353,14 @@ class AccountViewSetTests(APITestCase):
             "plan_provider": owner.plan_provider,
             "activated_student_count": 0,
             "student_count": 0,
-            "schedule_detail": {"id": "123", "scheduled_phase": None},
+            "schedule_detail": {
+                "id": "123",
+                "scheduled_phase": {
+                    "plan": "monthly",
+                    "quantity": schedule_params["quantity"],
+                    "start_date": schedule_params["start_date"],
+                },
+            },
         }
 
     @patch("services.billing.stripe.Subscription.retrieve")


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Adjust phases for scheduled changes to take the last phase 

### What does this PR do?
Adjust serializer + test

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
