### PR TITLE
chore: fix label-analysis metrics placement

### DIFF
--- a/labelanalysis/serializers.py
+++ b/labelanalysis/serializers.py
@@ -71,12 +71,13 @@ class LabelAnalysisRequestSerializer(serializers.ModelSerializer):
     errors = ProcessingErrorList(required=False)
 
     def validate(self, data):
+        metrics.incr("label_analysis_request.count")
         if data["base_commit"] == data["head_commit"]:
             metrics.incr("label_analysis_request.errors.base_head_equal")
             raise serializers.ValidationError(
                 {"base_commit": "Base and head must be different commits"}
             )
-        metrics.incr("label_analysis_request.count")
+        metrics.incr("label_analysis_request.valid.count")
         return data
 
     class Meta:


### PR DESCRIPTION
The count for label analysis only fires after validation.
So that is the total number of _valid_ label analysis requests.

The actual total number of requets that we receive need to be fired
_before_ the payload validation.

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
