### PR TITLE
Add send email task to task service

### DIFF
--- a/services/task/task.py
+++ b/services/task/task.py
@@ -368,7 +368,9 @@ class TaskService(object):
             ),
         )
 
-    def send_email(self, ownerid, template_name, from_addr, subject, **kwargs):
+    def send_email(
+        self, ownerid, template_name: str, from_addr: str, subject: str, **kwargs
+    ):
         self._create_signature(
             "app.tasks.send_email.SendEmail",
             kwargs=dict(

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -367,3 +367,15 @@ class TaskService(object):
                 report_code=report_code,
             ),
         )
+
+    def send_email(self, ownerid, template_name, from_addr, subject, **kwargs):
+        self._create_signature(
+            "app.tasks.send_email.SendEmail",
+            kwargs=dict(
+                ownerid=ownerid,
+                template_name=template_name,
+                from_addr=from_addr,
+                subject=subject,
+                **kwargs,
+            ),
+        ).apply_async()


### PR DESCRIPTION
### Purpose/Motivation
The API should be able to enqueue a task to send an email to a user.

### Links to relevant tickets
Fixes: https://github.com/codecov/engineering-team/issues/158

### What does this PR do?
- Creates a helper function to dispatch a send email task to the worker
entry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
