### PR TITLE
Fix enterprise build

### DIFF
--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -33,13 +33,6 @@ RUN rm /app/codecov/settings_staging.py
 RUN rm -rf /app/.github
 RUN rm -rf /app/.circleci
 
-# Remove and rewrite the settings module to the
-# enterprise variant. This removes all reference to
-# dev and prod settings.
-RUN rm /app/utils/config.py
-COPY enterprise/config.py /app/utils/config.py
-
-
 # execute Cython script in app dir 
 COPY enterprise/ldd /pyinstaller/ldd
 COPY enterprise/setup.py setup.py


### PR DESCRIPTION
### Purpose/Motivation
The enterprise build is currently broken.

### What does this PR do?
The utils/config.py file contains a function that is missing in enterprise/config.py and this results in a broken build. The plan-module also does not make it into the enterprise build due to the way the cythonize scripts work. The added init file fixes this. 

### Notes to Reviewer
Try building and running the enterprise-runtime or even pulling and running the newest stable enterprise-runtime Docker image and you will notice it is broken.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
