### PR TITLE
triggering pre-process upload for all users

### DIFF
--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -66,6 +66,7 @@ def test_create_report_already_exists(client, db, mocker):
 
 
 def test_reports_post_code_as_default(client, db, mocker):
+    mocked_call = mocker.patch.object(TaskService, "preprocess_upload")
     repository = RepositoryFactory(
         name="the_repo", author__username="codecov", author__service="github"
     )
@@ -84,6 +85,7 @@ def test_reports_post_code_as_default(client, db, mocker):
     )
     assert response.status_code == 201
     assert CommitReport.objects.filter(commit_id=commit.id, code=None).exists()
+    mocked_call.assert_called_once()
 
 
 def test_reports_results_post_successful(client, db, mocker):
@@ -222,23 +224,3 @@ def test_report_results_get_unsuccessful(client, db, mocker):
     )
     assert response.status_code == 400
     assert response.json() == ["Report Results not found"]
-
-
-def test_not_called_preprocess_upload_task(client, db, mocker):
-    mocked_call = mocker.patch.object(TaskService, "preprocess_upload")
-    repository = RepositoryFactory(
-        name="the_repo", author__username="not_codecov", author__service="github"
-    )
-    commit = CommitFactory(repository=repository)
-    repository.save()
-    client = APIClient()
-    client.credentials(HTTP_AUTHORIZATION="token " + repository.upload_token)
-    url = reverse(
-        "new_upload.reports",
-        args=["github", "not_codecov::::the_repo", commit.commitid],
-    )
-    response = client.post(url, data={"code": "code1"})
-
-    assert response.status_code == 201
-    assert CommitReport.objects.filter(commit_id=commit.id, code="code1").exists()
-    mocked_call.assert_not_called()

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -40,10 +40,9 @@ class ReportViews(ListCreateAPIView, GetterMixin):
         instance = serializer.save(
             commit_id=commit.id,
         )
-        if repository.author.username == "codecov":
-            TaskService().preprocess_upload(
-                repository.repoid, commit.commitid, instance.code
-            )
+        TaskService().preprocess_upload(
+            repository.repoid, commit.commitid, instance.code
+        )
         return instance
 
     def list(self, request: HttpRequest, service: str, repo: str, commit_sha: str):


### PR DESCRIPTION


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
