### PR TITLE
[feat] Add primary language field to repository GQL

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -68,6 +68,7 @@ default_fields = """
     criticalFiles { name }
     graphToken
     yaml
+    isATSConfigured
     bot { username }
 """
 
@@ -95,7 +96,6 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
     @freeze_time("2021-01-01")
     def test_when_repository_has_no_coverage(self):
-
         repo = RepositoryFactory(
             author=self.owner, active=True, private=True, name="a", yaml=self.yaml
         )
@@ -123,6 +123,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "criticalFiles": [],
             "graphToken": graphToken,
             "yaml": "test: test\n",
+            "isATSConfigured": False,
             "bot": None,
         }
 
@@ -173,6 +174,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "criticalFiles": [],
             "graphToken": graphToken,
             "yaml": "test: test\n",
+            "isATSConfigured": False,
             "bot": None,
         }
 
@@ -424,3 +426,16 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "__typename": "NotFoundError",
             "message": "Not found",
         }
+
+    def test_repository_has_ats_configured(self):
+        repo = RepositoryFactory(
+            author=self.owner,
+            active=True,
+            private=True,
+            yaml={
+                "flag_management": {"individual_flags": {"carryforward_mode": "labels"}}
+            },
+        )
+
+        res = self.fetch_repository(repo.name)
+        assert res["isATSConfigured"] == True

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -69,6 +69,7 @@ default_fields = """
     graphToken
     yaml
     isATSConfigured
+    language
     bot { username }
 """
 

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -439,3 +439,11 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         res = self.fetch_repository(repo.name)
         assert res["isATSConfigured"] == True
+
+    def test_repository_get_language(self):
+        repo = RepositoryFactory(
+            author=self.owner, active=True, private=True, language="python"
+        )
+
+        res = self.fetch_repository(repo.name)
+        assert res["language"] == "python"

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -104,7 +104,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             private=True,
             name="a",
             yaml=self.yaml,
-            language="rust"
+            language="rust",
         )
         profiling_token = RepositoryTokenFactory(
             repository_id=repo.repoid, token_type="profiling"
@@ -143,7 +143,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             private=True,
             name="b",
             yaml=self.yaml,
-            language="erlang"
+            language="erlang",
         )
 
         hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -2,10 +2,10 @@ import datetime
 from unittest.mock import PropertyMock, patch
 
 from django.test import TransactionTestCase, override_settings
-from core import models
 from freezegun import freeze_time
 
 from codecov_auth.tests.factories import OwnerFactory
+from core import models
 from core.tests.factories import (
     CommitFactory,
     PullFactory,

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -70,7 +70,7 @@ default_fields = """
     graphToken
     yaml
     isATSConfigured
-    language
+    primaryLanguage
     bot { username }
 """
 
@@ -131,7 +131,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
-            "language": "rust",
+            "primaryLanguage": "rust",
             "bot": None,
         }
 
@@ -184,7 +184,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
-            "language": "erlang",
+            "primaryLanguage": "erlang",
             "bot": None,
         }
 
@@ -456,4 +456,4 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         )
 
         res = self.fetch_repository(repo.name)
-        assert res["language"] == "python"
+        assert res["primaryLanguage"] == "python"

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import PropertyMock, patch
 
 from django.test import TransactionTestCase, override_settings
+from core import models
 from freezegun import freeze_time
 
 from codecov_auth.tests.factories import OwnerFactory
@@ -125,6 +126,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
+            "language": any(lang for lang in models.Repository.Languages),
             "bot": None,
         }
 
@@ -176,6 +178,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
+            "language": any(lang for lang in models.Repository.Languages),
             "bot": None,
         }
 

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -99,7 +99,12 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     @freeze_time("2021-01-01")
     def test_when_repository_has_no_coverage(self):
         repo = RepositoryFactory(
-            author=self.owner, active=True, private=True, name="a", yaml=self.yaml
+            author=self.owner,
+            active=True,
+            private=True,
+            name="a",
+            yaml=self.yaml,
+            language="rust"
         )
         profiling_token = RepositoryTokenFactory(
             repository_id=repo.repoid, token_type="profiling"
@@ -126,7 +131,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
-            "language": any(lang for lang in models.Repository.Languages),
+            "language": "rust",
             "bot": None,
         }
 
@@ -138,6 +143,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             private=True,
             name="b",
             yaml=self.yaml,
+            language="erlang"
         )
 
         hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)
@@ -178,7 +184,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
-            "language": any(lang for lang in models.Repository.Languages),
+            "language": "erlang",
             "bot": None,
         }
 

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -64,6 +64,7 @@ type Repository {
   repositoryConfig: RepositoryConfig
   staticAnalysisToken: String
   isATSConfigured: Boolean
+  language: String
 }
 
 type PullConnection {

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -64,7 +64,7 @@ type Repository {
   repositoryConfig: RepositoryConfig
   staticAnalysisToken: String
   isATSConfigured: Boolean
-  language: String
+  primaryLanguage: String
 }
 
 type PullConnection {

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -63,6 +63,7 @@ type Repository {
   ): [Measurement!]!
   repositoryConfig: RepositoryConfig
   staticAnalysisToken: String
+  isATSConfigured: Boolean
 }
 
 type PullConnection {

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -323,7 +323,7 @@ def resolve_repository_config(repository: Repository, info):
     return repository
 
 
-@repository_bindable.field("language")
+@repository_bindable.field("primaryLanguage")
 def resolve_languate(repository: Repository, info):
     return repository.language
 

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -323,6 +323,11 @@ def resolve_repository_config(repository: Repository, info):
     return repository
 
 
+@repository_bindable.field("language")
+def resolve_languate(repository: Repository, info):
+    return repository.language
+
+
 repository_result_bindable = UnionType("RepositoryResult")
 
 

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -283,6 +283,17 @@ def resolve_flags_measurements_backfilled(repository: Repository, info) -> bool:
     return dataset.is_backfilled()
 
 
+@repository_bindable.field("isATSConfigured")
+def resolve_is_ats_configured(repository: Repository, info) -> bool:
+    if not repository.yaml or "flag_management" not in repository.yaml:
+        return False
+
+    # See https://docs.codecov.com/docs/getting-started-with-ats-github-actions on configuring
+    # flags. To use Automated Test Selection, a flag is required with Carryforward mode "labels".
+    individual_flags = repository.yaml["flag_management"].get("individual_flags", {})
+    return individual_flags.get("carryforward_mode") == "labels"
+
+
 @repository_bindable.field("measurements")
 @sync_to_async
 def resolve_measurements(


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Following up from #321, adds the language field to the Repository type. This will be consumed in gazebo to conditionally render an `ATS` tab. This PR closes https://github.com/codecov/engineering-team/issues/930. 

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/930

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
