### PR TITLE
[feat] Allow search by term for flag comparisons

### DIFF
--- a/graphql_api/types/comparison/comparison.graphql
+++ b/graphql_api/types/comparison/comparison.graphql
@@ -10,7 +10,7 @@ type Comparison {
   baseTotals: CoverageTotals
   headTotals: CoverageTotals
   changeCoverage: Float
-  flagComparisons: [FlagComparison]
+  flagComparisons(filters: FlagComparisonFilters): [FlagComparison]
   componentComparisons(filters: ComponentsFilters): [ComponentComparison!]
   hasDifferentNumberOfHeadAndBaseReports: Boolean!
   flagComparisonsCount: Int!

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -176,9 +176,22 @@ def resolve_patch_totals(comparison: ComparisonReport, info) -> dict:
 @comparison_bindable.field("flagComparisons")
 @sync_to_async
 def resolve_flag_comparisons(
-    comparison: ComparisonReport, info
+    comparison: ComparisonReport, info, filters=None
 ) -> List[FlagComparison]:
-    return list(get_flag_comparisons(comparison.commit_comparison))
+    # Retrieve all flag comparisons
+    all_flags = get_flag_comparisons(comparison.commit_comparison)
+
+    # If filters are provided, filter the flags
+    if filters and filters.get("term"):
+        filtered_flags = [
+            flag for flag in all_flags 
+            if filters["term"] in flag.repositoryflag.flag_name 
+        ]
+        return filtered_flags
+
+    # If no filters provided, return all flags
+    return list(all_flags)
+
 
 
 @comparison_bindable.field("componentComparisons")

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -178,20 +178,17 @@ def resolve_patch_totals(comparison: ComparisonReport, info) -> dict:
 def resolve_flag_comparisons(
     comparison: ComparisonReport, info, filters=None
 ) -> List[FlagComparison]:
-    # Retrieve all flag comparisons
     all_flags = get_flag_comparisons(comparison.commit_comparison)
 
-    # If filters are provided, filter the flags
     if filters and filters.get("term"):
         filtered_flags = [
-            flag for flag in all_flags 
-            if filters["term"] in flag.repositoryflag.flag_name 
+            flag
+            for flag in all_flags
+            if filters["term"] in flag.repositoryflag.flag_name
         ]
         return filtered_flags
 
-    # If no filters provided, return all flags
     return list(all_flags)
-
 
 
 @comparison_bindable.field("componentComparisons")

--- a/graphql_api/types/inputs/flag_comparison_filters.graphql
+++ b/graphql_api/types/inputs/flag_comparison_filters.graphql
@@ -1,0 +1,3 @@
+input FlagComparisonFilters {
+  term: String
+}


### PR DESCRIPTION
### Purpose/Motivation
Related to https://github.com/codecov/engineering-team/issues/823, this PR updates the flags comparison type to accept a filter that allows lookups by flag term. This is required in the front end to allow the search field in the flags selector to apply to the query. 

### Links to relevant tickets
This closes https://github.com/codecov/engineering-team/issues/1064. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
