### PR TITLE
feat: Add authenticated view

### DIFF
--- a/api/internal/tests/views/test_current_user_view.py
+++ b/api/internal/tests/views/test_current_user_view.py
@@ -31,3 +31,19 @@ class CurrentUserViewTests(APITestCase):
         assert self.owner1.ownerid in ownerids
         assert self.owner2.ownerid in ownerids
         assert self.owner3.ownerid not in ownerids
+
+
+class AuthenticatedViewTests(APITestCase):
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_unauthenticated(self):
+        res = self.client.get(reverse("authenticated"))
+        assert res.status_code == 200
+        assert res.data == {"authenticated": False}
+
+    def test_authenticated(self):
+        self.client.force_login(self.user)
+        res = self.client.get(reverse("authenticated"))
+        assert res.status_code == 200
+        assert res.data == {"authenticated": True}

--- a/api/internal/urls.py
+++ b/api/internal/urls.py
@@ -16,7 +16,7 @@ from api.internal.owner.views import (
 )
 from api.internal.pull.views import PullViewSet
 from api.internal.repo.views import RepositoryViewSet
-from api.internal.user.views import CurrentUserView
+from api.internal.user.views import AuthenticatedView, CurrentUserView
 from api.shared.error_views import not_found
 from utils.routers import OptionalTrailingSlashRouter, RetrieveUpdateDestroyRouter
 
@@ -57,6 +57,7 @@ if settings.IS_ENTERPRISE:
 
 urlpatterns += [
     path("user", CurrentUserView.as_view(), name="current-user"),
+    path("authenticated", AuthenticatedView.as_view(), name="authenticated"),
     path("slack/", include("api.internal.slack.urls")),
     path("charts/", include("api.internal.chart.urls")),
     path("", include(plans_router.urls)),

--- a/api/internal/user/views.py
+++ b/api/internal/user/views.py
@@ -11,3 +11,8 @@ class CurrentUserView(APIView):
     def get(self, request):
         serializer = UserSerializer(request.user)
         return Response(serializer.data)
+
+
+class AuthenticatedView(APIView):
+    def get(self, request):
+        return Response({"authenticated": not request.user.is_anonymous})


### PR DESCRIPTION
### Purpose/Motivation

Gazebo isn't able to easily handle the 401 from `/internal/users` as a way to determine that the user is not authenticated.

### Links to relevant tickets

### What does this PR do?

Adds a new endpoint `GET /internal/authenticated` which always returns a 200 and has a JSON response body of the form:

```
{"authenticated": true/false}
```