### PR TITLE
Reduce db queries coming from health endpoint

### DIFF
--- a/codecov/views.py
+++ b/codecov/views.py
@@ -1,11 +1,24 @@
 from django.conf import settings
+from django.db import connection
 from django.http import HttpResponse, HttpResponseRedirect
 
 from core.models import Constants
 
+_version = None
+
+
+def _get_version():
+    global _version
+    if _version is None:
+        _version = Constants.objects.get(key="version")
+    return _version
+
 
 def health(request):
-    version = Constants.objects.get(key="version")
+    # will raise if connection cannot be estabilished
+    connection.ensure_connection()
+
+    version = _get_version()
     return HttpResponse("%s is live!" % version.value)
 
 


### PR DESCRIPTION
### Purpose/Motivation

> Our number 1 query by volume is our own health check endpoint

### What does this PR do?

* Cache the result of the version query for the lifetime of the process.
* Perform a check on the db connection state so that the health endpoint returns 500 when the db is down.