### PR TITLE
fix: Report filtering by path pattern string (#internal_148)

### DIFF
--- a/api/public/v2/report/views.py
+++ b/api/public/v2/report/views.py
@@ -120,7 +120,7 @@ class BaseReportViewSet(
         if path and flag:
             report = report.filter(flags=[flag], paths=[f"{path}*"])
         elif path:
-            report = report.filter(paths=[f"{path}*"])
+            report = report.filter(paths=[f"{path}.*"])
         elif flag:
             report = report.filter(flags=[flag])
         elif component_id:

--- a/api/public/v2/report/views.py
+++ b/api/public/v2/report/views.py
@@ -118,7 +118,7 @@ class BaseReportViewSet(
                 return Report()
 
         if path and flag:
-            report = report.filter(flags=[flag], paths=[f"{path}*"])
+            report = report.filter(flags=[flag], paths=[f"{path}.*"])
         elif path:
             report = report.filter(paths=[f"{path}.*"])
         elif flag:


### PR DESCRIPTION
### Purpose/Motivation

Fix the regex pattern matching for path filtering for Reports. `*` pattern will consume the previous pattern 0 or more times, in this case `{path}.*` means prefix matching. Before, `{path}*` will unintentionally consume the previous character of the path string.

### Links to relevant tickets

https://github.com/codecov/internal-issues/issues/148

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
