### PR TITLE
feat: Add fetching of repo languages in GQL

### DIFF
--- a/core/tests/factories.py
+++ b/core/tests/factories.py
@@ -21,6 +21,7 @@ class RepositoryFactory(DjangoModelFactory):
     language = factory.Iterator(
         [language.value for language in models.Repository.Languages]
     )
+    languages = []
     fork = None
     branch = "master"
     upload_token = factory.Faker("uuid4")

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -71,6 +71,7 @@ default_fields = """
     yaml
     isATSConfigured
     primaryLanguage
+    languages
     bundleAnalysisEnabled
     bot { username }
 """
@@ -106,6 +107,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             name="a",
             yaml=self.yaml,
             language="rust",
+            languages=["python", "rust"],
         )
         profiling_token = RepositoryTokenFactory(
             repository_id=repo.repoid, token_type="profiling"
@@ -133,6 +135,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "yaml": "test: test\n",
             "isATSConfigured": False,
             "primaryLanguage": "rust",
+            "languages": ["python", "rust"],
             "bundleAnalysisEnabled": False,
             "bot": None,
         }
@@ -146,6 +149,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             name="b",
             yaml=self.yaml,
             language="erlang",
+            languages=[],
         )
 
         hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)
@@ -187,6 +191,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "yaml": "test: test\n",
             "isATSConfigured": False,
             "primaryLanguage": "erlang",
+            "languages": [],
             "bundleAnalysisEnabled": False,
             "bot": None,
         }
@@ -467,3 +472,22 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_repository(repo.name)
         assert res["bundleAnalysisEnabled"] == True
+
+    def test_repository_get_languages_null(self):
+        repo = RepositoryFactory(
+            author=self.owner, active=True, private=True, languages=None
+        )
+        res = self.fetch_repository(repo.name)
+        assert res["languages"] == None
+
+    def test_repository_get_languages_empty(self):
+        repo = RepositoryFactory(author=self.owner, active=True, private=True)
+        res = self.fetch_repository(repo.name)
+        assert res["languages"] == []
+
+    def test_repository_get_languages_with_values(self):
+        repo = RepositoryFactory(
+            author=self.owner, active=True, private=True, languages=["C", "C++"]
+        )
+        res = self.fetch_repository(repo.name)
+        assert res["languages"] == ["C", "C++"]

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -65,6 +65,7 @@ type Repository {
   staticAnalysisToken: String
   isATSConfigured: Boolean
   primaryLanguage: String
+  languages: [String!]
   bundleAnalysisEnabled: Boolean
 }
 

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -328,6 +328,11 @@ def resolve_language(repository: Repository, info) -> str:
     return repository.language
 
 
+@repository_bindable.field("languages")
+def resolve_languages(repository: Repository, info) -> List[str]:
+    return repository.languages
+
+
 @repository_bindable.field("bundleAnalysisEnabled")
 def resolve_bundle_analysis_enabled(repository: Repository, info) -> bool:
     return repository.bundle_analysis_enabled


### PR DESCRIPTION
### Purpose/Motivation

Add a resolver for `Repository` to return list of languages for the given repo.

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/963

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
