### PR TITLE
feat: expand message for gm marketplace customer when customer has previous plan

### DIFF
--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -864,7 +864,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
         log_warning_mock.assert_called_with(
             "GHM webhook - user purchasing but has a Stripe Subscription",
-            extra=dict(username="username", plan_name=plan, quantity=quantity),
+            extra=dict(username="username", old_plan_name=plan, quantity=quantity),
         )
 
         sync_plans_mock.assert_called_once_with(

--- a/webhook_handlers/tests/test_github_enterprise.py
+++ b/webhook_handlers/tests/test_github_enterprise.py
@@ -735,7 +735,7 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
         log_warning_mock.assert_called_with(
             "GHM webhook - user purchasing but has a Stripe Subscription",
-            extra=dict(username="username", plan_name=plan, quantity=quantity),
+            extra=dict(username="username", old_plan_name=plan, quantity=quantity),
         )
 
         sync_plans_mock.assert_called_once_with(

--- a/webhook_handlers/tests/test_github_enterprise.py
+++ b/webhook_handlers/tests/test_github_enterprise.py
@@ -19,14 +19,14 @@ from core.tests.factories import (
     PullFactory,
     RepositoryFactory,
 )
+from plan.constants import PlanName
 from utils.config import get_config
 from webhook_handlers.constants import (
     GitHubHTTPHeaders,
     GitHubWebhookEvents,
     WebhookHandlerErrorMessages,
 )
-
-MockedSubscription = namedtuple("Subscription", ["status"])
+from webhook_handlers.tests.test_github import MockedSubscription
 
 WEBHOOK_SECRET = b"testixik8qdauiab1yiffydimvi72ekq"
 
@@ -719,7 +719,11 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
             service="github_enterprise",
             stripe_subscription_id="abc",
         )
-        subscription_retrieve_mock.return_value = MockedSubscription("active")
+        quantity = 14
+        plan = PlanName.CODECOV_PRO_MONTHLY.value
+        subscription_retrieve_mock.return_value = MockedSubscription(
+            "active", plan, quantity
+        )
         response = self._post_event_data(
             event=GitHubWebhookEvents.MARKETPLACE_PURCHASE,
             data={
@@ -731,7 +735,7 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
         log_warning_mock.assert_called_with(
             "GHM webhook - user purchasing but has a Stripe Subscription",
-            extra=dict(username="username"),
+            extra=dict(username="username", plan_name=plan, quantity=quantity),
         )
 
         sync_plans_mock.assert_called_once_with(

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -507,7 +507,7 @@ class GithubWebhookHandler(APIView):
                     "GHM webhook - user purchasing but has a Stripe Subscription",
                     extra=dict(
                         username=username,
-                        plan_name=subscription.plan.get("name", None),
+                        old_plan_name=subscription.plan.get("name", None),
                         quantity=subscription.quantity,
                     ),
                 )

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -505,7 +505,11 @@ class GithubWebhookHandler(APIView):
             if subscription.status == "active":
                 log.warning(
                     "GHM webhook - user purchasing but has a Stripe Subscription",
-                    extra=dict(username=username),
+                    extra=dict(
+                        username=username,
+                        plan_name=subscription.plan.get("name", None),
+                        quantity=subscription.quantity,
+                    ),
                 )
         TaskService().sync_plans(
             sender=request.data["sender"],


### PR DESCRIPTION
### Purpose/Motivation
Closes https://github.com/codecov/internal-issues/issues/150

### What does this PR do?
Adds a quick extra params to ghm customers

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
