### PR TITLE
Add Github OIDC token authentication to uploads

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ opentelemetry-sdk
 opentracing
 pre-commit
 psycopg2
-PyJWT
+PyJWT==2.8.0
 pytest
 pytest-cov
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ coverage==6.0.1
     #   pytest-cov
 cryptography==40.0.2
     # via shared
-ddtrace==0.46
+ddtrace==0.46.0
     # via -r requirements.in
 deprecated==1.2.12
     # via opentelemetry-api
@@ -256,7 +256,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.20
     # via cffi
-pyjwt==2.4.0
+pyjwt==2.8.0
     # via -r requirements.in
 pyparsing==2.4.7
     # via
@@ -361,7 +361,7 @@ tenacity==6.2.0
     # via ddtrace
 text-unidecode==1.3
     # via faker
-tlslite-ng==0.8.0-alpha39
+tlslite-ng==0.8.0a39
     # via shared
 toml==0.10.2
     # via


### PR DESCRIPTION
### Purpose/Motivation
It would be nice to be able to use the JWT token available in Github workflows in the uploader as an alternative to Codecov tokens

### Links to relevant tickets
https://github.com/codecov/feedback/issues/53
https://github.com/codecov/codecov-action/pull/1054

### What does this PR do?
Allows using a Github.com and Github enterprise JWT token in uploader 

### Notes to Reviewer
I'd like to get some feedback on tests and other modifications required to get this merged

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
