### PR TITLE
fix: stop returning 400 code when user installs github app

### DIFF
--- a/codecov_auth/tests/unit/views/test_base.py
+++ b/codecov_auth/tests/unit/views/test_base.py
@@ -85,14 +85,19 @@ def test_generate_state_when_wrong_url(mock_redis):
 
 def test_get_redirection_url_from_state_no_state(mock_redis):
     mixin = set_up_mixin()
-    with pytest.raises(SuspiciousOperation):
-        mixin.get_redirection_url_from_state("not exist")
+    assert mixin.get_redirection_url_from_state("not exist") == (
+        "http://localhost:3000/gh",
+        False,
+    )
 
 
 def test_get_redirection_url_from_state_give_url(mock_redis):
     mixin = set_up_mixin()
     mock_redis.set(f"oauth-state-abc", "http://localhost/gh/codecov")
-    assert mixin.get_redirection_url_from_state("abc") == "http://localhost/gh/codecov"
+    assert mixin.get_redirection_url_from_state("abc") == (
+        "http://localhost/gh/codecov",
+        True,
+    )
 
 
 def test_remove_state_with_with_delay(mock_redis):

--- a/codecov_auth/tests/unit/views/test_github.py
+++ b/codecov_auth/tests/unit/views/test_github.py
@@ -244,7 +244,7 @@ def test_get_github_already_with_code_github_error(
 def test_state_not_known(client, mocker, db, mock_redis, settings):
     url = reverse("github-login")
     res = client.get(url, {"code": "aaaaaaa", "state": "doesnt exist"})
-    assert res.status_code == 400
+    assert res.status_code == 302
     assert "current_owner_id" not in client.session
 
 

--- a/codecov_auth/tests/unit/views/test_github_enterprise.py
+++ b/codecov_auth/tests/unit/views/test_github_enterprise.py
@@ -238,7 +238,7 @@ def test_state_not_known(client, mocker, db, mock_redis, settings):
     settings.GITHUB_ENTERPRISE_CLIENT_ID = "3d44be0e772666136a13"
     url = reverse("ghe-login")
     res = client.get(url, {"code": "aaaaaaa", "state": "doesnt exist"})
-    assert res.status_code == 400
+    assert res.status_code == 302
     assert "github_enterprise-token" not in res.cookies
     assert "github_enterprise-username" not in res.cookies
 

--- a/codecov_auth/views/github.py
+++ b/codecov_auth/views/github.py
@@ -108,7 +108,9 @@ class GithubLoginView(LoginMixin, StateMixin, View):
     def actual_login_step(self, request):
         code = request.GET.get("code")
         state = request.GET.get("state")
-        redirection_url = self.get_redirection_url_from_state(state)
+        redirection_url, is_valid = self.get_redirection_url_from_state(state)
+        if not is_valid:
+            return redirect(redirection_url)
         try:
             user_dict = self.fetch_user_data(code)
             if user_dict is None:

--- a/codecov_auth/views/gitlab.py
+++ b/codecov_auth/views/gitlab.py
@@ -70,7 +70,9 @@ class GitlabLoginView(LoginMixin, StateMixin, View):
             log.warning("Unable to log in due to problem on Gitlab", exc_info=True)
             return redirect(self.error_redirection_page)
         user = self.get_and_modify_owner(user_dict, request)
-        redirection_url = self.get_redirection_url_from_state(state)
+        redirection_url, is_valid = self.get_redirection_url_from_state(state)
+        if not is_valid:
+            return redirect(redirection_url)
         redirection_url = self.modify_redirection_url_based_on_default_user_org(
             redirection_url, user
         )


### PR DESCRIPTION
### Purpose/Motivation
Sometimes when a user tries to install the github app (on self-hosted), they will encounter a 400 response

### Links to relevant tickets
Fixes: https://github.com/codecov/engineering-team/issues/806

### What does this PR do?
- change return of `get_redirection_url_from_state` to tuple
- if second element of tuple is False, it means that the state was not set and we should redirect to the dashboard without logging the user in
