### PR TITLE
feat: adjust benefits for team plan

### DIFF
--- a/plan/constants.py
+++ b/plan/constants.py
@@ -283,7 +283,7 @@ TEAM_PLAN_REPRESENTATIONS = {
         benefits=[
             "Up to 10 users",
             "Unlimited repositories",
-            "2500 uploads",
+            "2500 private repo uploads",
             "Patch coverage analysis",
         ],
         tier_name=TierName.TEAM.value,
@@ -298,7 +298,7 @@ TEAM_PLAN_REPRESENTATIONS = {
         benefits=[
             "Up to 10 users",
             "Unlimited repositories",
-            "2500 uploads",
+            "2500 private repo uploads",
             "Patch coverage analysis",
         ],
         tier_name=TierName.TEAM.value,


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Adjust benefits to better reflect what the plan does 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
