### PR TITLE
Update small badge

### DIFF
--- a/graphs/badges/badges.py
+++ b/graphs/badges/badges.py
@@ -57,8 +57,8 @@ small_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="112" height="20"
         <rect width="112" height="20" rx="3" fill="#fff" />
     </mask>
     <g mask="url(#a)">
-        <path fill="#555" d="M0 0h76v20H0z" />
-        <path fill="{0}" d="M76 0h36v20H76z" />
+        <path fill="#555" d="M0 0h73v20H0z" />
+        <path fill="{0}" d="M73 0h39v20H73z" />
         <path fill="url(#b)" d="M0 0h112v20H0z" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">

--- a/graphs/tests/test_badge_handler.py
+++ b/graphs/tests/test_badge_handler.py
@@ -456,8 +456,8 @@ class TestBadgeHandler(APITestCase):
                     <rect width="112" height="20" rx="3" fill="#fff" />
                 </mask>
                 <g mask="url(#a)">
-                    <path fill="#555" d="M0 0h76v20H0z" />
-                    <path fill="#c0b01b" d="M76 0h36v20H76z" />
+                    <path fill="#555" d="M0 0h73v20H0z" />
+                    <path fill="#c0b01b" d="M73 0h39v20H73z" />
                     <path fill="url(#b)" d="M0 0h112v20H0z" />
                 </g>
                 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
@@ -637,8 +637,8 @@ class TestBadgeHandler(APITestCase):
                     <rect width="112" height="20" rx="3" fill="#fff" />
                 </mask>
                 <g mask="url(#a)">
-                    <path fill="#555" d="M0 0h76v20H0z" />
-                    <path fill="#c0b01b" d="M76 0h36v20H76z" />
+                    <path fill="#555" d="M0 0h73v20H0z" />
+                    <path fill="#c0b01b" d="M73 0h39v20H73z" />
                     <path fill="url(#b)" d="M0 0h112v20H0z" />
                 </g>
                 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
@@ -709,8 +709,8 @@ class TestBadgeHandler(APITestCase):
                     <rect width="112" height="20" rx="3" fill="#fff" />
                 </mask>
                 <g mask="url(#a)">
-                    <path fill="#555" d="M0 0h76v20H0z" />
-                    <path fill="#8aca02" d="M76 0h36v20H76z" />
+                    <path fill="#555" d="M0 0h73v20H0z" />
+                    <path fill="#8aca02" d="M73 0h39v20H73z" />
                     <path fill="url(#b)" d="M0 0h112v20H0z" />
                 </g>
                 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
@@ -853,8 +853,8 @@ class TestBadgeHandler(APITestCase):
                     <rect width="112" height="20" rx="3" fill="#fff" />
                 </mask>
                 <g mask="url(#a)">
-                    <path fill="#555" d="M0 0h76v20H0z" />
-                    <path fill="#8aca02" d="M76 0h36v20H76z" />
+                    <path fill="#555" d="M0 0h73v20H0z" />
+                    <path fill="#8aca02" d="M73 0h39v20H73z" />
                     <path fill="url(#b)" d="M0 0h112v20H0z" />
                 </g>
                 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
@@ -1158,8 +1158,8 @@ class TestBadgeHandler(APITestCase):
                     <rect width="112" height="20" rx="3" fill="#fff" />
                 </mask>
                 <g mask="url(#a)">
-                    <path fill="#555" d="M0 0h76v20H0z" />
-                    <path fill="#4c1" d="M76 0h36v20H76z" />
+                    <path fill="#555" d="M0 0h73v20H0z" />
+                    <path fill="#4c1" d="M73 0h39v20H73z" />
                     <path fill="url(#b)" d="M0 0h112v20H0z" />
                 </g>
                 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
@@ -1209,8 +1209,8 @@ class TestBadgeHandler(APITestCase):
                     <rect width="112" height="20" rx="3" fill="#fff" />
                 </mask>
                 <g mask="url(#a)">
-                    <path fill="#555" d="M0 0h76v20H0z" />
-                    <path fill="#c0b01b" d="M76 0h36v20H76z" />
+                    <path fill="#555" d="M0 0h73v20H0z" />
+                    <path fill="#c0b01b" d="M73 0h39v20H73z" />
                     <path fill="url(#b)" d="M0 0h112v20H0z" />
                 </g>
                 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">

--- a/graphs/tests/test_helpers.py
+++ b/graphs/tests/test_helpers.py
@@ -69,8 +69,8 @@ class TestGraphsHelpers(object):
                 <rect width="112" height="20" rx="3" fill="#fff" />
             </mask>
             <g mask="url(#a)">
-                <path fill="#555" d="M0 0h76v20H0z" />
-                <path fill="#efa41b" d="M76 0h36v20H76z" />
+                <path fill="#555" d="M0 0h73v20H0z" />
+                <path fill="#efa41b" d="M73 0h39v20H73z" />
                 <path fill="url(#b)" d="M0 0h112v20H0z" />
             </g>
             <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">

--- a/graphs/views.py
+++ b/graphs/views.py
@@ -69,7 +69,7 @@ class BadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
 
     def get_coverage(self):
         """
-        Note: This endpoint has the behaviour of returning a gray badge with the word 'unknwon' instead of returning a 404
+        Note: This endpoint has the behavior of returning a gray badge with the word 'unknown' instead of returning a 404
               when the user enters an invalid service, owner, repo or when coverage is not found for a branch.
 
               We also need to support service abbreviations for users already using them


### PR DESCRIPTION
### Purpose/Motivation
Moves the small badge mask over to leave space for 100% while still looking good with 2 digits. Hopefully this addresses examples like https://community.codecov.com/t/badge-width-is-incorrect-when-cov-is-100-and-precision-is-not-zero/2600/2

### Links to relevant tickets
https://github.com/orgs/codecov/projects/31/views/11?pane=issue&itemId=34798619

### What does this PR do?

![Screenshot 2023-11-08 at 6 31 02 PM](https://github.com/codecov/codecov-api/assets/87824812/6b0c17f4-4d7a-4c68-ab3a-0ca9956dd982)

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
