### PR TITLE
feat: add resolver to expose private repos

### DIFF
--- a/codecov_auth/models.py
+++ b/codecov_auth/models.py
@@ -274,6 +274,10 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
         return self.repository_set.filter(active=True, private=True).count()
 
     @property
+    def has_private_repos(self):
+        return self.repository_set.filter(private=True).exists()
+
+    @property
     def repo_credits(self):
         # Returns the number of private repo credits remaining
         # Only meaningful for legacy plans

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -587,3 +587,34 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
 
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["hasPrivateRepos"] == True
+
+    def test_owner_query_with_public_repos(self):
+        current_org = OwnerFactory(
+            username="random-plan-user",
+            service="github",
+        )
+        RepositoryFactory(
+            author=current_org,
+            active=True,
+            activated=True,
+            private=False,
+            name="test-one",
+        )
+        RepositoryFactory(
+            author=current_org,
+            active=True,
+            activated=True,
+            private=False,
+            name="test-two",
+        )
+        query = """{
+            owner(username: "%s") {
+                hasPrivateRepos
+            }
+        }
+        """ % (
+            current_org.username
+        )
+
+        data = self.gql_request(query, owner=current_org)
+        assert data["owner"]["hasPrivateRepos"] == False

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -569,3 +569,21 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
 
         assert res["errors"][0]["message"] == MissingService.message
         assert res["data"]["owner"] is None
+
+    def test_owner_query_with_private_repos(self):
+        current_org = OwnerFactory(
+            username="random-plan-user",
+            service="github",
+        )
+        RepositoryFactory(author=current_org, active=True, activated=True, private=True)
+        query = """{
+            owner(username: "%s") {
+                hasPrivateRepos
+            }
+        }
+        """ % (
+            current_org.username
+        )
+
+        data = self.gql_request(query, owner=current_org)
+        assert data["owner"]["hasPrivateRepos"] == True

--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -15,6 +15,7 @@ type Owner {
   repository(name: String!): RepositoryResult!
   repositoryDeprecated(name: String!): Repository
   numberOfUploads: Int
+  hasPrivateRepos: Boolean!
   isAdmin: Boolean!
   hashOwnerid: String!
   ownerid: Int!

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -88,6 +88,12 @@ def resolve_available_plans(owner: Owner, info) -> List[PlanData]:
     return plan_service.available_plans(owner=owner)
 
 
+@owner_bindable.field("hasPrivateRepos")
+@sync_to_async
+def resolve_has_private_repos(owner: Owner, info) -> List[PlanData]:
+    return owner.has_private_repos
+
+
 @owner_bindable.field("repository")
 async def resolve_repository(owner, info, name):
     command = info.context["executor"].get_command("repository")


### PR DESCRIPTION
### Purpose/Motivation
We're adding a resolver to surface whether a repo has any private repos.

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/939

### What does this PR do?
- Adds a resolver for an owner to surface if it has any private repos
- Adds a property to the owner model

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
