### PR TITLE
fix: Skip login if GitHub OAuth does not return access_token

### DIFF
--- a/codecov_auth/tests/unit/views/test_github.py
+++ b/codecov_auth/tests/unit/views/test_github.py
@@ -411,3 +411,20 @@ async def test__get_teams_info_fails(client, mocker):
 
     result = await github._get_teams_data(repo_service)
     assert result == []
+
+
+def test_get_github_missing_access_token(client, mocker, db, mock_redis, settings):
+    settings.COOKIES_DOMAIN = ".simple.site"
+    settings.COOKIE_SECRET = "secret"
+
+    async def helper_func(*args, **kwargs):
+        return {
+            "id": 44376991,
+        }
+
+    mocker.patch.object(Github, "get_authenticated_user", side_effect=helper_func)
+    mock_redis.setex("oauth-state-abc", 300, "http://localhost:3000/gh")
+    url = reverse("github-login")
+    res = client.get(url, {"code": "aaaaaaa", "state": "abc"})
+    assert res.status_code == 302
+    assert res.headers["Location"] == "/"

--- a/codecov_auth/views/github.py
+++ b/codecov_auth/views/github.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Optional
 from urllib.parse import urlencode, urljoin
 
 from asgiref.sync import async_to_sync
@@ -67,11 +68,19 @@ class GithubLoginView(LoginMixin, StateMixin, View):
         return teams
 
     @async_to_sync
-    async def fetch_user_data(self, code):
+    async def fetch_user_data(self, code) -> Optional[dict]:
         # https://docs.github.com/en/rest/reference/teams#list-teams-for-the-authenticated-user
         # This is specific to GitHub
         repo_service = self.repo_service_instance
         authenticated_user = await repo_service.get_authenticated_user(code)
+        if "access_token" not in authenticated_user:
+            log.warning(
+                "Missing access_token during GitHub OAuth",
+                extra=dict(
+                    user_info=authenticated_user,
+                ),
+            )
+            return None
         # Comply to torngit's token encoding
         authenticated_user["key"] = authenticated_user["access_token"]
         user_orgs = await repo_service.list_teams()
@@ -98,6 +107,8 @@ class GithubLoginView(LoginMixin, StateMixin, View):
         redirection_url = self.get_redirection_url_from_state(state)
         try:
             user_dict = self.fetch_user_data(code)
+            if user_dict is None:
+                return redirect(self.error_redirection_page)
         except TorngitError:
             log.warning("Unable to log in due to problem on Github", exc_info=True)
             return redirect(self.error_redirection_page)


### PR DESCRIPTION
Resolves https://github.com/codecov/internal-issues/issues/126

If we don't receive an `access_token` during the GitHub OAuth flow then we can't really continue with the login since we'll be missing basically all the info about them.  I still don't entirely understand what exactly triggers this condition so I'm logging everything else we get back from GitHub in this case.