### PR TITLE
feat: add user link to owner view on admin page (#837)

### DIFF
--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -175,6 +175,7 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
         "student",
         "student_created_at",
         "student_updated_at",
+        "user",
     )
 
     fields = readonly_fields + (


### PR DESCRIPTION
### Purpose/Motivation

Creates a linkable field in owner view on admin page that goes to the user view, if the owner has a user associated.

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/837

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
