### PR TITLE
feat: GQL expose list of all git providers

### DIFF
--- a/graphql_api/tests/test_config.py
+++ b/graphql_api/tests/test_config.py
@@ -279,3 +279,18 @@ class TestConfigType(GraphQLTestHelper, TestCase):
                 "selfHostedLicense": {"expirationDate": "2020-05-09T00:00:00"},
             },
         }
+
+    def test_sync_providers(self):
+        data = self.gql_request("query { config { syncProviders } }")
+        assert data == {
+            "config": {
+                "syncProviders": [
+                    "github",
+                    "gitlab",
+                    "bitbucket",
+                    "github_enterprise",
+                    "gitlab_enterprise",
+                    "bitbucket_server",
+                ],
+            },
+        }

--- a/graphql_api/types/config/config.graphql
+++ b/graphql_api/types/config/config.graphql
@@ -8,4 +8,5 @@ type Config {
   gitlabEnterpriseURL: String
   bitbucketServerURL: String
   selfHostedLicense: SelfHostedLicense
+  syncProviders: [String!]!
 }

--- a/graphql_api/types/config/config.py
+++ b/graphql_api/types/config/config.py
@@ -1,10 +1,12 @@
 from distutils.util import strtobool
+from typing import List
 
 from ariadne import ObjectType
 from django.conf import settings
 
 import services.self_hosted as self_hosted
 from codecov.db import sync_to_async
+from codecov_auth.models import Service
 from graphql_api.types.enums.enums import LoginProvider
 
 config_bindable = ObjectType("Config")
@@ -111,3 +113,8 @@ def resolve_bitbucket_server_url(_, info):
 
     if settings.BITBUCKET_SERVER_CLIENT_ID:
         return settings.BITBUCKET_SERVER_URL
+
+
+@config_bindable.field("syncProviders")
+def resolve_sync_providers(_, info) -> List[str]:
+    return Service.values


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Show all git providers that Codecov supports

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/947

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
