### PR TITLE
ref: Accept service less requests gq

### DIFF
--- a/codecov/commands/base.py
+++ b/codecov/commands/base.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 
+from codecov.commands.exceptions import MissingService
 from codecov_auth.models import Owner
 
 
@@ -26,9 +27,15 @@ class BaseCommand:
 
 
 class BaseInteractor:
+    requires_service = True
+
     def __init__(self, current_owner: Owner, service: str):
         self.current_owner = current_owner
         self.service = service
+
+        if not self.service and self.requires_service:
+            raise MissingService()
+
         self.current_user = AnonymousUser()
         if self.current_owner:
             self.current_user = self.current_owner.user

--- a/codecov/commands/exceptions.py
+++ b/codecov/commands/exceptions.py
@@ -18,3 +18,7 @@ class Unauthorized(BaseException):
 
 class NotFound(BaseException):
     message = "Cant find the requested resource"
+
+
+class MissingService(BaseException):
+    message = "Missing required service"

--- a/codecov/commands/tests/test_base.py
+++ b/codecov/commands/tests/test_base.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth.models import AnonymousUser
 
 from codecov.commands.exceptions import MissingService
@@ -22,7 +23,7 @@ def test_base_command():
 
 
 def test_base_interactor_with_missing_required_service():
-    try:
+    with pytest.raises(MissingService) as excinfo:
         BaseInteractor(None, None)
-    except Exception as e:
-        assert isinstance(e, MissingService)
+
+    assert excinfo.value.message == "Missing required service"

--- a/codecov/commands/tests/test_base.py
+++ b/codecov/commands/tests/test_base.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 
+from codecov.commands.exceptions import MissingService
 from core.commands.commit import CommitCommands
 
 from ..base import BaseCommand, BaseInteractor
@@ -18,3 +19,10 @@ def test_base_command():
     # test get_command
     command_command = command.get_command("commit")
     assert isinstance(command_command, CommitCommands)
+
+
+def test_base_interactor_with_missing_required_service():
+    try:
+        BaseInteractor(None, None)
+    except Exception as e:
+        assert isinstance(e, MissingService)

--- a/codecov_auth/commands/owner/interactors/save_terms_agreement.py
+++ b/codecov_auth/commands/owner/interactors/save_terms_agreement.py
@@ -16,6 +16,8 @@ class TermsAgreementInput:
 
 
 class SaveTermsAgreementInteractor(BaseInteractor):
+    requires_service = False
+
     def validate(self, input: TermsAgreementInput):
         if input.terms_agreement is None:
             raise ValidationError("Terms of agreement cannot be null")

--- a/codecov_auth/commands/owner/interactors/tests/test_get_is_current_user_an_admin.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_get_is_current_user_an_admin.py
@@ -146,7 +146,7 @@ class GetIsCurrentUserAnAdminInteractorTest(TransactionTestCase):
 
     def test_is_admin_no_current_owner(self):
         owner = OwnerFactory(ownerid=5)
-        res = async_to_sync(GetIsCurrentUserAnAdminInteractor(owner, None).execute)(
+        res = async_to_sync(GetIsCurrentUserAnAdminInteractor(owner, "gitlab").execute)(
             owner, None
         )
         assert res == False

--- a/graphql_api/actions/owner.py
+++ b/graphql_api/actions/owner.py
@@ -1,3 +1,4 @@
+from codecov.commands.exceptions import MissingService
 from codecov.db import sync_to_async
 from codecov_auth.models import Owner
 from utils.services import get_long_service_name
@@ -14,6 +15,9 @@ def search_my_owners(current_user, filters):
 
 @sync_to_async
 def get_owner(service, username):
+    if not service:
+        raise MissingService()
+
     long_service = get_long_service_name(service)
     return Owner.objects.filter(username=username, service=long_service).first()
 

--- a/graphql_api/helpers/mutation.py
+++ b/graphql_api/helpers/mutation.py
@@ -23,6 +23,7 @@ class WrappedException:
             exceptions.Unauthorized: "UnauthorizedError",
             exceptions.NotFound: "NotFoundError",
             exceptions.ValidationError: "ValidationError",
+            exceptions.MissingService: "MissingService",
         }
         type_exception = type(self.exception)
         return error_to_graphql_type.get(type_exception, None)

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 
+import pytest
 from django.test import TransactionTestCase
 from django.utils import timezone
 from freezegun import freeze_time
@@ -564,8 +565,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
             current_org.username
         )
 
-        try:
-            self.gql_request(query, provider="", owner=current_org)
-        except MissingService as e:
-            assert str(e) == "Missing service"
-            raise
+        res = self.gql_request(query, provider="", with_errors=True)
+
+        assert res["errors"][0]["message"] == MissingService.message
+        assert res["data"]["owner"] is None

--- a/graphql_api/urls.py
+++ b/graphql_api/urls.py
@@ -15,6 +15,7 @@ ALLOWED_SERVICES = [
     "gitlab_enterprise",
     "bbs",
     "bitbucket_server",
+    "",
 ]
 
 service_regex = "|".join(ALLOWED_SERVICES)


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
To be able to use TOS with service less requests, we need to update the mutation (graphql endpoints) to accept no service, and raise a proper exception otherwise. 

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.
- Add new MissingService exception 
- Allow non-service based TOS mutation 
- Add tests 

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.