### PR TITLE
don't save student status to owner if it is false

### DIFF
--- a/codecov_auth/views/base.py
+++ b/codecov_auth/views/base.py
@@ -221,7 +221,10 @@ class LoginMixin(object):
         self._check_user_count_limitations(user_dict["user"])
         owner, is_new_user = self._get_or_create_owner(user_dict, request)
         fields_to_update = []
-        if user_dict.get("is_student") != owner.student:
+        if (
+            get_config(self.service, "student_disabled", default=False)
+            and user_dict.get("is_student") != owner.student
+        ):
             owner.student = user_dict.get("is_student")
             if owner.student_created_at is None:
                 owner.student_created_at = timezone.now()

--- a/codecov_auth/views/base.py
+++ b/codecov_auth/views/base.py
@@ -222,7 +222,7 @@ class LoginMixin(object):
         owner, is_new_user = self._get_or_create_owner(user_dict, request)
         fields_to_update = []
         if (
-            get_config(self.service, "student_disabled", default=False)
+            not get_config(self.service, "student_disabled", default=False)
             and user_dict.get("is_student") != owner.student
         ):
             owner.student = user_dict.get("is_student")


### PR DESCRIPTION
### Purpose/Motivation
We don't want to save the student status of an owner if it's false

### Links to relevant tickets
Fixes: https://github.com/codecov/engineering-team/issues/644

### What does this PR do?
- Only save student status from user_dict to owner if user_dict student status is True
