### PR TITLE
bug: Fix indentation for monthly_upload_limit and misc

### DIFF
--- a/codecov_auth/commands/owner/interactors/get_uploads_number_per_user.py
+++ b/codecov_auth/commands/owner/interactors/get_uploads_number_per_user.py
@@ -34,5 +34,5 @@ class GetUploadsNumberPerUserInteractor(BaseInteractor):
                     | Q(created_at__lte=plan_service.trial_start_date)
                 )
 
-        uploads_used = queryset[:monthly_limit].count()
-        return uploads_used
+            uploads_used = queryset[:monthly_limit].count()
+            return uploads_used


### PR DESCRIPTION
### Purpose/Motivation
- Fix indentation for monthly_upload_limit
- Retract ReadOnlyReport on comparison as we're getting errors from our public api

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
