### PR TITLE
sending org id for upload events

### DIFF
--- a/services/analytics.py
+++ b/services/analytics.py
@@ -181,14 +181,19 @@ class AnalyticsService:
 
     @inject_analytics_repository
     def account_activated_repository_on_upload(self, org_ownerid, analytics_repository):
+        event_data = {
+            **analytics_repository.traits,
+            "user_id": org_ownerid,
+        }
         analytics_manager.track_event(
             Events.ACCOUNT_ACTIVATED_REPOSITORY_ON_UPLOAD.value,
             is_enterprise=settings.IS_ENTERPRISE,
-            event_data=analytics_repository.traits,
+            event_data=event_data,
             context={"groupId": org_ownerid},
         )
 
     def account_uploaded_coverage_report(self, org_ownerid, upload_details):
+        upload_details = {**upload_details, "user_id": org_ownerid}
         analytics_manager.track_event(
             Events.ACCOUNT_UPLOADED_COVERAGE_REPORT.value,
             is_enterprise=settings.IS_ENTERPRISE,

--- a/services/tests/test_analytics.py
+++ b/services/tests/test_analytics.py
@@ -184,14 +184,17 @@ class AnalyticsServiceTests(TestCase):
             track_mock.assert_called_once_with(
                 Events.ACCOUNT_ACTIVATED_REPOSITORY_ON_UPLOAD.value,
                 is_enterprise=False,
-                event_data=AnalyticsRepository(repo).traits,
+                event_data={
+                    **AnalyticsRepository(repo).traits,
+                    "user_id": owner.ownerid,
+                },
                 context={"groupId": repo.author.ownerid},
             )
 
     @patch("shared.analytics_tracking.analytics_manager.track_event")
     def test_account_uploaded_coverage_report(self, track_mock):
         owner = OwnerFactory()
-        upload_details = {"some": "dict"}
+        upload_details = {"some": "dict", "user_id": owner.ownerid}
         with self.settings(IS_ENTERPRISE=False):
             self.analytics_service.account_uploaded_coverage_report(
                 owner.ownerid, upload_details


### PR DESCRIPTION
We want to send to segment the org_id as user_id for upload events 
<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
