### PR TITLE
feat: Update comparison result with first pull request type

### DIFF
--- a/graphql_api/types/comparison/comparison.graphql
+++ b/graphql_api/types/comparison/comparison.graphql
@@ -36,8 +36,13 @@ type MissingHeadReport implements ResolverError {
   message: String!
 }
 
+type FirstPullRequest {
+  message: String!
+}
+
 union ComparisonResult =
     Comparison
+  | FirstPullRequest
   | MissingBaseCommit
   | MissingHeadCommit
   | MissingComparison

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -20,6 +20,7 @@ from reports.models import ReportLevelTotals
 from services.comparison import (
     Comparison,
     ComparisonReport,
+    FirstPullRequest,
     ImpactedFile,
     MissingComparisonReport,
 )
@@ -229,3 +230,5 @@ def resolve_comparison_result_type(obj, *_):
         return "MissingBaseReport"
     elif isinstance(obj, MissingHeadReport):
         return "MissingHeadReport"
+    elif isinstance(obj, FirstPullRequest):
+        return "FirstPullRequest"

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -59,6 +59,10 @@ class MissingComparisonReport(ComparisonException):
     pass
 
 
+class FirstPullRequest:
+    message = "This is the first pull request for this repository"
+
+
 class FileComparisonTraverseManager:
     """
     The FileComparisonTraverseManager uses the visitor-pattern to execute a series


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
instead of fetching the missing base commit error and check for first pull, we fetch the new type and handle in gazebo.

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/535

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
