### PR TITLE
feat: add fn to update stripe email address

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -1,4 +1,6 @@
+import email
 import logging
+import re
 from abc import ABC, abstractmethod
 
 import stripe
@@ -61,6 +63,10 @@ class AbstractPaymentService(ABC):
 
     @abstractmethod
     def update_payment_method(self, owner, payment_method):
+        pass
+
+    @abstractmethod
+    def update_email_address(self, owner, email_address):
         pass
 
     @abstractmethod
@@ -406,6 +412,22 @@ class StripeService(AbstractPaymentService):
         )
 
     @_log_stripe_error
+    def update_email_address(self, owner: Owner, email_address: str):
+        if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", email_address):
+            return None
+
+        log.info(f"Stripe update email address owner {owner.ownerid}")
+        if owner.stripe_subscription_id is None:
+            log.info(
+                f"stripe_subscription_id is None, no updating stripe email for owner {owner.ownerid}"
+            )
+            return None
+        stripe.Customer.modify(owner.stripe_customer_id, email=email_address)
+        log.info(
+            f"Stripe success update email address for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"
+        )
+
+    @_log_stripe_error
     def apply_cancellation_discount(self, owner: Owner):
         if owner.stripe_subscription_id is None:
             log.info(
@@ -465,6 +487,9 @@ class EnterprisePaymentService(AbstractPaymentService):
         pass
 
     def update_payment_method(self, owner, payment_method):
+        pass
+
+    def update_email_address(self, owner, email_address):
         pass
 
     def get_schedule(self, owner):
@@ -533,6 +558,15 @@ class BillingService:
         the card data differently
         """
         return self.payment_service.update_payment_method(owner, payment_method)
+
+    def update_email_address(self, owner: Owner, email_address: str):
+        """
+        Takes an owner and a new email. Email is a string coming directly from
+        the front-end. If the owner has a payment id and if it's a valid email,
+        the payment service will update the email address in the upstream service.
+        Otherwise returns None.
+        """
+        return self.payment_service.update_email_address(owner, email_address)
 
     def apply_cancellation_discount(self, owner: Owner):
         return self.payment_service.apply_cancellation_discount(owner)

--- a/services/billing.py
+++ b/services/billing.py
@@ -1,4 +1,3 @@
-import email
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -416,15 +415,15 @@ class StripeService(AbstractPaymentService):
         if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", email_address):
             return None
 
-        log.info(f"Stripe update email address owner {owner.ownerid}")
+        log.info(f"Stripe update email address for owner {owner.ownerid}")
         if owner.stripe_subscription_id is None:
             log.info(
-                f"stripe_subscription_id is None, no updating stripe email for owner {owner.ownerid}"
+                f"stripe_subscription_id is None, not updating stripe email for owner {owner.ownerid}"
             )
             return None
         stripe.Customer.modify(owner.stripe_customer_id, email=email_address)
         log.info(
-            f"Stripe success update email address for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"
+            f"Stripe successfully updated email address for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"
         )
 
     @_log_stripe_error

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1221,6 +1221,25 @@ class StripeServiceTests(TestCase):
             customer_id, invoice_settings={"default_payment_method": payment_method_id}
         )
 
+    def test_update_email_address_with_invalid_email(self):
+        owner = OwnerFactory(stripe_subscription_id=None)
+        assert self.stripe.update_email_address(owner, "not-an-email") == None
+
+    def test_update_email_address_when_no_subscription(self):
+        owner = OwnerFactory(stripe_subscription_id=None)
+        assert self.stripe.update_email_address(owner, "test@gmail.com") == None
+
+    @patch("services.billing.stripe.Customer.modify")
+    def test_update_email_address(self, modify_customer_mock):
+        subscription_id = "sub_abc"
+        customer_id = "cus_abc"
+        email = "test@gmail.com"
+        owner = OwnerFactory(
+            stripe_subscription_id=subscription_id, stripe_customer_id=customer_id
+        )
+        self.stripe.update_email_address(owner, "test@gmail.com")
+        modify_customer_mock.assert_called_once_with(customer_id, email=email)
+
     @patch("services.billing.stripe.Invoice.retrieve")
     def test_get_invoice_not_found(self, retrieve_invoice_mock):
         invoice_id = "abc"
@@ -1351,6 +1370,9 @@ class MockPaymentService(AbstractPaymentService):
         pass
 
     def update_payment_method(self, owner, plan):
+        pass
+
+    def update_email_address(self, owner, email_address):
         pass
 
     def get_schedule(self, owner):

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1532,6 +1532,12 @@ class BillingServiceTests(TestCase):
         self.billing_service.update_payment_method(owner, "abc")
         get_subscription_mock.assert_called_once_with(owner, "abc")
 
+    @patch("services.tests.test_billing.MockPaymentService.update_email_address")
+    def test_email_address(self, get_subscription_mock):
+        owner = OwnerFactory()
+        self.billing_service.update_email_address(owner, "test@gmail.com")
+        get_subscription_mock.assert_called_once_with(owner, "test@gmail.com")
+
     @patch("services.tests.test_billing.MockPaymentService.get_invoice")
     def test_get_invoice(self, get_invoice_mock):
         owner = OwnerFactory()


### PR DESCRIPTION
### Purpose/Motivation
Customers want to update the stripe email address via Gazebo. This is the backend portion for this change.

### What does this PR do?
- Add `update_email_address` fn and tests

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
