### PR TITLE
feat: Start populating report_type column

### DIFF
--- a/upload/serializers.py
+++ b/upload/serializers.py
@@ -146,11 +146,18 @@ class CommitReportSerializer(serializers.ModelSerializer):
         fields = read_only_fields + ("code",)
 
     def create(self, validated_data):
-        report = CommitReport.objects.filter(
-            code=validated_data.get("code"),
-            commit_id=validated_data.get("commit_id"),
-        ).first()
+        report = (
+            CommitReport.objects.coverage_reports()
+            .filter(
+                code=validated_data.get("code"),
+                commit_id=validated_data.get("commit_id"),
+            )
+            .first()
+        )
         if report:
+            if report.report_type is None:
+                report.report_type = CommitReport.ReportType.COVERAGE
+                report.save()
             return report
         return super().create(validated_data)
 

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -38,7 +38,9 @@ def test_reports_post(client, db, mocker):
         url == f"/upload/github/codecov::::the_repo/commits/{commit.commitid}/reports"
     )
     assert response.status_code == 201
-    assert CommitReport.objects.filter(commit_id=commit.id, code="code1").exists()
+    assert CommitReport.objects.filter(
+        commit_id=commit.id, code="code1", report_type=CommitReport.ReportType.COVERAGE
+    ).exists()
     mocked_call.assert_called_with(repository.repoid, commit.commitid, "code1")
 
 
@@ -63,7 +65,9 @@ def test_create_report_already_exists(client, db, mocker):
         url == f"/upload/github/codecov::::the_repo/commits/{commit.commitid}/reports"
     )
     assert response.status_code == 201
-    assert CommitReport.objects.filter(commit_id=commit.id, code="code").exists()
+    assert CommitReport.objects.filter(
+        commit_id=commit.id, code="code", report_type=CommitReport.ReportType.COVERAGE
+    ).exists()
     mocked_call.assert_called_once()
 
 
@@ -86,7 +90,9 @@ def test_reports_post_code_as_default(client, db, mocker):
         url == f"/upload/github/codecov::::the_repo/commits/{commit.commitid}/reports"
     )
     assert response.status_code == 201
-    assert CommitReport.objects.filter(commit_id=commit.id, code=None).exists()
+    assert CommitReport.objects.filter(
+        commit_id=commit.id, code=None, report_type=CommitReport.ReportType.COVERAGE
+    ).exists()
     mocked_call.assert_called_once()
 
 

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -9,7 +9,7 @@ from codecov_auth.authentication.repo_auth import (
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
 )
-from reports.models import ReportResults
+from reports.models import CommitReport, ReportResults
 from services.task import TaskService
 from upload.serializers import CommitReportSerializer, ReportResultsSerializer
 from upload.views.base import GetterMixin
@@ -39,6 +39,7 @@ class ReportViews(ListCreateAPIView, GetterMixin):
             serializer.validated_data["code"] = None
         instance = serializer.save(
             commit_id=commit.id,
+            report_type=CommitReport.ReportType.COVERAGE,
         )
         TaskService().preprocess_upload(
             repository.repoid, commit.commitid, instance.code


### PR DESCRIPTION
### Purpose/Motivation

Follow up from https://github.com/codecov/codecov-api/pull/287

### Links to relevant tickets

N/A

### What does this PR do?

Starts populating the `report_type` column when we create new commit reports or query for existing commit reports (as part of upload).