### PR TITLE
ref: Handle current_user in base

### DIFF
--- a/codecov/commands/base.py
+++ b/codecov/commands/base.py
@@ -42,5 +42,5 @@ class BaseInteractor:
         if not self.service and self.requires_service:
             raise MissingService()
 
-        if self.current_owner and not self.current_user.is_authenticated:
-            self.current_user = self.current_owner
+        if self.current_owner:
+            self.current_user = self.current_owner.user

--- a/codecov/commands/base.py
+++ b/codecov/commands/base.py
@@ -5,10 +5,8 @@ from codecov_auth.models import Owner, User
 
 
 class BaseCommand:
-    def __init__(
-        self, current_owner: Owner, service: str, current_user: User = AnonymousUser()
-    ):
-        self.current_user = current_user
+    def __init__(self, current_owner: Owner, service: str, current_user: User = None):
+        self.current_user = current_user or AnonymousUser()
         self.current_owner = current_owner
         self.service = service
         self.executor = None
@@ -36,10 +34,8 @@ class BaseCommand:
 class BaseInteractor:
     requires_service = True
 
-    def __init__(
-        self, current_owner: Owner, service: str, current_user: User = AnonymousUser()
-    ):
-        self.current_user = current_user
+    def __init__(self, current_owner: Owner, service: str, current_user: User = None):
+        self.current_user = current_user or AnonymousUser()
         self.current_owner = current_owner
         self.service = service
 

--- a/codecov/commands/base.py
+++ b/codecov/commands/base.py
@@ -1,17 +1,24 @@
 from django.contrib.auth.models import AnonymousUser
 
 from codecov.commands.exceptions import MissingService
-from codecov_auth.models import Owner
+from codecov_auth.models import Owner, User
 
 
 class BaseCommand:
-    def __init__(self, current_owner: Owner, service: str):
+    def __init__(
+        self, current_owner: Owner, service: str, current_user: User = AnonymousUser()
+    ):
+        self.current_user = current_user
         self.current_owner = current_owner
         self.service = service
         self.executor = None
 
     def get_interactor(self, InteractorKlass):
-        return InteractorKlass(self.current_owner, self.service)
+        return InteractorKlass(
+            current_owner=self.current_owner,
+            service=self.service,
+            current_user=self.current_user,
+        )
 
     def get_command(self, namespace):
         """
@@ -29,13 +36,15 @@ class BaseCommand:
 class BaseInteractor:
     requires_service = True
 
-    def __init__(self, current_owner: Owner, service: str):
+    def __init__(
+        self, current_owner: Owner, service: str, current_user: User = AnonymousUser()
+    ):
+        self.current_user = current_user
         self.current_owner = current_owner
         self.service = service
 
         if not self.service and self.requires_service:
             raise MissingService()
 
-        self.current_user = AnonymousUser()
-        if self.current_owner:
-            self.current_user = self.current_owner.user
+        if self.current_owner and not self.current_user.is_authenticated:
+            self.current_user = self.current_owner

--- a/codecov/commands/executor.py
+++ b/codecov/commands/executor.py
@@ -1,5 +1,5 @@
 from codecov_auth.commands.owner import OwnerCommands
-from codecov_auth.models import Owner
+from codecov_auth.models import Owner, User
 from compare.commands.compare import CompareCommands
 from core.commands.branch import BranchCommands
 from core.commands.commit import CommitCommands
@@ -22,13 +22,14 @@ mapping = {
 
 
 class Executor:
-    def __init__(self, current_owner: Owner, service: str):
+    def __init__(self, current_owner: Owner, service: str, current_user: User):
+        self.current_user = current_user
         self.current_owner = current_owner
         self.service = service
 
     def get_command(self, namespace):
         KlassCommand = mapping[namespace]
-        return KlassCommand(self.current_owner, self.service)
+        return KlassCommand(self.current_owner, self.service, self.current_user)
 
 
 def get_executor_from_request(request):
@@ -36,6 +37,7 @@ def get_executor_from_request(request):
     return Executor(
         current_owner=request.current_owner,
         service=get_long_service_name(service_in_url),
+        current_user=request.user,
     )
 
 
@@ -43,4 +45,5 @@ def get_executor_from_command(command):
     return Executor(
         current_owner=command.current_owner,
         service=command.service,
+        current_user=command.current_user,
     )

--- a/codecov/commands/tests/test_executor.py
+++ b/codecov/commands/tests/test_executor.py
@@ -3,7 +3,6 @@ from django.test import RequestFactory
 from django.urls import ResolverMatch
 
 from codecov_auth.commands.owner import OwnerCommands
-from codecov_auth.tests.factories import OwnerFactory
 
 from ..executor import get_executor_from_command, get_executor_from_request
 

--- a/codecov_auth/commands/owner/interactors/save_terms_agreement.py
+++ b/codecov_auth/commands/owner/interactors/save_terms_agreement.py
@@ -4,9 +4,8 @@ from typing import Optional
 from django.utils import timezone
 
 from codecov.commands.base import BaseInteractor
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthenticated, ValidationError
 from codecov.db import sync_to_async
-from codecov_auth.models import User
 
 
 @dataclass
@@ -22,8 +21,8 @@ class SaveTermsAgreementInteractor(BaseInteractor):
     def validate(self, input: TermsAgreementInput):
         if input.terms_agreement is None:
             raise ValidationError("Terms of agreement cannot be null")
-        if not self.current_owner or not self.current_owner.user_id:
-            raise ValidationError("Owner does not have an associated user")
+        if not self.current_user.is_authenticated:
+            raise Unauthenticated()
 
     def update_terms_agreement(self, input: TermsAgreementInput):
         self.current_user.terms_agreement = input.terms_agreement
@@ -31,8 +30,8 @@ class SaveTermsAgreementInteractor(BaseInteractor):
         self.current_user.save()
 
         if input.business_email is not None and input.business_email != "":
-            self.current_owner.business_email = input.business_email
-            self.current_owner.save()
+            self.current_user.email = input.business_email
+            self.current_user.save()
 
     @sync_to_async
     def execute(self, input):

--- a/codecov_auth/commands/owner/interactors/tests/test_save_terms_agreement.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_save_terms_agreement.py
@@ -1,86 +1,72 @@
 import pytest
 from asgiref.sync import async_to_sync
+from django.contrib.auth.models import AnonymousUser
 from django.test import TransactionTestCase
 from django.utils import timezone
 from freezegun import freeze_time
+from freezegun.api import FakeDatetime
 
-from codecov.commands.exceptions import ValidationError
-from codecov_auth.models import User
-from codecov_auth.tests.factories import OwnerFactory
+from codecov.commands.exceptions import Unauthenticated, ValidationError
+from codecov_auth.tests.factories import UserFactory
 
 from ..save_terms_agreement import SaveTermsAgreementInteractor
 
 
 class UpdateSaveTermsAgreementInteractorTest(TransactionTestCase):
     def setUp(self):
-        self.current_owner = OwnerFactory(
-            username="random-user-123",
-            service="github",
-            business_email="asdfasdfa@gmail.com",
-        )
+        self.current_user = UserFactory(name="codecov-user")
+        self.updated_at = FakeDatetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
     @async_to_sync
     def execute(
-        self, current_owner, input={"businessEmail": None, "termsAgreement": False}
+        self, current_user, input={"businessEmail": None, "termsAgreement": False}
     ):
-        return SaveTermsAgreementInteractor(current_owner, "github").execute(
+        return SaveTermsAgreementInteractor(None, "github", current_user).execute(
             input=input,
         )
 
     @freeze_time("2022-01-01T00:00:00")
     def test_update_user_when_agreement_is_false(self):
-        self.execute(current_owner=self.current_owner, input={"termsAgreement": False})
-        before_refresh_business_email = self.current_owner.business_email
+        self.execute(current_user=self.current_user, input={"termsAgreement": False})
+        before_refresh_business_email = self.current_user.email
 
-        user: User = User.objects.filter(id=self.current_owner.user_id).first()
-        assert user.terms_agreement == False
-        assert user.terms_agreement_at == timezone.datetime(2022, 1, 1)
+        assert self.current_user.terms_agreement == False
+        assert self.current_user.terms_agreement_at == self.updated_at
 
-        self.current_owner.refresh_from_db()
-        self.current_owner.business_email == before_refresh_business_email
+        self.current_user.refresh_from_db()
+        self.current_user.email == before_refresh_business_email
 
-    @freeze_time("2022-01-02T00:00:00")
+    @freeze_time("2022-01-01T00:00:00")
     def test_update_user_when_agreement_is_true(self):
-        self.execute(current_owner=self.current_owner, input={"termsAgreement": True})
-        before_refresh_business_email = self.current_owner.business_email
+        self.execute(current_user=self.current_user, input={"termsAgreement": True})
+        before_refresh_business_email = self.current_user.email
 
-        user: User = User.objects.filter(id=self.current_owner.user_id).first()
-        assert user.terms_agreement == True
-        assert user.terms_agreement_at == timezone.datetime(2022, 1, 2)
+        assert self.current_user.terms_agreement == True
+        assert self.current_user.terms_agreement_at == self.updated_at
 
-        self.current_owner.refresh_from_db()
-        self.current_owner.business_email == before_refresh_business_email
+        self.current_user.refresh_from_db()
+        self.current_user.email == before_refresh_business_email
 
-    @freeze_time("2022-01-03T00:00:00")
+    @freeze_time("2022-01-01T00:00:00")
     def test_update_owner_and_user_when_email_is_not_empty(self):
         self.execute(
-            current_owner=self.current_owner,
+            current_user=self.current_user,
             input={"businessEmail": "something@email.com", "termsAgreement": True},
         )
 
-        user: User = User.objects.filter(id=self.current_owner.user_id).first()
-        assert user.terms_agreement == True
-        assert user.terms_agreement_at == timezone.datetime(2022, 1, 3)
+        assert self.current_user.terms_agreement == True
+        assert self.current_user.terms_agreement_at == self.updated_at
 
-        self.current_owner.refresh_from_db()
-        self.current_owner.business_email == "something@email.com"
+        self.current_user.refresh_from_db()
+        self.current_user.email == "something@email.com"
 
     def test_validation_error_when_terms_is_none(self):
         with pytest.raises(ValidationError):
-            self.execute(
-                current_owner=self.current_owner, input={"termsAgreement": None}
-            )
+            self.execute(current_user=self.current_user, input={"termsAgreement": None})
 
-    def test_owner_has_no_user(self):
-        owner_without_user = OwnerFactory(
-            username="random-user-123",
-            service="github",
-            business_email="asdfasdfa@gmail.com",
-            user=None,
-        )
-        with pytest.raises(ValidationError) as e:
+    def test_user_is_not_authenticated(self):
+        with pytest.raises(Unauthenticated) as e:
             self.execute(
-                current_owner=owner_without_user,
+                current_user=AnonymousUser(),
                 input={"businessEmail": "something@email.com", "termsAgreement": True},
             )
-        assert str(e.value) == "Owner does not have an associated user"


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
passing current_user to use instead of relying on owner

### Links to relevant tickets
TBD

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.
- Handled current user in executor 
- Default to none user, so we don't go over 1000 tests :D 
- Refactor save terms interactor to handle user specific fields  

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?
..


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
