### PR TITLE
backend: interactor to config repo via PR

### DIFF
--- a/core/commands/repository/interactors/config_repo_via_PR.py
+++ b/core/commands/repository/interactors/config_repo_via_PR.py
@@ -1,0 +1,35 @@
+from codecov.commands.base import BaseInteractor
+from codecov.commands.exceptions import ValidationError
+from codecov.db import sync_to_async
+from codecov_auth.models import Owner
+from core.models import Repository
+from graphql_api.types.enums.enums import CiProvider
+
+
+class ConfigureRepoViaPRInteractor(BaseInteractor):
+
+    supported_ci_providers = [CiProvider.GITHUB_ACTIONS]
+
+    @sync_to_async
+    def execute(self, repo_name: str, owner_username: str, ci_provider: CiProvider):
+        author = Owner.objects.filter(
+            username=owner_username, service=self.service
+        ).first()
+        repo = (
+            Repository.objects.viewable_repos(self.current_owner)
+            .filter(author=author, name=repo_name)
+            .first()
+        )
+        if not repo:
+            raise ValidationError("Repo not found")
+
+        if ci_provider not in self.supported_ci_providers:
+            raise ValidationError(f"Provider {ci_provider} is not supported")
+
+        try:
+            # TODO: Enqueue task to generate the config PR
+            raise NotImplementedError()
+        except NotImplementedError:
+            result = False
+
+        return result

--- a/core/commands/repository/interactors/tests/test_config_repo_via_pr.py
+++ b/core/commands/repository/interactors/tests/test_config_repo_via_pr.py
@@ -1,0 +1,51 @@
+import pytest
+from django.test import TransactionTestCase
+
+from codecov.commands.exceptions import ValidationError
+from codecov_auth.tests.factories import OwnerFactory
+from core.tests.factories import RepositoryFactory
+from graphql_api.types.enums.enums import CiProvider
+
+from ..config_repo_via_PR import ConfigureRepoViaPRInteractor
+
+
+class TestConfigRepoViaPRInteractor(TransactionTestCase):
+    def setUp(self):
+        self.org = OwnerFactory(username="codecov")
+        self.new_repo = RepositoryFactory(
+            author=self.org, name="new-repo", active=False
+        )
+        self.user = OwnerFactory(
+            organizations=[self.org.ownerid],
+            permission=[self.new_repo.repoid],
+        )
+        self.random_user = OwnerFactory(organizations=[self.org.ownerid])
+
+    def execute(self, owner, repo, provider):
+        return ConfigureRepoViaPRInteractor(owner, "github").execute(
+            repo_name=repo.name,
+            owner_username=self.org.username,
+            ci_provider=provider,
+        )
+
+    async def test_when_validation_error_ci_provider_not_supported(self):
+        missing_provider = "CIRCLECI"
+        with pytest.raises(ValidationError) as exp:
+            await self.execute(
+                owner=self.user, repo=self.new_repo, provider=missing_provider
+            )
+        assert str(exp.value) == f"Provider {missing_provider} is not supported"
+
+    async def test_when_validation_error_repo_not_found(self):
+        with pytest.raises(ValidationError):
+            await ConfigureRepoViaPRInteractor(self.random_user, "github").execute(
+                repo_name="missing-repo",
+                owner_username=self.org.username,
+                ci_provider=CiProvider.GITHUB_ACTIONS,
+            )
+
+    async def test_validation_ok(self):
+        result = await self.execute(
+            owner=self.user, repo=self.new_repo, provider=CiProvider.GITHUB_ACTIONS
+        )
+        assert result is False

--- a/core/commands/repository/repository.py
+++ b/core/commands/repository/repository.py
@@ -1,7 +1,9 @@
 from codecov.commands.base import BaseCommand
+from graphql_api.types.enums.enums import CiProvider
 from timeseries.models import MeasurementName
 
 from .interactors.activate_measurements import ActivateMeasurementsInteractor
+from .interactors.config_repo_via_PR import ConfigureRepoViaPRInteractor
 from .interactors.fetch_repository import FetchRepositoryInteractor
 from .interactors.get_repository_token import GetRepositoryTokenInteractor
 from .interactors.get_upload_token import GetUploadTokenInteractor
@@ -32,4 +34,11 @@ class RepositoryCommands(BaseCommand):
     ):
         return self.get_interactor(ActivateMeasurementsInteractor).execute(
             repo_name, owner_name, measurement_type
+        )
+
+    def configure_repo_via_PR(
+        self, repo_name: str, owner_name: str, ci_provider: CiProvider
+    ):
+        return self.get_interactor(ConfigureRepoViaPRInteractor).execute(
+            repo_name, owner_name, ci_provider
         )

--- a/graphql_api/types/enums/__init__.py
+++ b/graphql_api/types/enums/__init__.py
@@ -1,4 +1,5 @@
 from .enums import (
+    CiProvider,
     CommitErrorCode,
     CommitErrorGeneralType,
     CoverageLine,

--- a/graphql_api/types/enums/ci_provider.graphql
+++ b/graphql_api/types/enums/ci_provider.graphql
@@ -1,0 +1,3 @@
+enum CiProvider {
+    GITHUB_ACTIONS
+}

--- a/graphql_api/types/enums/enums.py
+++ b/graphql_api/types/enums/enums.py
@@ -83,6 +83,10 @@ class LoginProvider(enum.Enum):
     OKTA = "okta"
 
 
+class CiProvider(enum.Enum):
+    GITHUB_ACTIONS = "github_actions"
+
+
 class CommitErrorGeneralType(enum.Enum):
     yaml_error = "YAML_ERROR"
     bot_error = "BOT_ERROR"

--- a/graphql_api/types/inputs/config_via_PR.graphql
+++ b/graphql_api/types/inputs/config_via_PR.graphql
@@ -1,0 +1,5 @@
+input ConfigRepositoryViaPRInput {
+  owner: String!
+  repoName: String!
+  ciProvider: CiProvider!
+}

--- a/graphql_api/types/mutation/__init__.py
+++ b/graphql_api/types/mutation/__init__.py
@@ -2,6 +2,7 @@ from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 
 from .activate_measurements import gql_activate_measurements
 from .cancel_trial import gql_cancel_trial
+from .config_repo_via_PR import gql_config_repo_via_pr
 from .create_api_token import gql_create_api_token
 from .create_user_token import gql_create_user_token
 from .delete_flag import gql_delete_flag
@@ -37,3 +38,4 @@ mutation = mutation + gql_save_sentry_state
 mutation = mutation + gql_save_terms_agreement
 mutation = mutation + gql_start_trial
 mutation = mutation + gql_cancel_trial
+mutation = mutation + gql_config_repo_via_pr

--- a/graphql_api/types/mutation/config_repo_via_PR/__init__.py
+++ b/graphql_api/types/mutation/config_repo_via_PR/__init__.py
@@ -1,0 +1,10 @@
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+
+from .config_repo_via_PR import (
+    error_configure_repo_via_PR,
+    resolve_config_repository_via_PR,
+)
+
+gql_config_repo_via_pr = ariadne_load_local_graphql(
+    __file__, "config_repo_via_PR.graphql"
+)

--- a/graphql_api/types/mutation/config_repo_via_PR/config_repo_via_PR.graphql
+++ b/graphql_api/types/mutation/config_repo_via_PR/config_repo_via_PR.graphql
@@ -1,0 +1,6 @@
+union ConfigRepositoryViaPRError = UnauthenticatedError | ValidationError
+
+type ConfigRepositoryViaPRPayload {
+    success: Int
+    error: ConfigRepositoryViaPRError
+}

--- a/graphql_api/types/mutation/config_repo_via_PR/config_repo_via_PR.py
+++ b/graphql_api/types/mutation/config_repo_via_PR/config_repo_via_PR.py
@@ -1,0 +1,26 @@
+from ariadne import UnionType, convert_kwargs_to_snake_case
+
+from graphql_api.helpers.mutation import (
+    require_authenticated,
+    resolve_union_error_type,
+    wrap_error_handling_mutation,
+)
+
+
+@wrap_error_handling_mutation
+@require_authenticated
+@convert_kwargs_to_snake_case
+async def resolve_config_repository_via_PR(_, info, input):
+    command = info.context["executor"].get_command("repository")
+    # FIXME
+    await command.regenerate_repository_token(
+        repo_name=input.get("repo_name"),
+        owner_username=input.get("owner"),
+        token_type=input.get("token_type"),
+    )
+
+    return {"success": int(True)}
+
+
+error_configure_repo_via_PR = UnionType("ConfigRepositoryViaPRError")
+error_configure_repo_via_PR.type_resolver(resolve_union_error_type)

--- a/graphql_api/types/mutation/mutation.graphql
+++ b/graphql_api/types/mutation/mutation.graphql
@@ -15,6 +15,9 @@ type Mutation {
   regenerateRepositoryToken(
     input: RegenerateRepositoryTokenInput!
   ): RegenerateRepositoryTokenPayload
+  configRepositoryViaPR(
+    input: ConfigRepositoryViaPRInput!
+  ): ConfigRepositoryViaPRPayload
   activateMeasurements(
     input: ActivateMeasurementsInput!
   ): activateMeasurementsPayload


### PR DESCRIPTION
THese changes extend the graphQL schema to introduce an interactor
that _would_ call a task in the worker to config a repo via PR.

context: codecov/engineering-team#150

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
