### PR TITLE
Allow Sentry email aliases to be made staff users

### DIFF
--- a/codecov_auth/models.py
+++ b/codecov_auth/models.py
@@ -335,9 +335,9 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
     def clean(self):
         if self.staff:
             domain = self.email.split("@")[1] if self.email else ""
-            if domain != "codecov.io":
+            if domain not in ["codecov.io", "sentry.io"]:
                 raise ValidationError(
-                    "User not part of Codecov cannot be a staff member"
+                    "User not part of Codecov or Sentry cannot be a staff member"
                 )
         if not self.plan:
             self.plan = None


### PR DESCRIPTION
https://sentry.slack.com/archives/C04MGV3DF8D/p1701451737952949?thread_ts=1701451230.594479&cid=C04MGV3DF8D

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
