### PR TITLE
fix: Make OrgLevelToken work for self-hosted

### DIFF
--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -162,8 +162,6 @@ class GlobalTokenAuthentication(authentication.TokenAuthentication):
 
 class OrgLevelTokenAuthentication(authentication.TokenAuthentication):
     def authenticate_credentials(self, key):
-        if settings.IS_ENTERPRISE:
-            return None
         # Actual verification for org level tokens
         token = OrganizationLevelToken.objects.filter(token=key).first()
 


### PR DESCRIPTION
Removes restriction that `OrgLevelToken` is cloud-exclusive.

closes codecov/codecov-api#123

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
