### PR TITLE
Upgrade pytest-django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -318,7 +318,7 @@ pytest-asyncio==0.18.2
     # via -r requirements.in
 pytest-cov==2.12.1
     # via -r requirements.in
-pytest-django==4.4.0
+pytest-django==4.7.0
     # via -r requirements.in
 pytest-mock==1.12.1
     # via -r requirements.in


### PR DESCRIPTION
The old version was causing some conflicts with database access.  If the database connection was first setup through the pytest fixture then subsequent tests (that used the Django `TestCase` class) would fail.