### PR TITLE
fix: update logout_view to redirect to dashboard_url

### DIFF
--- a/codecov_auth/tests/unit/views/test_logout.py
+++ b/codecov_auth/tests/unit/views/test_logout.py
@@ -32,7 +32,7 @@ class LogoutViewTest(TransactionTestCase):
         self.assertEqual(self._is_authenticated(), True)
 
         res = self._get("/logout/gh")
-        assert res.url == "/"
+        assert res.url == "http://localhost:3000"
         self.assertEqual(res.status_code, 302)
 
         res = self._get("/graphql/gh/")
@@ -47,7 +47,7 @@ class LogoutViewTest(TransactionTestCase):
         self.assertEqual(self._is_authenticated(), True)
 
         res = self._get("/logout/gh?to=/test")
-        assert res.url == "/test"
+        assert res.url == "http://localhost:3000"
         self.assertEqual(res.status_code, 302)
 
         res = self._get("/graphql/gh/")

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -4,7 +4,7 @@ from django.shortcuts import redirect
 
 
 def logout_view(request, **kwargs):
-    redirect_url = request.GET.get("to", "/")
+    redirect_url = settings.CODECOV_DASHBOARD_URL
     response = redirect(redirect_url)
     logout(request)
     kwargs_cookie = dict(


### PR DESCRIPTION
### What does this PR do?
- change logout_view redirect url to hardcoded dashboard url in settings

