### PR TITLE
Add RiskyAlterField to utils/migrations

### DIFF
--- a/utils/migrations.py
+++ b/utils/migrations.py
@@ -24,6 +24,20 @@ class RiskyAddField(migrations.AddField):
         super().database_backwards(app_label, schema_editor, from_state, to_state)
 
 
+class RiskyAlterField(migrations.AlterField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if settings.SKIP_RISKY_MIGRATION_STEPS:
+            return
+
+        super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if settings.SKIP_RISKY_MIGRATION_STEPS:
+            return
+
+        super().database_backwards(app_label, schema_editor, from_state, to_state)
+
+
 class RiskyRemoveField(migrations.RemoveField):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         if settings.SKIP_RISKY_MIGRATION_STEPS:

--- a/utils/migrations.py
+++ b/utils/migrations.py
@@ -52,20 +52,6 @@ class RiskyRemoveField(migrations.RemoveField):
         super().database_backwards(app_label, schema_editor, from_state, to_state)
 
 
-class RiskyAddField(migrations.AddField):
-    def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        if settings.SKIP_RISKY_MIGRATION_STEPS:
-            return
-
-        super().database_forwards(app_label, schema_editor, from_state, to_state)
-
-    def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        if settings.SKIP_RISKY_MIGRATION_STEPS:
-            return
-
-        super().database_backwards(app_label, schema_editor, from_state, to_state)
-
-
 class RiskyAlterUniqueTogether(migrations.AlterUniqueTogether):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         if settings.SKIP_RISKY_MIGRATION_STEPS:


### PR DESCRIPTION
### Purpose/Motivation
Out of convenience in order to be used in migrations instead of `RiskyRunSQL` to run risky `AlterField` operations

### What does this PR do?
- Create `RiskyAlterField` class in `utils.migrations` that wraps the `AlterField` migration class with "Risky" 
