### PR TITLE
feat: Update and retrieve bundle_analysis_enabled field

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -71,6 +71,7 @@ default_fields = """
     yaml
     isATSConfigured
     primaryLanguage
+    bundleAnalysisEnabled
     bot { username }
 """
 
@@ -132,6 +133,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "yaml": "test: test\n",
             "isATSConfigured": False,
             "primaryLanguage": "rust",
+            "bundleAnalysisEnabled": False,
             "bot": None,
         }
 
@@ -185,6 +187,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "yaml": "test: test\n",
             "isATSConfigured": False,
             "primaryLanguage": "erlang",
+            "bundleAnalysisEnabled": False,
             "bot": None,
         }
 
@@ -457,3 +460,10 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         res = self.fetch_repository(repo.name)
         assert res["primaryLanguage"] == "python"
+
+    def test_repository_get_bundle_analysis_enabled(self):
+        repo = RepositoryFactory(
+            author=self.owner, active=True, private=True, bundle_analysis_enabled=True
+        )
+        res = self.fetch_repository(repo.name)
+        assert res["bundleAnalysisEnabled"] == True

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -65,6 +65,7 @@ type Repository {
   staticAnalysisToken: String
   isATSConfigured: Boolean
   primaryLanguage: String
+  bundleAnalysisEnabled: Boolean
 }
 
 type PullConnection {

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -324,8 +324,13 @@ def resolve_repository_config(repository: Repository, info):
 
 
 @repository_bindable.field("primaryLanguage")
-def resolve_languate(repository: Repository, info):
+def resolve_language(repository: Repository, info):
     return repository.language
+
+
+@repository_bindable.field("bundleAnalysisEnabled")
+def resolve_bundle_analysis_enabled(repository: Repository, info):
+    return repository.bundle_analysis_enabled
 
 
 repository_result_bindable = UnionType("RepositoryResult")

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -324,12 +324,12 @@ def resolve_repository_config(repository: Repository, info):
 
 
 @repository_bindable.field("primaryLanguage")
-def resolve_language(repository: Repository, info):
+def resolve_language(repository: Repository, info) -> str:
     return repository.language
 
 
 @repository_bindable.field("bundleAnalysisEnabled")
-def resolve_bundle_analysis_enabled(repository: Repository, info):
+def resolve_bundle_analysis_enabled(repository: Repository, info) -> bool:
     return repository.bundle_analysis_enabled
 
 

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -62,10 +62,18 @@ class BundleAnalysisView(APIView):
         else:
             raise NotAuthenticated()
 
+        update_fields = []
         if not repo.active or not repo.activated:
             repo.active = True
             repo.activated = True
-            repo.save(update_fields=["active", "activated"])
+            update_fields += ["active", "activated"]
+
+        if not repo.bundle_analysis_enabled:
+            repo.bundle_analysis_enabled = True
+            update_fields += ["bundle_analysis_enabled"]
+
+        if update_fields:
+            repo.save(update_fields=update_fields)
 
         commit, _ = Commit.objects.get_or_create(
             commitid=data["commit"],


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

For client app to know whether use has bundle analysis enabled:
- When a upload endpoint is called for a bundle analysis type, set the flag to true in DB.
- Allow GQL to query this field

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1005


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
