### PR TITLE
perf: use new get_file_totals() report method for BranchContents

### DIFF
--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -102,6 +102,9 @@ class MockReport(object):
     def flags(self):
         return ["flag-a"]
 
+    def get_file_totals(self, path):
+        return MockTotals().totals
+
 
 class TestBranch(GraphQLTestHelper, TransactionTestCase):
     def setUp(self):

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/73a0aa871fd3169673d1deb0509408b7d1b908ee.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/3d97484fcb707027743501a7ec5e1be24445d0f9.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/1389399bfa489143b537c7a41f4d97b16db1fbd8.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/e3f09405be85f6e1e0290cb51aed19576a6cc53e.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/3d97484fcb707027743501a7ec5e1be24445d0f9.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/1389399bfa489143b537c7a41f4d97b16db1fbd8.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -360,7 +360,7 @@ sentry-sdk==1.19.1
     # via -r requirements.in
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/1389399bfa489143b537c7a41f4d97b16db1fbd8.tar.gz
+shared @ https://github.com/codecov/shared/archive/e3f09405be85f6e1e0290cb51aed19576a6cc53e.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -360,7 +360,7 @@ sentry-sdk==1.19.1
     # via -r requirements.in
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/73a0aa871fd3169673d1deb0509408b7d1b908ee.tar.gz
+shared @ https://github.com/codecov/shared/archive/3d97484fcb707027743501a7ec5e1be24445d0f9.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -360,7 +360,7 @@ sentry-sdk==1.19.1
     # via -r requirements.in
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/3d97484fcb707027743501a7ec5e1be24445d0f9.tar.gz
+shared @ https://github.com/codecov/shared/archive/1389399bfa489143b537c7a41f4d97b16db1fbd8.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/services/path.py
+++ b/services/path.py
@@ -209,7 +209,7 @@ class ReportPaths:
         """
         Returns the report totals for a given prefixed path.
         """
-        return self.report.get(path.full_path).totals
+        return self.report.get_file_totals(path.full_path)
 
     def _single_directory_recursive(
         self, paths: Iterable[PrefixedPath]


### PR DESCRIPTION
https://github.com/codecov/shared/pull/83
https://github.com/codecov/internal-issues/issues/155

sentry traces show `ReportPaths.single_directory()` taking a while in the `BranchContents` graphql query handler. it basically returns a flat list of directory/file objects with the names/totals of each. it calls `report.get(path).totals` to get the totals which does more processing than is strictly necessary.

https://github.com/codecov/shared/pull/83 adds a new `get_file_totals()` method to `Report`/`ReadOnlyReport` that returns the values from the `ReportFileSummary`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
