### PR TITLE
feat(logging): change access logging format to JSON

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -336,9 +336,7 @@ LOGGING = {
         },
     },
     "filters": {
-        "health_check_filter": {
-            "()": "utils.logging_configuration.HealthCheckFilter"
-        }
+        "health_check_filter": {"()": "utils.logging_configuration.HealthCheckFilter"}
     },
     "root": {"handlers": ["default"], "level": "INFO", "propagate": True},
     "handlers": {
@@ -362,7 +360,7 @@ LOGGING = {
         "gunicorn.access": {
             "level": "INFO",
             "handlers": ["json-gunicorn-console"],
-            }
+        }
     },
 }
 

--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -335,6 +335,11 @@ LOGGING = {
             "format": '%(h)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"',
         },
     },
+    "filters": {
+        "health_check_filter": {
+            "()": "utils.logging_configuration.HealthCheckFilter"
+        }
+    },
     "root": {"handlers": ["default"], "level": "INFO", "propagate": True},
     "handlers": {
         "default": {
@@ -350,10 +355,14 @@ LOGGING = {
             "formatter": "gunicorn_json",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",  # Default is stderr
+            "filters": ["health_check_filter"],
         },
     },
     "loggers": {
-        "gunicorn.access": {"level": "INFO", "handlers": ["json-gunicorn-console"]}
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": ["json-gunicorn-console"],
+            }
     },
 }
 

--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -329,6 +329,11 @@ LOGGING = {
             "format": "%(message)s %(asctime)s %(name)s %(levelname)s %(lineno)s %(pathname)s %(funcName)s %(threadName)s",
             "class": "utils.logging_configuration.CustomDatadogJsonFormatter",
         },
+        "gunicorn_json": {
+            "class": "utils.logging_configuration.CustomGunicornLogFormatter",
+            "datefmt": '%Y-%m-%dT%H:%M:%S%z',
+            "format": '%(h)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"',
+        }
     },
     "root": {"handlers": ["default"], "level": "INFO", "propagate": True},
     "handlers": {
@@ -339,9 +344,22 @@ LOGGING = {
             else "json",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",  # Default is stderr
+        },
+        "json-gunicorn-console": {
+            "level": "INFO",
+            "formatter": "gunicorn_json",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",  # Default is stderr
         }
     },
-    "loggers": {},
+    "loggers": {
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": [
+                "json-gunicorn-console"
+            ]
+        }
+    },
 }
 
 MINIO_ACCESS_KEY = get_config("services", "minio", "access_key_id")

--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -331,9 +331,9 @@ LOGGING = {
         },
         "gunicorn_json": {
             "class": "utils.logging_configuration.CustomGunicornLogFormatter",
-            "datefmt": '%Y-%m-%dT%H:%M:%S%z',
+            "datefmt": "%Y-%m-%dT%H:%M:%S%z",
             "format": '%(h)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"',
-        }
+        },
     },
     "root": {"handlers": ["default"], "level": "INFO", "propagate": True},
     "handlers": {
@@ -350,15 +350,10 @@ LOGGING = {
             "formatter": "gunicorn_json",
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",  # Default is stderr
-        }
+        },
     },
     "loggers": {
-        "gunicorn.access": {
-            "level": "INFO",
-            "handlers": [
-                "json-gunicorn-console"
-            ]
-        }
+        "gunicorn.access": {"level": "INFO", "handlers": ["json-gunicorn-console"]}
     },
 }
 

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -1,4 +1,4 @@
-from pythonjsonlogger.jsonlogger import JsonFormatter
+from pythonjsonlogger.jsonlogger import JsonFormatter, merge_record_extra
 from sentry_sdk import Hub
 
 
@@ -36,3 +36,23 @@ class CustomDatadogJsonFormatter(BaseLogger):
         span = Hub.current.scope.span
         if span and span.trace_id:
             log_record["sentry_trace_id"] = span.trace_id
+
+class CustomGunicornLogFormatter(JsonFormatter):
+    rename_fields = {
+        "levelname": "level",
+        "r": "request",
+        "a": "useragent",
+        "f": "referer", # the biggest concern in my mind: should this be correctly spelled historically (one r) or correctly spelled linguistically (two r)
+        "b": "response_length",
+        "h": "remote_address",
+        "t": "request_time",
+        "s": "status_code",
+    }
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomGunicornLogFormatter, self).add_fields(log_record, record, message_dict)
+        for field in self._required_fields:
+            if field in self.rename_fields:
+                log_record[self.rename_fields[field]] = record.args.get(field)
+                del log_record[field]
+            else:
+                log_record[field] = record.args.get(field)

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -1,5 +1,6 @@
 from pythonjsonlogger.jsonlogger import JsonFormatter, merge_record_extra
 from sentry_sdk import Hub
+from logging import Filter
 
 
 class BaseLogger(JsonFormatter):
@@ -60,3 +61,8 @@ class CustomGunicornLogFormatter(JsonFormatter):
                 del log_record[field]
             else:
                 log_record[field] = record.args.get(field)
+
+class HealthCheckFilter(Filter):
+    def filter(self, record):
+        # Ignore /health/ requests, unless it's not a 200.
+        return ('GET /health/' not in record.getMessage()) if record.args.get('s') != '200' else True

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -37,19 +37,23 @@ class CustomDatadogJsonFormatter(BaseLogger):
         if span and span.trace_id:
             log_record["sentry_trace_id"] = span.trace_id
 
+
 class CustomGunicornLogFormatter(JsonFormatter):
     rename_fields = {
         "levelname": "level",
         "r": "request",
         "a": "useragent",
-        "f": "referer", # the biggest concern in my mind: should this be correctly spelled historically (one r) or correctly spelled linguistically (two r)
+        "f": "referer",  # the biggest concern in my mind: should this be correctly spelled historically (one r) or correctly spelled linguistically (two r)
         "b": "response_length",
         "h": "remote_address",
         "t": "request_time",
         "s": "status_code",
     }
+
     def add_fields(self, log_record, record, message_dict):
-        super(CustomGunicornLogFormatter, self).add_fields(log_record, record, message_dict)
+        super(CustomGunicornLogFormatter, self).add_fields(
+            log_record, record, message_dict
+        )
         for field in self._required_fields:
             if field in self.rename_fields:
                 log_record[self.rename_fields[field]] = record.args.get(field)

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -1,6 +1,7 @@
+from logging import Filter
+
 from pythonjsonlogger.jsonlogger import JsonFormatter, merge_record_extra
 from sentry_sdk import Hub
-from logging import Filter
 
 
 class BaseLogger(JsonFormatter):
@@ -62,7 +63,12 @@ class CustomGunicornLogFormatter(JsonFormatter):
             else:
                 log_record[field] = record.args.get(field)
 
+
 class HealthCheckFilter(Filter):
     def filter(self, record):
         # Ignore /health/ requests, unless it's not a 200.
-        return ('GET /health/' not in record.getMessage()) if record.args.get('s') != '200' else True
+        return (
+            ("GET /health/" not in record.getMessage())
+            if record.args.get("s") != "200"
+            else True
+        )

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -69,6 +69,6 @@ class HealthCheckFilter(Filter):
         # Ignore /health/ requests, unless it's not a 200.
         return (
             ("GET /health/" not in record.getMessage())
-            if record.args.get("s") != "200"
+            if record.args.get("s") == "200"
             else True
         )


### PR DESCRIPTION
This is for https://github.com/codecov/infrastructure-team/issues/162 -- it enables GUnicorn access logs to be output as JSON instead of as HTTP access log format. 