### PR TITLE
Fix urllib and opentelemetry-instrumentation dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,8 +22,8 @@ google-cloud-pubsub
 gunicorn
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz
 minio
-opentelemetry-instrumentation-django
-opentelemetry-sdk
+opentelemetry-instrumentation-django>=0.41b0
+opentelemetry-sdk>=1.20.0
 opentracing
 pre-commit
 psycopg2

--- a/requirements.in
+++ b/requirements.in
@@ -43,5 +43,6 @@ sentry-sdk
 setproctitle
 simplejson
 stripe
+urllib3>=1.26.17
 vcrpy
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,7 @@ ariadne==0.19.1
 ariadne-django==0.2.0
     # via -r requirements.in
 asgiref==3.6.0
-    # via
-    #   django
-    #   opentelemetry-util-http
+    # via django
 async-timeout==4.0.2
     # via redis
 attrs==20.3.0
@@ -197,6 +195,8 @@ idna==2.8
     #   requests
     #   rfc3986
     #   yarl
+importlib-metadata==6.8.0
+    # via opentelemetry-api
 inflection==0.5.1
     # via drf-spectacular
 iniconfig==1.1.1
@@ -227,33 +227,33 @@ oauth2==1.9.0.post1
     # via shared
 oauthlib==3.1.0
     # via shared
-opentelemetry-api==1.3.0
+opentelemetry-api==1.20.0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-    #   opentelemetry-util-http
-opentelemetry-instrumentation==0.22b0
+opentelemetry-instrumentation==0.41b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
-    #   opentelemetry-util-http
-opentelemetry-instrumentation-django==0.22b0
+opentelemetry-instrumentation-django==0.41b0
     # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.22b0
+opentelemetry-instrumentation-wsgi==0.41b0
     # via opentelemetry-instrumentation-django
-opentelemetry-sdk==1.3.0
+opentelemetry-sdk==1.20.0
     # via
     #   -r requirements.in
     #   codecovopentelem
-opentelemetry-semantic-conventions==0.22b0
+opentelemetry-semantic-conventions==0.41b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.22b0
-    # via opentelemetry-instrumentation-django
+opentelemetry-util-http==0.41b0
+    # via
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
 opentracing==2.4.0
     # via -r requirements.in
 packaging==20.9
@@ -409,6 +409,7 @@ typing==3.7.4.3
 typing-extensions==4.6.2
     # via
     #   ariadne
+    #   opentelemetry-sdk
     #   shared
 uritemplate==4.1.1
     # via drf-spectacular
@@ -442,6 +443,8 @@ wrapt==1.14.1
     #   vcrpy
 yarl==1.5.1
     # via vcrpy
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -138,7 +138,6 @@ freezegun==1.1.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-storage
@@ -352,9 +351,7 @@ requests==2.31.0
     #   google-cloud-storage
     #   stripe
 rfc3986[idna2008]==1.4.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -415,8 +412,9 @@ typing-extensions==4.6.2
     #   shared
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.13
+urllib3==1.26.18
     # via
+    #   -r requirements.in
     #   botocore
     #   elastic-apm
     #   google-auth


### PR DESCRIPTION
### Purpose/Motivation
The versions of `urllib3` and `opentelemetry-instrumentation` we currently use have vulnerabilities, we can fix them by updating.

### Links to relevant tickets
Fixes: https://github.com/codecov/internal-issues/issues/104

### What does this PR do?
- Put restriction on urllib3 to be above version `1.26.17`
- Put restriction on opentelemetry-instrumentation-django to be above version `0.41b0`
- Put restriction on opentelemetry-sdk to be above `1.20.0`
