### PR TITLE
trigger pre-process upload for all users now

### DIFF
--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -40,11 +40,9 @@ class ReportViews(ListCreateAPIView, GetterMixin):
         instance = serializer.save(
             commit_id=commit.id,
         )
-        username = repository.author.username.lower()
-        if username == "codecov" or username == "getsentry":
-            TaskService().preprocess_upload(
-                repository.repoid, commit.commitid, instance.code
-            )
+        TaskService().preprocess_upload(
+            repository.repoid, commit.commitid, instance.code
+        )
         return instance
 
     def list(self, request: HttpRequest, service: str, repo: str, commit_sha: str):


### PR DESCRIPTION
We were triggering the pre-process upload task for our internal use. Now we're rolling it out for all users 
<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
