### PR TITLE
957 add frp proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ export API_DOCKER_REPO=${AR_REPO}
 export API_DOCKER_VERSION=${VERSION}
 export CODECOV_TOKEN=${CODECOV_UPLOAD_TOKEN}
 API_DOMAIN ?= api
+PROXY_NETWORK ?= api_default
 
 # Codecov CLI version to use
 CODECOV_CLI_VERSION := 0.4.1
@@ -253,7 +254,7 @@ proxy.run: # Used to run the proxy
 proxy.run:
 	make proxy.build
 	make proxy.down
-	docker run --rm --network api_default -e FRP_TOKEN=${FRP_TOKEN} -e DOMAIN=${API_DOMAIN} --name api-proxy ${API_DOCKER_REPO}/proxy:latest
+	docker run --rm --network ${PROXY_NETWORK} -e FRP_TOKEN=${FRP_TOKEN} -e DOMAIN=${API_DOMAIN} --name api-proxy ${API_DOCKER_REPO}/proxy:latest
 	sleep 3
 	make proxy.logs
 	# You should see "[api] start proxy success"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ export DOCKER_BUILDKIT=1
 export API_DOCKER_REPO=${AR_REPO}
 export API_DOCKER_VERSION=${VERSION}
 export CODECOV_TOKEN=${CODECOV_UPLOAD_TOKEN}
+API_DOMAIN ?= api
 
 # Codecov CLI version to use
 CODECOV_CLI_VERSION := 0.4.1
@@ -235,3 +236,42 @@ test_env:
 	make test_env.check_db
 	make test_env.run_unit
 	make test_env.check-for-migration-conflicts
+
+
+### START Proxy Commands
+.PHONY: proxy.build
+proxy.build: # Used to build the proxy
+proxy.build:
+	docker build -f docker/Dockerfile-proxy . -t ${API_DOCKER_REPO}/proxy:latest -t ${API_DOCKER_REPO}/proxy:${release_version}-${sha} \
+			--label "org.label-schema.build-date"="$(build_date)" \
+			--label "org.label-schema.name"="API Proxy" \
+			--label "org.label-schema.vendor"="api" \
+			--label "org.label-schema.version"="${release_version}"
+
+.PHONY: proxy.run
+proxy.run: # Used to run the proxy
+proxy.run:
+	make proxy.build
+	make proxy.down
+	docker run --rm --network api_default -e FRP_TOKEN=${FRP_TOKEN} -e DOMAIN=${API_DOMAIN} --name api-proxy ${API_DOCKER_REPO}/proxy:latest
+	sleep 3
+	make proxy.logs
+	# You should see "[api] start proxy success"
+	# If no logs then proxy failed to start. Check if you are on VPN. If you get a 404, check if you are on VPN
+
+.PHONY: proxy.logs
+proxy.logs: # Used to logs the proxy
+proxy.logs:
+	docker logs api-proxy
+
+.PHONY: proxy.shell
+proxy.shell: # Used to shell the proxy
+proxy.shell:
+	docker exec -it api-proxy sh
+
+.PHONY: proxy.down
+proxy.down: # Used to down the proxy
+proxy.down:
+	docker kill api-proxy || true
+
+### END PROXY Commands

--- a/codecov/settings_dev.py
+++ b/codecov/settings_dev.py
@@ -4,7 +4,7 @@ from .settings_base import *
 
 DEBUG = True
 ALLOWED_HOSTS = get_config(
-    "setup", "api_allowed_hosts", default=["localhost", "local-api-stripe.ngrok.io"]
+    "setup", "api_allowed_hosts", default=["localhost", "local-api-stripe.ngrok.io", "local-api-stripe"]
 )
 
 WEBHOOK_URL = ""  # NGROK TUNNEL HERE

--- a/codecov/settings_dev.py
+++ b/codecov/settings_dev.py
@@ -4,7 +4,7 @@ from .settings_base import *
 
 DEBUG = True
 ALLOWED_HOSTS = get_config(
-    "setup", "api_allowed_hosts", default=["localhost", "local-api-stripe.ngrok.io", "local-api-stripe"]
+    "setup", "api_allowed_hosts", default=["localhost", "api.lt.codecov.dev"]
 )
 
 WEBHOOK_URL = ""  # NGROK TUNNEL HERE

--- a/docker/Dockerfile-proxy
+++ b/docker/Dockerfile-proxy
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.3
+FROM alpine
+
+ENV FRP_VERSION=v0.51.3
+
+RUN addgroup -S frp \
+&& adduser -D -S -h /var/frp -s /sbin/nologin -G frp frp \
+&& apk add --no-cache curl \
+&& curl -fSL https://github.com/fatedier/frp/releases/download/${FRP_VERSION}/frp_${FRP_VERSION:1}_linux_amd64.tar.gz -o frp.tar.gz \
+&& tar -zxv -f frp.tar.gz \
+&& rm -rf frp.tar.gz \
+&& mv frp_*_linux_amd64 /frp \
+&& chown -R frp:frp /frp
+
+COPY --chown=frp:frp docker/frpc-entrypoint.sh /frp/entrypoint.sh
+RUN chmod 755 /frp/entrypoint.sh
+USER frp
+
+WORKDIR /frp
+ADD docker/frpc.ini /frp/frpc.ini
+
+EXPOSE 6000 7000
+
+CMD ["/frp/entrypoint.sh"]

--- a/docker/frpc-entrypoint.sh
+++ b/docker/frpc-entrypoint.sh
@@ -24,7 +24,7 @@ if [ $REMOTE_PORT ]; then
   sed -i "s|remote_port = 6000|remote_port = $REMOTE_PORT|g" /frp/frpc.ini
 fi
 if [ $DOMAIN ]; then
-  sed -i "s|subdomain = local-api-stripe|subdomain = $DOMAIN|g" /frp/frpc.ini
-  sed -i "s|\[local-api-stripe\]|\[$DOMAIN\]|g" /frp/frpc.ini
+  sed -i "s|subdomain = api|subdomain = $DOMAIN|g" /frp/frpc.ini
+  sed -i "s|\[api\]|\[$DOMAIN\]|g" /frp/frpc.ini
 fi
 /frp/frpc -c /frp/frpc.ini

--- a/docker/frpc-entrypoint.sh
+++ b/docker/frpc-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+if [ $SERVER_ADDR ]; then
+  sed -i "s|server_addr = 127.0.0.1|server_addr = $SERVER_ADDR|g" /frp/frpc.ini
+fi
+if [ $FRP_USER ]; then
+  sed -i "1 a user = $FRP_USER" /frp/frpc.ini
+fi
+if [ $PROXY_NAME ]; then
+  sed -i "s|ssh|$PROXY_NAME|g" /frp/frpc.ini
+fi
+if [ $SERVER_PORT ]; then
+  sed -i "s|server_port = 7000|server_port = $SERVER_PORT|g" /frp/frpc.ini
+fi
+if [ $PROTO ]; then
+  sed -i "s|type = tcp|type = $PROTO|g" /frp/frpc.ini
+fi
+if [ $LOCAL_IP ]; then
+  sed -i "s|local_ip = 127.0.0.1|local_ip = $LOCAL_IP|g" /frp/frpc.ini
+fi
+if [ $LOCAL_PORT ]; then
+  sed -i "s|local_port = 22|local_port = $LOCAL_PORT|g" /frp/frpc.ini
+fi
+if [ $REMOTE_PORT ]; then
+  sed -i "s|remote_port = 6000|remote_port = $REMOTE_PORT|g" /frp/frpc.ini
+fi
+if [ $DOMAIN ]; then
+  sed -i "s|subdomain = local-api-stripe|subdomain = $DOMAIN|g" /frp/frpc.ini
+  sed -i "s|\[local-api-stripe\]|\[$DOMAIN\]|g" /frp/frpc.ini
+fi
+/frp/frpc -c /frp/frpc.ini

--- a/docker/frpc.ini
+++ b/docker/frpc.ini
@@ -6,5 +6,5 @@ token = {{ .Envs.FRP_TOKEN }}
 [api]
 type = http
 local_port = 8000
-local_ip = 127.0.0.1
-subdomain = local-api-stripe
+local_ip = api
+subdomain = api

--- a/docker/frpc.ini
+++ b/docker/frpc.ini
@@ -1,0 +1,10 @@
+[common]
+server_addr = lt.codecov.dev
+server_port = 7000
+authentication_method = token
+token = {{ .Envs.FRP_TOKEN }}
+[api]
+type = http
+local_port = 8000
+local_ip = 127.0.0.1
+subdomain = local-api-stripe


### PR DESCRIPTION
### Purpose/Motivation
We occasionally test Stripe locally, and to do so we need to expose our local setup to the world. We normally use Ngrok, but we have an inhouse solution, this ticket, instead to save us some money.

### What does this PR do?
- Add frpc proxy setup information + minutiae to ensure the new setup works


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
