### PR TITLE
"fix": allow branch to be overridden in v4 upload endpoint

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -447,8 +447,12 @@ def insert_commit(commitid, branch, pr, repository, owner, parent_commit_id=None
     if parent_commit_id and commit.parent_commit_id is None:
         commit.parent_commit_id = parent_commit_id
         edited = True
+    if branch and commit.branch != branch:
+        # A branch head may have been moved; this allows commits to be "moved"
+        commit.branch = branch
+        edited = True
     if edited:
-        commit.save(update_fields=["parent_commit_id", "state"])
+        commit.save(update_fields=["parent_commit_id", "state", "branch"])
     return commit
 
 

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -633,6 +633,7 @@ class UploadHandlerHelpersTest(TestCase):
                 repository=repo,
                 parent_commit_id=None,
             )
+            # parent_commit_id, state, and branch should be updated
             insert_commit(
                 "1c78206f1a46dc6db8412a491fc770eb7d0f8a47",
                 "oranges",
@@ -647,7 +648,7 @@ class UploadHandlerHelpersTest(TestCase):
             )
             assert commit.repository == repo
             assert commit.state == "pending"
-            assert commit.branch == "apples"
+            assert commit.branch == "oranges"
             assert commit.pullid == 456
             assert commit.merged == None
             assert commit.parent_commit_id == "different_parent_commit"


### PR DESCRIPTION
closes https://github.com/codecov/engineering-team/issues/889

this should allow a commit's branch to be changed if future uploads come in with a new branch set. this could happen if branch heads were reset (e.g. recovering from pushed a commit to the wrong branch) or if the user just wants to take matters into their own hands

NOTE: project coverage delta is calculated by comparing a head report against a base report. if the PR's actual base isn't in our database we use the next-oldest commit from the same branch. if a commit is moved to another branch, then a PR for which that commit is the "next-oldest" will have to use an even older commit. just an edge case to be aware of

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
