### PR TITLE
feat: Support filters in componentComparisons

### DIFF
--- a/graphql_api/types/comparison/comparison.graphql
+++ b/graphql_api/types/comparison/comparison.graphql
@@ -11,7 +11,7 @@ type Comparison {
   headTotals: CoverageTotals
   changeCoverage: Float
   flagComparisons: [FlagComparison]
-  componentComparisons: [ComponentComparison!]
+  componentComparisons(filters: ComponentsFilters): [ComponentComparison!]
   hasDifferentNumberOfHeadAndBaseReports: Boolean!
   flagComparisonsCount: Int!
   componentComparisonsCount: Int!

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -184,18 +184,30 @@ def resolve_flag_comparisons(
 @comparison_bindable.field("componentComparisons")
 @sync_to_async
 def resolve_component_comparisons(
-    comparison_report: ComparisonReport, info
+    comparison_report: ComparisonReport, info, filters=None
 ) -> List[ComponentComparison]:
     current_owner = info.context["request"].current_owner
     head_commit = comparison_report.commit_comparison.compare_commit
     components = components_service.commit_components(head_commit, current_owner)
+    list_components = comparison_report.commit_comparison.component_comparisons.all()
+
+    if filters and filters.get("components"):
+        components = [
+            component
+            for component in components
+            if component.name in filters["components"]
+        ]
+
+        list_components = list_components.filter(
+            component_id__in=[component.component_id for component in components]
+        )
 
     # store for child resolvers (needed to get the component name, for example)
     info.context["components"] = {
         component.component_id: component for component in components
     }
 
-    return list(comparison_report.commit_comparison.component_comparisons.all())
+    return list(list_components)
 
 
 @comparison_bindable.field("componentComparisonsCount")

--- a/graphql_api/types/inputs/components_filters.graphql
+++ b/graphql_api/types/inputs/components_filters.graphql
@@ -1,0 +1,3 @@
+input ComponentsFilters {
+  components: [String!]
+}


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
we need this to filter components tab **and** to filter components on search term 

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/838

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.
- Update comparison to handle the filter
- Tests 

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
