### PR TITLE
trigger preprocess upload for codecov repos only

### DIFF
--- a/services/task/task.py
+++ b/services/task/task.py
@@ -357,3 +357,13 @@ class TaskService(object):
                 commitid=commit_id,
             ),
         ).apply_async()
+
+    def preprocess_upload(self, repoid, commitid, report_code):
+        self._create_signature(
+            "app.tasks.upload.PreProcessUpload",
+            kwargs=dict(
+                repoid=repoid,
+                commitid=commitid,
+                report_code=report_code,
+            ),
+        )

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -40,6 +40,10 @@ class ReportViews(ListCreateAPIView, GetterMixin):
         instance = serializer.save(
             commit_id=commit.id,
         )
+        if repository.author.username == "codecov":
+            TaskService().preprocess_upload(
+                repository.repoid, commit.commitid, instance.code
+            )
         return instance
 
     def list(self, request: HttpRequest, service: str, repo: str, commit_sha: str):


### PR DESCRIPTION
trigger pre-process task for codecov only repos 
<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
