### PR TITLE
ref: Add marketing consent to save TOS mutation

### DIFF
--- a/codecov_auth/commands/owner/interactors/save_terms_agreement.py
+++ b/codecov_auth/commands/owner/interactors/save_terms_agreement.py
@@ -13,6 +13,7 @@ from codecov_auth.models import User
 class TermsAgreementInput:
     business_email: Optional[str] = None
     terms_agreement: bool = False
+    marketing_consent: bool = False
 
 
 class SaveTermsAgreementInteractor(BaseInteractor):
@@ -36,6 +37,7 @@ class SaveTermsAgreementInteractor(BaseInteractor):
         typed_input = TermsAgreementInput(
             business_email=input.get("businessEmail"),
             terms_agreement=input.get("termsAgreement"),
+            marketing_consent=input.get("marketingConsent"),
         )
         self.validate(typed_input)
         return self.update_terms_agreement(typed_input)

--- a/graphql_api/types/mutation/save_terms_agreement/save_terms_agreement.graphql
+++ b/graphql_api/types/mutation/save_terms_agreement/save_terms_agreement.graphql
@@ -7,4 +7,5 @@ type SaveTermsAgreementPayload {
 input SaveTermsAgreementInput {
   businessEmail: String
   termsAgreement: Boolean!
+  marketingConsent: Boolean
 }


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
need to fire the marketing consent emails.

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
