### PR TITLE
fix: speedup flag filtering in GraphQL API

### DIFF
--- a/services/report.py
+++ b/services/report.py
@@ -249,14 +249,17 @@ def sessions_with_specific_flags(
 
 
 def files_in_sessions(commit_report: Report, session_ids: List[int]) -> List[str]:
-    return [
-        file.name
-        for file in commit_report
-        if any(
-            [
-                any([session.id in session_ids for session in line.sessions])
-                for line in file
-                if line
-            ]
-        )
-    ]
+    files, session_ids = [], set(session_ids)
+    for file in commit_report:
+        found = False
+        for line in file:
+            if line:
+                for session in line.sessions:
+                    if session.id in session_ids:
+                        found = True
+                        break
+            if found:
+                break
+        if found:
+            files.append(file.name)
+    return files


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Speed up filtering by flags in GraphQL endpoints by rewriting the search function to be able to compute faster on average.
Change it to exit each of the nested for loops quicker by not going through the entire iterator.


### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/691

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
