### PR TITLE
feat: allow nulls in non-required params for BA upload endpoint

### DIFF
--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -32,11 +32,11 @@ class UploadBundleAnalysisPermission(BasePermission):
 class UploadSerializer(serializers.Serializer):
     commit = serializers.CharField(required=True)
     slug = serializers.CharField(required=True)
-    build = serializers.CharField(required=False)
-    buildURL = serializers.CharField(required=False)
-    job = serializers.CharField(required=False)
-    pr = serializers.CharField(required=False)
-    service = serializers.CharField(required=False)
+    build = serializers.CharField(required=False, allow_null=True)
+    buildURL = serializers.CharField(required=False, allow_null=True)
+    job = serializers.CharField(required=False, allow_null=True)
+    pr = serializers.CharField(required=False, allow_null=True)
+    service = serializers.CharField(required=False, allow_null=True)
 
 
 class BundleAnalysisView(APIView):


### PR DESCRIPTION
### Purpose/Motivation

Allow clients to send null values for the params that are not required. Null values are appropriately handled by the API.

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/1052

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
