### PR TITLE
fix: Fallback to OAuth bot token when installation token fails

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -13,6 +13,7 @@ from django.db.models import Q
 from django.utils import timezone
 from jwt import PyJWKClient, PyJWTError
 from rest_framework.exceptions import NotFound, Throttled, ValidationError
+from shared.github import InvalidInstallationError
 from shared.reports.enums import UploadType
 from shared.torngit.exceptions import TorngitClientError, TorngitObjectNotFoundError
 
@@ -316,10 +317,21 @@ def determine_upload_pr_to_use(upload_params):
 
 def try_to_get_best_possible_bot_token(repository):
     if repository.using_integration and repository.author.integration_id:
-        github_token = get_github_integration_token(
-            repository.author.service, integration_id=repository.author.integration_id
-        )
-        return dict(key=github_token)
+        try:
+            github_token = get_github_integration_token(
+                repository.author.service,
+                integration_id=repository.author.integration_id,
+            )
+            return dict(key=github_token)
+        except InvalidInstallationError:
+            log.warning(
+                "Invalid installation error",
+                extra=dict(
+                    service=repository.author.service,
+                    integration_id=repository.author.integration_id,
+                ),
+            )
+            # now we'll fallback to trying an OAuth token
     service = repository.author.service
     if repository.bot is not None and repository.bot.oauth_token is not None:
         log.info(

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -6,6 +6,7 @@ import pytest
 from django.conf import settings
 from rest_framework.exceptions import Throttled, ValidationError
 from shared.config import get_config
+from shared.github import InvalidInstallationError
 
 from core.tests.factories import CommitFactory, OwnerFactory, RepositoryFactory
 from plan.constants import PlanName
@@ -70,6 +71,26 @@ def test_try_to_get_best_possible_bot_token_using_integration(
     repository.save()
     assert try_to_get_best_possible_bot_token(repository) == {
         "key": "test-token",
+    }
+    get_github_integration_token.assert_called_once_with("github", integration_id=12345)
+
+
+@patch("upload.helpers.get_github_integration_token")
+@pytest.mark.django_db
+def test_try_to_get_best_possible_bot_token_using_integration(
+    get_github_integration_token,
+):
+    get_github_integration_token.side_effect = InvalidInstallationError()
+    bot = OwnerFactory.create(unencrypted_oauth_token="bornana")
+    bot.save()
+    owner = OwnerFactory.create(integration_id=12345, bot=bot)
+    owner.save()
+    repository = RepositoryFactory.create(author=owner, using_integration=True)
+    repository.save()
+    # falls back to bot token
+    assert try_to_get_best_possible_bot_token(repository) == {
+        "key": "bornana",
+        "secret": None,
     }
     get_github_integration_token.assert_called_once_with("github", integration_id=12345)
 

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -77,7 +77,7 @@ def test_try_to_get_best_possible_bot_token_using_integration(
 
 @patch("upload.helpers.get_github_integration_token")
 @pytest.mark.django_db
-def test_try_to_get_best_possible_bot_token_using_integration(
+def test_try_to_get_best_possible_bot_token_using_invalid_integration(
     get_github_integration_token,
 ):
     get_github_integration_token.side_effect = InvalidInstallationError()


### PR DESCRIPTION
Should resolve https://codecov.sentry.io/issues/4643278430

If we fail to fetch an access token using the GitHub app installation then just fallback to trying to find an acceptable OAuth token for the bot token.