### PR TITLE
Improve logging for GHM plan changes

### DIFF
--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -858,13 +858,23 @@ class GithubWebhookHandlerTests(APITestCase):
             data={
                 "action": action,
                 "sender": sender,
-                "marketplace_purchase": {"account": account},
+                "marketplace_purchase": {
+                    "account": account,
+                    "plan": {"name": "gh-marketplace"},
+                    "unit_count": 200,
+                },
             },
         )
 
         log_warning_mock.assert_called_with(
             "GHM webhook - user purchasing but has a Stripe Subscription",
-            extra=dict(username="username", old_plan_name=plan, quantity=quantity),
+            extra={
+                "username": "username",
+                "old_plan_name": plan,
+                "old_plan_seats": quantity,
+                "new_plan_name": "gh-marketplace",
+                "new_plan_seats": 200,
+            },
         )
 
         sync_plans_mock.assert_called_once_with(

--- a/webhook_handlers/tests/test_github_enterprise.py
+++ b/webhook_handlers/tests/test_github_enterprise.py
@@ -729,13 +729,23 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
             data={
                 "action": action,
                 "sender": sender,
-                "marketplace_purchase": {"account": account},
+                "marketplace_purchase": {
+                    "account": account,
+                    "plan": {"name": "gh-marketplace"},
+                    "unit_count": 14,
+                },
             },
         )
 
         log_warning_mock.assert_called_with(
             "GHM webhook - user purchasing but has a Stripe Subscription",
-            extra=dict(username="username", old_plan_name=plan, quantity=quantity),
+            extra={
+                "username": "username",
+                "old_plan_name": plan,
+                "old_plan_seats": quantity,
+                "new_plan_name": "gh-marketplace",
+                "new_plan_seats": 14,
+            },
         )
 
         sync_plans_mock.assert_called_once_with(

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -500,6 +500,8 @@ class GithubWebhookHandler(APIView):
         with suppress(Exception):
             # log if users purchase GHM plans while having a stripe plan
             username = request.data["marketplace_purchase"]["account"]["login"]
+            new_plan_seats = request.data["marketplace_purchase"]["unit_count"]
+            new_plan_name = request.data["marketplace_purchase"]["plan"]["name"]
             owner = Owner.objects.get(service=self.service_name, username=username)
             subscription = BillingService(requesting_user=owner).get_subscription(owner)
             if subscription.status == "active":
@@ -508,7 +510,9 @@ class GithubWebhookHandler(APIView):
                     extra=dict(
                         username=username,
                         old_plan_name=subscription.plan.get("name", None),
-                        quantity=subscription.quantity,
+                        old_plan_seats=subscription.quantity,
+                        new_plan_name=new_plan_name,
+                        new_plan_seats=new_plan_seats,
                     ),
                 )
         TaskService().sync_plans(


### PR DESCRIPTION
### Purpose/Motivation

Following up from https://github.com/codecov/internal-issues/issues/150, add some extra fields to our logs if the user has an active subscription. More info about the payload object [here](https://docs.github.com/en/apps/github-marketplace/using-the-github-marketplace-api-in-your-app/webhook-events-for-the-github-marketplace-api). 

Adding the following info to logs:

- From plan
- From no. seats
- To plan
- To no. seats


### Links to relevant tickets
This closes https://github.com/codecov/internal-issues/issues/151

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
