### PR TITLE
fix: Address various security scanning vulerabilities

### DIFF
--- a/api/public/v2/report/views.py
+++ b/api/public/v2/report/views.py
@@ -39,7 +39,7 @@ class ReportMixin:
             service=service,
             owner=owner,
             repo=repo,
-            commit_sha=commit.commitid,
+            commit=commit,
         )
         return commit_file_url
 

--- a/codecov_auth/tests/unit/views/test_bitbucket.py
+++ b/codecov_auth/tests/unit/views/test_bitbucket.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.core import signing
 from django.http.cookie import SimpleCookie
 from django.test import TestCase
 from django.urls import reverse
@@ -28,10 +29,7 @@ def test_get_bitbucket_redirect(client, settings, mocker):
     assert res.status_code == 302
     assert "_oauth_request_token" in res.cookies
     cookie = res.cookies["_oauth_request_token"]
-    assert (
-        cookie.value
-        == "dGVzdHk2cjJvZjZhamttcnVi|dGVzdHppYnc1cTAxc2NwbDhxZWV1cHpoOHU5eXU4aHo="
-    )
+    assert cookie.value
     assert cookie.get("domain") == settings.COOKIES_DOMAIN
     assert (
         res.url
@@ -122,7 +120,11 @@ def test_get_bitbucket_already_token(client, settings, mocker, db, mock_redis):
     url = reverse("bitbucket-login")
     client.cookies = SimpleCookie(
         {
-            "_oauth_request_token": "dGVzdDZ0bDNldnE3Yzh2dXlu|dGVzdGRtNjF0cHBiNXgwdGFtN25hZTNxYWpoY2Vweno="
+            "_oauth_request_token": signing.get_cookie_signer(
+                salt="_oauth_request_token"
+            ).sign(
+                "5XCHJ1AulIWMpL8j7/Rhh97fz67xFesXlIzqBHH6dh+f4/8DBKe6eeUTWLKLma3+kc6UPJYq2odDwrL/apsL0c6QZHlW7zyUfF0sQuVnb9t5q+KcJCaMFCRbcerY80Qz"
+            )
         }
     )
     res = client.get(

--- a/codecov_auth/tests/unit/views/test_bitbucket.py
+++ b/codecov_auth/tests/unit/views/test_bitbucket.py
@@ -118,13 +118,14 @@ def test_get_bitbucket_already_token(client, settings, mocker, db, mock_redis):
     settings.CODECOV_DASHBOARD_URL = "dashboard.value"
     settings.COOKIE_SECRET = "aaaaa"
     url = reverse("bitbucket-login")
+    oauth_request_token = (
+        "dGVzdDZ0bDNldnE3Yzh2dXlu|dGVzdGRtNjF0cHBiNXgwdGFtN25hZTNxYWpoY2Vweno="
+    )
     client.cookies = SimpleCookie(
         {
             "_oauth_request_token": signing.get_cookie_signer(
                 salt="_oauth_request_token"
-            ).sign(
-                "5XCHJ1AulIWMpL8j7/Rhh97fz67xFesXlIzqBHH6dh+f4/8DBKe6eeUTWLKLma3+kc6UPJYq2odDwrL/apsL0c6QZHlW7zyUfF0sQuVnb9t5q+KcJCaMFCRbcerY80Qz"
-            )
+            ).sign(encryptor.encode(oauth_request_token).decode())
         }
     )
     res = client.get(

--- a/codecov_auth/tests/unit/views/test_bitbucket_server.py
+++ b/codecov_auth/tests/unit/views/test_bitbucket_server.py
@@ -92,13 +92,14 @@ def test_get_bbs_already_token(client, settings, mocker, db, mock_redis):
     )
 
     url = reverse("bbs-login")
+    oauth_request_token = (
+        "dGVzdDZ0bDNldnE3Yzh2dXlu|dGVzdGRtNjF0cHBiNXgwdGFtN25hZTNxYWpoY2Vweno="
+    )
     client.cookies = SimpleCookie(
         {
             "_oauth_request_token": signing.get_cookie_signer(
                 salt="_oauth_request_token"
-            ).sign(
-                "EEvU7w+GYguqFtdvLRFe8FJRvrgpa73BFfdBNjmdpp2C57+c+d8H/mu2j2FzYnlbLpmlUMTUity8TLynnnkbIo9ilQz6ZFI6vKb03Y/OuKJ9AED2U4R4O4/lzqhC08Gq"
-            )
+            ).sign(encryptor.encode(oauth_request_token).decode())
         }
     )
     res = client.get(

--- a/codecov_auth/tests/unit/views/test_bitbucket_server.py
+++ b/codecov_auth/tests/unit/views/test_bitbucket_server.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.core import signing
 from django.http.cookie import SimpleCookie
 from django.urls import reverse
 from shared.torngit.exceptions import TorngitClientGeneralError
@@ -93,7 +94,11 @@ def test_get_bbs_already_token(client, settings, mocker, db, mock_redis):
     url = reverse("bbs-login")
     client.cookies = SimpleCookie(
         {
-            "_oauth_request_token": "dGVzdDZ0bDNldnE3Yzh2dXlu|dGVzdGRtNjF0cHBiNXgwdGFtN25hZTNxYWpoY2Vweno="
+            "_oauth_request_token": signing.get_cookie_signer(
+                salt="_oauth_request_token"
+            ).sign(
+                "EEvU7w+GYguqFtdvLRFe8FJRvrgpa73BFfdBNjmdpp2C57+c+d8H/mu2j2FzYnlbLpmlUMTUity8TLynnnkbIo9ilQz6ZFI6vKb03Y/OuKJ9AED2U4R4O4/lzqhC08Gq"
+            )
         }
     )
     res = client.get(

--- a/codecov_auth/views/bitbucket.py
+++ b/codecov_auth/views/bitbucket.py
@@ -12,6 +12,7 @@ from shared.torngit import Bitbucket
 from shared.torngit.exceptions import TorngitServerFailureError
 
 from codecov_auth.views.base import LoginMixin
+from utils.encryption import encryptor
 
 log = logging.getLogger(__name__)
 
@@ -63,8 +64,10 @@ class BitbucketLoginView(View, LoginMixin):
             + b"|"
             + base64.b64encode(oauth_token_secret.encode())
         ).decode()
-        response.set_cookie(
-            "_oauth_request_token", data, domain=settings.COOKIES_DOMAIN
+        response.set_signed_cookie(
+            "_oauth_request_token",
+            encryptor.encode(data).decode(),
+            domain=settings.COOKIES_DOMAIN,
         )
         self.store_to_cookie_utm_tags(response)
         return response
@@ -77,14 +80,13 @@ class BitbucketLoginView(View, LoginMixin):
             )
         )
         oauth_verifier = request.GET.get("oauth_verifier")
-        # we use an unsigned cookie here because that's what tornado also does
-        # and we are keeping compaitiblity with them for a bit
-        request_cookie = request.COOKIES.get("_oauth_request_token")
+        request_cookie = request.get_signed_cookie("_oauth_request_token", default=None)
         if not request_cookie:
             log.warning(
                 "Request arrived with proper url params but not the proper cookies"
             )
             return redirect(reverse("bitbucket-login"))
+        request_cookie = encryptor.decode(request_cookie)
         cookie_key, cookie_secret = [
             base64.b64decode(i).decode() for i in request_cookie.split("|")
         ]

--- a/codecov_auth/views/bitbucket_server.py
+++ b/codecov_auth/views/bitbucket_server.py
@@ -14,6 +14,7 @@ from shared.torngit.exceptions import TorngitServerFailureError
 
 from codecov_auth.models import SERVICE_BITBUCKET_SERVER
 from codecov_auth.views.base import LoginMixin
+from utils.encryption import encryptor
 
 log = logging.getLogger(__name__)
 
@@ -79,8 +80,10 @@ class BitbucketServerLoginView(View, LoginMixin):
         url_params = urlencode(dict(oauth_token=auth_token))
         authorize_url = f"{settings.BITBUCKET_SERVER_URL}/plugins/servlet/oauth/authorize?{url_params}"
         response = redirect(authorize_url)
-        response.set_cookie(
-            "_oauth_request_token", data, domain=settings.COOKIES_DOMAIN
+        response.set_signed_cookie(
+            "_oauth_request_token",
+            encryptor.encode(data).decode(),
+            domain=settings.COOKIES_DOMAIN,
         )
         self.store_to_cookie_utm_tags(response)
         return response
@@ -89,13 +92,14 @@ class BitbucketServerLoginView(View, LoginMixin):
         # Retrieve the authorized request_token and create a new client
         # This new client has the same consumer as before, but uses the request token.
         # ! Each request_token can only be used once
-        request_cookie = request.COOKIES.get("_oauth_request_token")
+        request_cookie = request.get_signed_cookie("_oauth_request_token", default=None)
         if not request_cookie:
             log.warning(
                 "Request arrived with proper url params but not the proper cookies"
             )
             return redirect(reverse("bbs-login"))
 
+        request_cookie = encryptor.decode(request_cookie)
         cookie_key, cookie_secret = [
             base64.b64decode(i).decode() for i in request_cookie.split("|")
         ]

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,8 @@ import fakeredis
 import pytest
 import vcr
 from django.conf import settings
+from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.utils.sessions import Session
 
 # we need to enable this in the test environment since we're often creating
 # timeseries data and then asserting something about the aggregates all in
@@ -42,3 +44,32 @@ def mock_redis(mocker):
     redis_server = fakeredis.FakeStrictRedis()
     m.return_value = redis_server
     yield redis_server
+
+
+@pytest.fixture(scope="class")
+def sample_report(request):
+    report = Report()
+    first_file = ReportFile("foo/file1.py")
+    first_file.append(
+        1, ReportLine.create(coverage=1, sessions=[[0, 1]], complexity=(10, 2))
+    )
+    first_file.append(2, ReportLine.create(coverage=0, sessions=[[0, 1]]))
+    first_file.append(3, ReportLine.create(coverage=1, sessions=[[0, 1]]))
+    first_file.append(5, ReportLine.create(coverage=1, sessions=[[0, 1]]))
+    first_file.append(6, ReportLine.create(coverage=0, sessions=[[0, 1]]))
+    first_file.append(8, ReportLine.create(coverage=1, sessions=[[0, 1]]))
+    first_file.append(9, ReportLine.create(coverage=1, sessions=[[0, 1]]))
+    first_file.append(10, ReportLine.create(coverage=0, sessions=[[0, 1]]))
+    second_file = ReportFile("bar/file2.py")
+    second_file.append(12, ReportLine.create(coverage=1, sessions=[[0, 1]]))
+    second_file.append(
+        51, ReportLine.create(coverage="1/2", type="b", sessions=[[0, 1]])
+    )
+    third_file = ReportFile("file3.py")
+    third_file.append(1, ReportLine.create(coverage=1, sessions=[[0, 1]]))
+    report.append(first_file)
+    report.append(second_file)
+    report.append(third_file)
+    report.add_session(Session(flags=["flag1", "flag2"]))
+
+    request.cls.sample_report = report

--- a/services/path.py
+++ b/services/path.py
@@ -121,25 +121,19 @@ def is_subpath(full_path: str, subpath: str):
     return full_path.startswith(f"{subpath}/") or full_path == subpath
 
 
-# Regex that separates string into 2 groups, taken from https://stackoverflow.com/a/33021907
-def calculate_path_file_and_dir_groups(path: str) -> tuple[str, str]:
-    result = re.search(r"((?:[^/]*/)*)(.*)", path)
-    return result.groups()
-
-
-def is_file(path) -> bool:
-    (path, filename) = calculate_path_file_and_dir_groups(path=path)
-    return True if "." in filename and filename[0] != "." else False
-
-
 def dashboard_commit_file_url(
-    path: Optional[str], service: str, owner: str, repo: str, commit_sha: str
+    path: Optional[str],
+    service: str,
+    owner: str,
+    repo: str,
+    commit: Commit,
 ) -> str:
     if path is None:
         path = ""
-    is_path_a_file = is_file(path=path)
-    commit_path = f"blob/{path}" if is_path_a_file else f"tree/{path}"
-    return f"{settings.CODECOV_DASHBOARD_URL}/{service}/{owner}/{repo}/commit/{commit_sha}/{commit_path}"
+    report = commit.full_report
+    is_file = report and path in report.files
+    commit_path = f"blob/{path}" if is_file else f"tree/{path}"
+    return f"{settings.CODECOV_DASHBOARD_URL}/{service}/{owner}/{repo}/commit/{commit.commitid}/{commit_path}"
 
 
 class ReportPaths:


### PR DESCRIPTION
### Purpose/Motivation

Addresses multiple vulnerabilities detected by GH code scanning alerts.

### Links to relevant tickets

https://github.com/codecov/internal-issues/issues/53
https://github.com/codecov/internal-issues/issues/54
https://github.com/codecov/internal-issues/issues/55
https://github.com/codecov/internal-issues/issues/70
https://github.com/codecov/internal-issues/issues/71

Fixes https://github.com/codecov/codecov-api/security/code-scanning/5
Fixes https://github.com/codecov/codecov-api/security/code-scanning/6
Fixes https://github.com/codecov/codecov-api/security/code-scanning/7

These tickets boil down to 2 vulnerabilities described below. 

### What does this PR do?

* Encrypts the OAuth token data before saving it in a cookie
  - for BitBucket and BitBucket server
  - also signs the cookie for good measure

* Addresses a potential DoS on a path regex that originates from user input
  - completely changed the logic related to this and removed the regex altogether
  - @adrian-codecov Can you verify that this still makes sense?