### PR TITLE
Only auto-activate if state has changed, remove update to repo.updatestamp

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -559,11 +559,12 @@ def validate_upload(upload_params, repository, redis):
             repository.author.ownerid, repository
         )
 
-    # Activate the repository
-    repository.activated = True
-    repository.active = True
-    repository.deleted = False
-    repository.save(update_fields=["activated", "active", "deleted", "updatestamp"])
+    if not repository.activated or not repository.active or repository.deleted:
+        # Activate the repository
+        repository.activated = True
+        repository.active = True
+        repository.deleted = False
+        repository.save(update_fields=["activated", "active", "deleted"])
 
 
 def _determine_responsible_owner(repository):


### PR DESCRIPTION
### Purpose/Motivation

This query was quite slow at times.  See here for p99 response time > 60s in some cases: https://codecov.sentry.io/performance/summary/spans/db:500d772238719a7c/?environment=production&project=5215654&query=http.method%3APOST&statsPeriod=7d&transaction=%2Fupload%2F%7Bversion%7D%2F

Presumably there's just lots of contention for that repo row and updates are waiting on locks.  The actual query itself is conditional on the primary key so it's not like adding an index would speed that up or anything.

### Links to relevant tickets

Depends on https://github.com/codecov/worker/pull/150

### What does this PR do?

* Removes the update to `repos.updatestamp` (this will now happen in the worker - see here: https://github.com/codecov/worker/pull/150)
* only update the `active/activated/deleted` state if it actually changed