### PR TITLE
segment is expecting user_id not owner_id, fixing it

### DIFF
--- a/services/analytics.py
+++ b/services/analytics.py
@@ -56,6 +56,7 @@ class AnalyticsOwner:
             "email": self.owner.email or "unknown@codecov.io",
             "username": self.owner.username or "unknown",
             "owner_id": self.owner.ownerid,
+            "user_id": self.owner.ownerid,
         }
 
     @property

--- a/services/tests/test_analytics.py
+++ b/services/tests/test_analytics.py
@@ -38,6 +38,7 @@ class AnalyticsOwnerTests(TestCase):
             "service_id": self.analytics_owner.owner.service_id,
             "plan": self.analytics_owner.owner.plan,
             "owner_id": self.analytics_owner.owner.ownerid,
+            "user_id": self.analytics_owner.owner.ownerid,
         }
 
         assert self.analytics_owner.traits == expected_traits


### PR DESCRIPTION
shared is expecting "user_id" to be part of the owner object traits, and the traits had owner_id instead that's why it was sending -1 
<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
