### PR TITLE
fix: Backfill task takes commit ID instead of sha

### DIFF
--- a/core/management/commands/backfill_commits.py
+++ b/core/management/commands/backfill_commits.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             )
             return
 
-        commits = Commit.objects.all().only("id", "commitid")
+        commits = Commit.objects.all().only("id")
 
         # this stores the oldest commit id that has already been backfilled
         commit_id = storage_redis.get("backfill_commits_id")
@@ -51,7 +51,7 @@ class Command(BaseCommand):
 
         commits = commits.order_by("-id")[:batch_size]
         for commit in commits:
-            TaskService().backfill_commit_data(commitid=commit.commitid)
+            TaskService().backfill_commit_data(commit_id=commit.id)
             if commit_id is None or commit.id < commit_id:
                 commit_id = commit.id
 

--- a/core/tests/test_management_commands.py
+++ b/core/tests/test_management_commands.py
@@ -137,8 +137,8 @@ def test_backfill_commits_command(mocker):
     )
 
     assert backfill_commits.mock_calls == [
-        mock.call(commitid=commit3.commitid),
-        mock.call(commitid=commit2.commitid),
+        mock.call(commit_id=commit3.id),
+        mock.call(commit_id=commit2.id),
     ]
 
     backfill_commits.reset_mock()
@@ -153,7 +153,7 @@ def test_backfill_commits_command(mocker):
     )
 
     assert backfill_commits.mock_calls == [
-        mock.call(commitid=commit1.commitid),
+        mock.call(commit_id=commit1.id),
     ]
 
     backfill_commits.reset_mock()

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -350,10 +350,10 @@ class TaskService(object):
             ),
         ).apply_async()
 
-    def backfill_commit_data(self, commitid: str):
+    def backfill_commit_data(self, commit_id: int):
         self._create_signature(
             "app.tasks.archive.BackfillCommitDataToStorage",
             kwargs=dict(
-                commitid=commitid,
+                commitid=commit_id,
             ),
         ).apply_async()

--- a/services/tests/test_task.py
+++ b/services/tests/test_task.py
@@ -329,16 +329,16 @@ def test_backfill_commit_data_task(mocker):
             "extra_config": {"soft_timelimit": 300, "hard_timelimit": 400},
         },
     )
-    TaskService().backfill_commit_data("example-commitid")
+    TaskService().backfill_commit_data(123)
     mock_route_task.assert_called_with(
         "app.tasks.archive.BackfillCommitDataToStorage",
         args=None,
-        kwargs=dict(commitid="example-commitid"),
+        kwargs=dict(commitid=123),
     )
     signature_mock.assert_called_with(
         "app.tasks.archive.BackfillCommitDataToStorage",
         args=None,
-        kwargs=dict(commitid="example-commitid"),
+        kwargs=dict(commitid=123),
         app=celery_app,
         queue="celery",
         soft_time_limit=300,


### PR DESCRIPTION
I had thought `commitid` was the SHA but it is not.