### PR TITLE
fix test that fails depending on run order

### DIFF
--- a/compare/commands/compare/interactors/tests/test_fetch_impacted_files.py
+++ b/compare/commands/compare/interactors/tests/test_fetch_impacted_files.py
@@ -590,6 +590,7 @@ class FetchImpactedFilesTest(TransactionTestCase):
             CommitFactory(repository=repo),
         )
         pull = PullFactory(
+            pullid=256,
             repository=repo,
             base=base.commitid,
             head=head.commitid,


### PR DESCRIPTION
If you run
```
pytest \
 graphql_api/tests/test_impacted_file.py::TestImpactedFileFiltering::test_filtering_with_successful_flags \
 compare/commands/compare/interactors/tests/test_fetch_impacted_files.py::FetchImpactedFilesTest::test_impacted_files_filtered_by_flags_and_commit_comparison_for_pull
```

you'll see the 2nd test fails.

This is because of the PullID that apparently both tests create a pullID of 1.
It is strange because they are `TransactionTestCase` and that's supposed to reset the DB,
but God knowns what is going on.

Hard setting the pullID to different numbers solves the issue, but I'll be the 1st
to admit is not a pretty fix

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
