### PR TITLE
feat: Support components filter in pathContents (#825)

### DIFF
--- a/api/public/v2/report/views.py
+++ b/api/public/v2/report/views.py
@@ -23,7 +23,7 @@ from codecov_auth.authentication import (
     UserTokenAuthentication,
 )
 from core.models import Commit
-from services.components import commit_components, component_filtered_report
+from services.components import commit_components
 from services.path import ReportPaths, dashboard_commit_file_url
 
 

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -24,7 +24,7 @@ from graphql_api.types.enums import OrderingDirection, PathContentDisplayType
 from graphql_api.types.errors import MissingCoverage, MissingHeadReport, UnknownPath
 from graphql_api.types.errors.errors import UnknownFlags
 from services.comparison import Comparison, ComparisonReport
-from services.components import Component
+from services.components import Component, component_filtered_report
 from services.path import ReportPaths
 from services.profiling import CriticalFile, ProfilingSummary
 from services.report import ReadOnlyReport
@@ -174,9 +174,23 @@ def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
     search_value = filters.get("search_value")
     display_type = filters.get("display_type")
     flags = filters.get("flags", [])
+    component_filter = filters.get("components", [])
 
     if flags and not set(flags) & set(commit_report.flags):
         return UnknownFlags()
+
+    if component_filter:
+        all_components = components.commit_components(commit, current_owner)
+        filtered_components = components.filter_components_by_name(
+            all_components, component_filter
+        )
+
+        if not filtered_components:
+            return MissingCoverage(
+                f"missing coverage for report with components: {component_filter}"
+            )
+
+        commit_report = component_filtered_report(commit_report, filtered_components)
 
     report_paths = ReportPaths(
         report=commit_report, path=path, search_term=search_value, filter_flags=flags
@@ -224,7 +238,8 @@ def resolve_components(commit: Commit, info, filters=None) -> List[Component]:
     all_components = components.commit_components(commit, request.user)
 
     if filters and filters.get("components"):
-        terms = [v.lower() for v in filters["components"]]
-        return filter(lambda c: c.name.lower() in terms, all_components)
+        return components.filter_components_by_name(
+            all_components, filters["components"]
+        )
 
     return all_components

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -24,7 +24,7 @@ from graphql_api.types.enums import OrderingDirection, PathContentDisplayType
 from graphql_api.types.errors import MissingCoverage, MissingHeadReport, UnknownPath
 from graphql_api.types.errors.errors import UnknownFlags
 from services.comparison import Comparison, ComparisonReport
-from services.components import Component, component_filtered_report
+from services.components import Component
 from services.path import ReportPaths
 from services.profiling import CriticalFile, ProfilingSummary
 from services.report import ReadOnlyReport
@@ -190,7 +190,9 @@ def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
                 f"missing coverage for report with components: {component_filter}"
             )
 
-        commit_report = component_filtered_report(commit_report, filtered_components)
+        commit_report = components.component_filtered_report(
+            commit_report, filtered_components
+        )
 
     report_paths = ReportPaths(
         report=commit_report, path=path, search_term=search_value, filter_flags=flags

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -192,10 +192,9 @@ def resolve_component_comparisons(
     list_components = comparison_report.commit_comparison.component_comparisons.all()
 
     if filters and filters.get("components"):
-        terms = [v.lower() for v in filters["components"]]
-        components = [
-            component for component in components if component.name.lower() in terms
-        ]
+        components = components_service.filter_components_by_name(
+            components, filters["components"]
+        )
 
         list_components = list_components.filter(
             component_id__in=[component.component_id for component in components]

--- a/graphql_api/types/component/component.py
+++ b/graphql_api/types/component/component.py
@@ -25,5 +25,5 @@ def resolve_name(component: Component, info) -> str:
 def resolve_totals(component: Component, info) -> Optional[ReportTotals]:
     commit: Commit = info.context["component_commit"]
     report = commit.full_report
-    filtered_report = component_filtered_report(report, component)
+    filtered_report = component_filtered_report(report, [component])
     return filtered_report.totals

--- a/graphql_api/types/inputs/path_contents_filters.graphql
+++ b/graphql_api/types/inputs/path_contents_filters.graphql
@@ -3,6 +3,7 @@ input PathContentsFilters {
   displayType: PathContentDisplayType
   ordering: PathContentsOrdering
   flags: [String!]
+  components: [String!]
 }
 
 input PathContentsOrdering {

--- a/services/components.py
+++ b/services/components.py
@@ -22,13 +22,29 @@ def commit_components(commit: Commit, owner: Owner) -> List[Component]:
     return yaml.get_components()
 
 
-def component_filtered_report(report: Report, component: Component) -> FilteredReport:
+def component_filtered_report(
+    report: Report, components: List[Component]
+) -> FilteredReport:
     """
     Filter a report such that the totals, etc. are only pertaining to the given component.
     """
-    flags = component.get_matching_flags(report.flags.keys())
-    filtered_report = report.filter(flags=flags, paths=component.paths)
+    flags, paths = [], []
+    for component in components:
+        flags.extend(component.get_matching_flags(report.flags.keys()))
+        paths.extend(component.paths)
+    filtered_report = report.filter(flags=flags, paths=paths)
     return filtered_report
+
+
+def filter_components_by_name(
+    components: List[Component], terms: List[str]
+) -> List[Component]:
+    """
+    Given a list of Components and a list of strings (terms),
+    return a new list of Components only including Components with names in terms (case insensitive)
+    """
+    terms = [v.lower() for v in terms]
+    return list(filter(lambda c: c.name.lower() in terms, components))
 
 
 class ComponentComparison:
@@ -38,11 +54,11 @@ class ComponentComparison:
 
     @cached_property
     def base_report(self) -> FilteredReport:
-        return component_filtered_report(self.comparison.base_report, self.component)
+        return component_filtered_report(self.comparison.base_report, [self.component])
 
     @cached_property
     def head_report(self) -> FilteredReport:
-        return component_filtered_report(self.comparison.head_report, self.component)
+        return component_filtered_report(self.comparison.head_report, [self.component])
 
     @cached_property
     def base_totals(self) -> ReportTotals:

--- a/services/tests/test_components.py
+++ b/services/tests/test_components.py
@@ -118,7 +118,7 @@ class ComponentServiceTest(TransactionTestCase):
                 "paths": [".*/*.go"],
             }
         )
-        report_go = component_filtered_report(report, component_go)
+        report_go = component_filtered_report(report, [component_go])
         assert report_go.files == ["file_1.go"]
         assert report_go.totals.coverage == report.get("file_1.go").totals.coverage
 
@@ -128,7 +128,7 @@ class ComponentServiceTest(TransactionTestCase):
                 "paths": [".*/*.py"],
             }
         )
-        report_py = component_filtered_report(report, component_py)
+        report_py = component_filtered_report(report, [component_py])
         assert report_py.files == ["file_2.py"]
         assert report_py.totals.coverage == report.get("file_2.py").totals.coverage
 


### PR DESCRIPTION
### Purpose/Motivation
Adds component filtering in pathContents query

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/825

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
