### PR TITLE
Allow for Database options to be set via config

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -1,3 +1,4 @@
+import ast
 import os
 from urllib.parse import urlparse
 
@@ -102,6 +103,8 @@ else:
     DATABASE_HOST = get_config("services", "database", "host", default="postgres")
     DATABASE_PORT = get_config("services", "database", "port", default=5432)
 
+DATABASE_OPTIONS = get_config("services", "database", "options", default="{}")
+
 DATABASE_READ_REPLICA_ENABLED = get_config(
     "setup", "database", "read_replica_enabled", default=False
 )
@@ -128,6 +131,8 @@ else:
         "services", "database_read", "host", default="postgres"
     )
     DATABASE_READ_PORT = get_config("services", "database_read", "port", default=5432)
+
+DATABASE_READ_OPTIONS = get_config("services", "database_read", "options", default="{}")
 
 TIMESERIES_ENABLED = get_config("setup", "timeseries", "enabled", default=False)
 TIMESERIES_REAL_TIME_AGGREGATES = get_config(
@@ -159,6 +164,10 @@ else:
         "services", "timeseries_database", "port", default=5432
     )
 
+TIMESERIES_DATABASE_OPTIONS = get_config(
+    "services", "timeseries_database", "options", default="{}"
+)
+
 TIMESERIES_DATABASE_READ_REPLICA_ENABLED = get_config(
     "setup", "timeseries", "read_replica_enabled", default=False
 )
@@ -188,6 +197,10 @@ else:
         "services", "timeseries_database_read", "port", default=5432
     )
 
+TIMESERIES_DATABASE_READ_OPTIONS = get_config(
+    "services", "timeseries_database_read", "options", default="{}"
+)
+
 # this is the time in seconds django decides to keep the connection open after the request
 # the default is 0 seconds, meaning django closes the connection after every request
 # https://docs.djangoproject.com/en/3.1/ref/settings/#conn-max-age
@@ -202,6 +215,7 @@ DATABASES = {
         "HOST": DATABASE_HOST,
         "PORT": DATABASE_PORT,
         "CONN_MAX_AGE": CONN_MAX_AGE,
+        "OPTIONS": ast.literal_eval(DATABASE_OPTIONS),
     }
 }
 
@@ -214,6 +228,7 @@ if DATABASE_READ_REPLICA_ENABLED:
         "HOST": DATABASE_READ_HOST,
         "PORT": DATABASE_READ_PORT,
         "CONN_MAX_AGE": CONN_MAX_AGE,
+        "OPTIONS": ast.literal_eval(DATABASE_READ_OPTIONS),
     }
 
 if TIMESERIES_ENABLED:
@@ -225,6 +240,7 @@ if TIMESERIES_ENABLED:
         "HOST": TIMESERIES_DATABASE_HOST,
         "PORT": TIMESERIES_DATABASE_PORT,
         "CONN_MAX_AGE": CONN_MAX_AGE,
+        "OPTIONS": ast.literal_eval(TIMESERIES_DATABASE_OPTIONS),
     }
 
     if TIMESERIES_DATABASE_READ_REPLICA_ENABLED:
@@ -236,6 +252,7 @@ if TIMESERIES_ENABLED:
             "HOST": TIMESERIES_DATABASE_READ_HOST,
             "PORT": TIMESERIES_DATABASE_READ_PORT,
             "CONN_MAX_AGE": CONN_MAX_AGE,
+            "OPTIONS": ast.literal_eval(TIMESERIES_DATABASE_READ_OPTIONS),
         }
 
 DATABASE_ROUTERS = ["codecov.db.DatabaseRouter"]


### PR DESCRIPTION
### Purpose/Motivation
This is especially needed for Postgres 15 where by default users are no longer allowed to write to schema `public`. Being able to set options enables switching to another default schema (e.g. `codecov`)

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
