### PR TITLE
Fix XSS vulnerability by removing ref_type from Response

### DIFF
--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -201,7 +201,7 @@ class GithubWebhookHandler(APIView):
                 f"Unsupported ref type: {ref_type}, exiting",
                 extra=dict(repoid=repo.repoid, github_webhook_event=self.event),
             )
-            return Response(f"Unsupported ref type: {ref_type}")
+            return Response(f"Unsupported ref type")
         branch_name = self.request.data.get("ref")[11:]
         Branch.objects.filter(
             repository=self._get_repo(request), name=branch_name
@@ -232,7 +232,7 @@ class GithubWebhookHandler(APIView):
                 "Ref is tag, not branch, ignoring push event",
                 extra=dict(repoid=repo.repoid, github_webhook_event=self.event),
             )
-            return Response(f"Unsupported ref type: {ref_type}")
+            return Response(f"Unsupported ref type")
 
         if not repo.active:
             log.debug(


### PR DESCRIPTION
### Purpose/Motivation
A cross-site scripting vulnerability was detected, this PR attempts to remove that vulnerability

### Links to relevant tickets
Fixes: https://github.com/codecov/internal-issues/issues/68

### What does this PR do?
Remove ref_type value from Response in github webhook handler 

