### PR TITLE
fix: allow self hosted admins to have parity with cloud admins

### DIFF
--- a/api/shared/permissions.py
+++ b/api/shared/permissions.py
@@ -1,10 +1,12 @@
 import logging
 
 from asgiref.sync import async_to_sync
+from django.conf import settings
 from django.http import Http404
 from rest_framework.permissions import SAFE_METHODS  # ['GET', 'HEAD', 'OPTIONS']
 from rest_framework.permissions import BasePermission
 
+import services.self_hosted as self_hosted
 from api.shared.mixins import InternalPermissionsMixin, SuperPermissionsMixin
 from api.shared.repo.repository_accessors import RepoAccessors
 from services.activation import try_auto_activate
@@ -125,6 +127,8 @@ class UserIsAdminPermissions(BasePermission):
     """
 
     def has_permission(self, request, view):
+        if settings.IS_ENTERPRISE:
+            return self_hosted.is_admin_owner(request.user)
         return request.user.is_authenticated and (
             view.owner.is_admin(request.user)
             or self._is_admin_on_provider(request.user, view.owner)

--- a/core/commands/flag/interactors/delete_flag.py
+++ b/core/commands/flag/interactors/delete_flag.py
@@ -24,8 +24,9 @@ class DeleteFlagInteractor(BaseInteractor):
         if not repo:
             raise ValidationError("Repo not found")
 
-        if settings.IS_ENTERPRISE and not self_hosted.is_admin_owner(self.current_user):
-            raise Unauthorized()
+        if settings.IS_ENTERPRISE:
+            if not self_hosted.is_admin_owner(self.current_user):
+                raise Unauthorized()
 
     def execute(self, owner_username: str, repo_name: str, flag_name: str):
         owner = Owner.objects.filter(

--- a/core/commands/flag/interactors/delete_flag.py
+++ b/core/commands/flag/interactors/delete_flag.py
@@ -27,6 +27,9 @@ class DeleteFlagInteractor(BaseInteractor):
         if settings.IS_ENTERPRISE:
             if not self_hosted.is_admin_owner(self.current_user):
                 raise Unauthorized()
+        else:
+            if not owner.is_admin(self.current_user):
+                raise Unauthorized()
 
     def execute(self, owner_username: str, repo_name: str, flag_name: str):
         owner = Owner.objects.filter(

--- a/core/commands/flag/interactors/delete_flag.py
+++ b/core/commands/flag/interactors/delete_flag.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+import services.self_hosted as self_hosted
 from codecov.commands.base import BaseInteractor
 from codecov.commands.exceptions import (
     NotFound,
@@ -21,7 +24,7 @@ class DeleteFlagInteractor(BaseInteractor):
         if not repo:
             raise ValidationError("Repo not found")
 
-        if not owner.is_admin(self.current_user):
+        if settings.IS_ENTERPRISE and not self_hosted.is_admin_owner(self.current_user):
             raise Unauthorized()
 
     def execute(self, owner_username: str, repo_name: str, flag_name: str):


### PR DESCRIPTION
### Purpose/Motivation
See https://github.com/codecov/feedback/issues/181

- Allow erase repository coverage
- Allow flag deletion

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
