### PR TITLE
feat: add a filter for public/private repo filter for viewableRepository

### DIFF
--- a/graphql_api/actions/repository.py
+++ b/graphql_api/actions/repository.py
@@ -8,6 +8,7 @@ def apply_filters_to_queryset(queryset, filters):
     active = filters.get("active")
     activated = filters.get("activated")
     repo_names = filters.get("repo_names")
+    is_public = filters.get("is_public")
 
     if repo_names:
         queryset = queryset.filter(name__in=repo_names)
@@ -17,6 +18,9 @@ def apply_filters_to_queryset(queryset, filters):
         queryset = queryset.filter(activated=activated)
     if active is not None:
         queryset = queryset.filter(active=active)
+    if is_public is not None:
+        queryset = queryset.filter(private=not is_public)
+
     return queryset
 
 

--- a/graphql_api/types/inputs/repository_set_filters.graphql
+++ b/graphql_api/types/inputs/repository_set_filters.graphql
@@ -3,4 +3,5 @@ input RepositorySetFilters {
   repoNames: [String]
   active: Boolean
   activated: Boolean
+  isPublic: Boolean
 }


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

- On GraphQL `viewableRepository` resolver, add ability to filter repo list by public/private.
- If `isPublic` is not provided it will return both public and private repos
- If `isPublic=true` it will only return public repos
- If `isPublic=false` it will only return private repos

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/724

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
