### PR TITLE
Revert "feat: use GithubAppInstallation in api (#347)"

### DIFF
--- a/services/repo_providers.py
+++ b/services/repo_providers.py
@@ -1,18 +1,13 @@
 import logging
 from os import getenv
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict
 
 from django.conf import settings
 from shared.encryption.token import encode_token
 from shared.torngit import get
 
 from codecov.db import sync_to_async
-from codecov_auth.models import (
-    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-    GithubAppInstallation,
-    Owner,
-    Service,
-)
+from codecov_auth.models import Owner, Service
 from core.models import Repository
 from utils.config import get_config
 from utils.encryption import encryptor
@@ -29,14 +24,12 @@ class TorngitInitializationFailed(Exception):
 
 
 def get_token_refresh_callback(
-    owner: Optional[Owner], service: Service
+    owner: Owner, service: Service
 ) -> Callable[[Dict], None]:
     """
     Produces a callback function that will encode and update the oauth token of an owner.
     This callback is passed to the TorngitAdapter for the service.
     """
-    if owner is None:
-        return None
     if service == Service.BITBUCKET or service == Service.BITBUCKET_SERVER:
         return None
 
@@ -53,9 +46,7 @@ def get_token_refresh_callback(
     return callback
 
 
-def get_generic_adapter_params(
-    owner: Optional[Owner], service, use_ssl=False, token=None
-):
+def get_generic_adapter_params(owner: Owner, service, use_ssl=False, token=None):
     if use_ssl:
         verify_ssl = (
             get_config(service, "ssl_pem")
@@ -96,21 +87,7 @@ def get_provider(service, adapter_params):
 
 
 class RepoProviderService(object):
-    def _is_using_integration(self, owner: Optional[Owner], repo: Repository) -> bool:
-        if owner is None:
-            return False
-        ghapp_installation: Optional[
-            GithubAppInstallation
-        ] = owner.github_app_installations.filter(
-            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME
-        ).first()
-        if ghapp_installation:
-            return ghapp_installation.is_repo_covered_by_integration(repo)
-        return repo.using_integration
-
-    def get_adapter(
-        self, owner: Optional[Owner], repo: Repository, use_ssl=False, token=None
-    ):
+    def get_adapter(self, owner: Owner, repo: Repository, use_ssl=False, token=None):
         """
         Return the corresponding implementation for calling the repository provider
 
@@ -122,11 +99,10 @@ class RepoProviderService(object):
         generic_adapter_params = get_generic_adapter_params(
             owner, repo.author.service, use_ssl, token
         )
-
         owner_and_repo_params = {
             "repo": {
                 "name": repo.name,
-                "using_integration": self._is_using_integration(owner, repo),
+                "using_integration": repo.using_integration or False,
                 "service_id": repo.service_id,
                 "private": repo.private,
                 "repoid": repo.repoid,

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -4,42 +4,20 @@ from unittest.mock import patch
 import jwt
 import pytest
 from django.conf import settings
-from django.test import TransactionTestCase
 from rest_framework.exceptions import Throttled, ValidationError
 from shared.config import get_config
 from shared.github import InvalidInstallationError
 
-from codecov_auth.models import GithubAppInstallation, Service
 from core.tests.factories import CommitFactory, OwnerFactory, RepositoryFactory
 from plan.constants import PlanName
 from reports.tests.factories import CommitReportFactory, UploadFactory
 from upload.helpers import (
     check_commit_upload_constraints,
     determine_repo_for_upload,
-    ghapp_installation_id_to_use,
     try_to_get_best_possible_bot_token,
     validate_activated_repo,
     validate_upload,
 )
-
-
-class TestGithubAppInstallationUsage(TransactionTestCase):
-    def test_not_github_provider(self):
-        repo = RepositoryFactory(author__service=Service.GITLAB.value)
-        assert ghapp_installation_id_to_use(repo) is None
-
-    def test_github_app_installation_flow(self):
-        owner = OwnerFactory(service=Service.GITHUB.value, integration_id=None)
-        covered_repo = RepositoryFactory(author=owner)
-        not_covered_repo = RepositoryFactory(author=owner)
-        ghapp_installation = GithubAppInstallation(
-            owner=owner,
-            repository_service_ids=[covered_repo.service_id],
-            installation_id=200,
-        )
-        ghapp_installation.save()
-        assert ghapp_installation_id_to_use(covered_repo) == 200
-        assert ghapp_installation_id_to_use(not_covered_repo) is None
 
 
 def test_try_to_get_best_possible_bot_token_no_repobot_no_ownerbot(db):
@@ -94,9 +72,7 @@ def test_try_to_get_best_possible_bot_token_using_integration(
     assert try_to_get_best_possible_bot_token(repository) == {
         "key": "test-token",
     }
-    get_github_integration_token.assert_called_once_with(
-        "github", installation_id=12345
-    )
+    get_github_integration_token.assert_called_once_with("github", integration_id=12345)
 
 
 @patch("upload.helpers.get_github_integration_token")
@@ -116,9 +92,7 @@ def test_try_to_get_best_possible_bot_token_using_invalid_integration(
         "key": "bornana",
         "secret": None,
     }
-    get_github_integration_token.assert_called_once_with(
-        "github", installation_id=12345
-    )
+    get_github_integration_token.assert_called_once_with("github", integration_id=12345)
 
 
 def test_try_to_get_best_possible_nothing_and_is_private(db):

--- a/utils/github.py
+++ b/utils/github.py
@@ -4,5 +4,5 @@ from utils.cache import cache
 
 
 @cache.cache_function(ttl=480)
-def get_github_integration_token(service, installation_id=None):
-    return _get_github_integration_token(service, integration_id=installation_id)
+def get_github_integration_token(service, integration_id=None):
+    return _get_github_integration_token(service, integration_id=integration_id)

--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -12,7 +12,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 from shared.utils.test_utils import mock_config_helper, mock_metrics
 
-from codecov_auth.models import GithubAppInstallation, Owner, Service
+from codecov_auth.models import Owner, Service
 from codecov_auth.tests.factories import OwnerFactory
 from core.models import Repository
 from core.tests.factories import (
@@ -84,14 +84,6 @@ class GithubWebhookHandlerTests(APITestCase):
     )
     @patch(
         "webhook_handlers.views.github.GithubWebhookHandler._handle_marketplace_events",
-        lambda self, request, *args, **kwargs: Response(),
-    )
-    @patch(
-        "webhook_handlers.views.github.GithubWebhookHandler._handle_installation_repository_events",
-        lambda self, request, *args, **kwargs: Response(),
-    )
-    @patch(
-        "webhook_handlers.views.github.GithubWebhookHandler._handle_installation_events",
         lambda self, request, *args, **kwargs: Response(),
     )
     def test_webhook_counters(self):
@@ -609,393 +601,137 @@ class GithubWebhookHandlerTests(APITestCase):
         "services.task.TaskService.refresh",
         lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
     )
-    def test_installation_creates_new_owner_if_dne(self):
+    def test_installation_events_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
 
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "selected",
-                    "account": {"id": service_id, "login": username},
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "id": 4,
+                        "account": {"id": service_id, "login": username},
+                    },
+                    "sender": {"type": "User"},
                 },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "sender": {"type": "User"},
-            },
-        )
+            )
 
-        owner_set = Owner.objects.filter(
-            service="github", service_id=service_id, username=username
-        )
+            owner = Owner.objects.filter(
+                service="github", service_id=service_id, username=username
+            )
 
-        assert owner_set.exists()
+            assert owner.exists()
 
-        owner = owner_set.first()
+            # clear to check next event also creates
+            owner.delete()
 
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == ["12321", "12343"]
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_creates_new_owner_if_dne_all_repos(self):
-        username, service_id = "newuser", 123456
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "all",
-                    "account": {"id": service_id, "login": username},
-                },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner_set = Owner.objects.filter(
-            service="github", service_id=service_id, username=username
-        )
-
-        assert owner_set.exists()
-
-        owner = owner_set.first()
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == None
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_repositories_creates_new_owner_if_dne(self):
-        username, service_id = "newuser", 123456
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "all",
-                    "account": {"id": service_id, "login": username},
-                },
-                "repository_selection": "all",
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner_set = Owner.objects.filter(
-            service="github", service_id=service_id, username=username
-        )
-
-        assert owner_set.exists()
-
-        owner = owner_set.first()
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == None
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_update_repos_existing_ghapp_installation(self):
-        owner = OwnerFactory(service=Service.GITHUB.value)
-        owner.save()
-        installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=["repo1", "repo2"], installation_id=4
-        )
-        installation.save()
-        assert owner.github_app_installations.count() == 1
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repositories": [{"id": "repo1"}, {"id": "repo2"}, {"id": "repo3"}],
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner.refresh_from_db()
-        installation.refresh_from_db()
-
-        assert (
-            owner.github_app_installations.count() == 1
-        )  # no new installations created
-        installation = owner.github_app_installations.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == ["repo1", "repo2", "repo3"]
-
-    def test_installation_with_deleted_action_nulls_values(self):
+    def test_installation_events_with_deleted_action_nulls_values(self):
         # Should set integration_id to null for owner,
         # and set using_integration=False and bot=null for repos
         owner = OwnerFactory(service=Service.GITHUB.value)
         repo1 = RepositoryFactory(author=owner)
         repo2 = RepositoryFactory(author=owner)
 
-        owner.integration_id = 12
-        owner.save()
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            owner.integration_id = 12
+            owner.save()
 
-        repo1.using_integration, repo2.using_integration = True, True
-        repo1.bot, repo2.bot = owner, owner
+            repo1.using_integration, repo2.using_integration = True, True
+            repo1.bot, repo2.bot = owner, owner
 
-        repo1.save()
-        repo2.save()
+            repo1.save()
+            repo2.save()
 
-        ghapp_installation = GithubAppInstallation(
-            installation_id=25,
-            repository_service_ids=[repo1.service_id, repo2.service_id],
-            owner=owner,
-        )
-        ghapp_installation.save()
-
-        assert owner.github_app_installations.exists()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 25,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "account": {"id": owner.service_id, "login": owner.username}
+                    },
+                    "action": "deleted",
+                    "sender": {"type": "User"},
                 },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "action": "deleted",
-                "sender": {"type": "User"},
-            },
-        )
+            )
 
-        owner.refresh_from_db()
-        repo1.refresh_from_db()
-        repo2.refresh_from_db()
+            owner.refresh_from_db()
+            repo1.refresh_from_db()
+            repo2.refresh_from_db()
 
-        assert owner.integration_id == None
-        assert repo1.using_integration == False
-        assert repo2.using_integration == False
+            assert owner.integration_id == None
+            assert repo1.using_integration == False
+            assert repo2.using_integration == False
 
-        assert repo1.bot == None
-        assert repo2.bot == None
-
-        assert not owner.github_app_installations.exists()
+            assert repo1.bot == None
+            assert repo2.bot == None
 
     @patch(
         "services.task.TaskService.refresh",
         lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
     )
-    def test_installation_repositories_update_existing_ghapp(self):
-        # Should set integration_id to null for owner,
-        # and set using_integration=False and bot=null for repos
-        owner = OwnerFactory(service=Service.GITHUB.value)
-        repo1 = RepositoryFactory(author=owner)
-        repo2 = RepositoryFactory(author=owner)
-        installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=[repo1.service_id], installation_id=12
-        )
-
-        owner.integration_id = 12
-        owner.save()
-
-        repo1.using_integration, repo2.using_integration = True, True
-        repo1.bot, repo2.bot = owner, owner
-
-        repo1.save()
-        repo2.save()
-
-        installation.save()
-
-        assert owner.github_app_installations.exists()
-
-        assert installation.is_repo_covered_by_integration(repo2) is False
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": installation.installation_id,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repositories_added": [{"id": repo2.service_id}],
-                "repositories_removed": [{"id": repo1.service_id}],
-                "repository_selection": "selected",
-                "action": "added",
-                "sender": {"type": "User"},
-            },
-        )
-
-        installation.refresh_from_db()
-        assert installation.installation_id == 12
-        assert installation.repository_service_ids == [repo2.service_id]
-        assert installation.is_repo_covered_by_integration(repo2) is True
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_repositories_update_existing_ghapp_all_repos(self):
-        # Should set integration_id to null for owner,
-        # and set using_integration=False and bot=null for repos
-        owner = OwnerFactory(service=Service.GITHUB.value)
-        repo1 = RepositoryFactory(author=owner)
-        repo2 = RepositoryFactory(author=owner)
-        installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=[repo1.service_id], installation_id=12
-        )
-
-        owner.integration_id = 12
-        owner.save()
-
-        repo1.using_integration, repo2.using_integration = True, True
-        repo1.bot, repo2.bot = owner, owner
-
-        repo1.save()
-        repo2.save()
-
-        installation.save()
-
-        assert owner.github_app_installations.exists()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": 12,
-                    "repository_selection": "all",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repositories_added": [{"id": repo2.service_id}],
-                "repositories_removed": [],
-                "repository_selection": "all",
-                "action": "deleted",
-                "sender": {"type": "User"},
-            },
-        )
-
-        installation.refresh_from_db()
-        assert installation.installation_id == 12
-        assert installation.repository_service_ids == None
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_with_other_actions_sets_owner_itegration_id_if_none(
+    def test_installation_events_with_other_actions_sets_owner_itegration_id_if_none(
         self,
     ):
-        installation_id = 44
+        integration_id = 44
         owner = OwnerFactory(service=Service.GITHUB.value)
 
-        owner.integration_id = None
-        owner.save()
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            owner.integration_id = None
+            owner.save()
 
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": installation_id,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "id": integration_id,
+                        "account": {"id": owner.service_id, "login": owner.username},
+                    },
+                    "action": "added",
+                    "sender": {"type": "User"},
                 },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "action": "added",
-                "sender": {"type": "User"},
-            },
-        )
+            )
 
-        owner.refresh_from_db()
+            owner.refresh_from_db()
 
-        assert owner.integration_id == installation_id
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == installation_id
-        assert installation.repository_service_ids == ["12321", "12343"]
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_repositories_with_other_actions_sets_owner_itegration_id_if_none(
-        self,
-    ):
-        installation_id = 44
-        owner = OwnerFactory(service=Service.GITHUB.value)
-
-        owner.integration_id = None
-        owner.save()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": installation_id,
-                    "repository_selection": "all",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repository_selection": "all",
-                "action": "added",
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner.refresh_from_db()
-
-        assert owner.integration_id == installation_id
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == installation_id
-        assert installation.repository_service_ids == None
+            assert owner.integration_id == integration_id
 
     @patch("services.task.TaskService.refresh")
-    def test_installation_trigger_refresh_with_other_actions(self, refresh_mock):
+    def test_installation_events_trigger_refresh_with_other_actions(self, refresh_mock):
         owner = OwnerFactory(service=Service.GITHUB.value)
 
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 11,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "id": 11,
+                        "account": {"id": owner.service_id, "login": owner.username},
+                    },
+                    "action": "added",
+                    "sender": {"type": "User"},
                 },
-                "action": "added",
-                "sender": {"type": "User"},
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-            },
-        )
+            )
 
         refresh_mock.assert_has_calls(
             [
+                call(
+                    ownerid=owner.ownerid,
+                    username=owner.username,
+                    sync_teams=False,
+                    sync_repos=True,
+                    using_integration=True,
+                ),
                 call(
                     ownerid=owner.ownerid,
                     username=owner.username,

--- a/webhook_handlers/tests/test_github_enterprise.py
+++ b/webhook_handlers/tests/test_github_enterprise.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from codecov_auth.models import GithubAppInstallation, Owner, Service
+from codecov_auth.models import Owner, Service
 from codecov_auth.tests.factories import OwnerFactory
 from core.models import Repository
 from core.tests.factories import (
@@ -466,360 +466,137 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
         "services.task.TaskService.refresh",
         lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
     )
-    def test_installation_creates_new_owner_if_dne(self):
+    def test_installation_events_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
 
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "selected",
-                    "account": {"id": service_id, "login": username},
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "id": 4,
+                        "account": {"id": service_id, "login": username},
+                    },
+                    "sender": {"type": "User"},
                 },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "sender": {"type": "User"},
-            },
-        )
+            )
 
-        owner_set = Owner.objects.filter(
-            service=Service.GITHUB_ENTERPRISE.value,
-            service_id=service_id,
-            username=username,
-        )
+            owner = Owner.objects.filter(
+                service="github_enterprise", service_id=service_id, username=username
+            )
 
-        assert owner_set.exists()
+            assert owner.exists()
 
-        owner = owner_set.first()
+            # clear to check next event also creates
+            owner.delete()
 
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == ["12321", "12343"]
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_creates_new_owner_if_dne_all_repos(self):
-        username, service_id = "newuser", 123456
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "all",
-                    "account": {"id": service_id, "login": username},
-                },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner_set = Owner.objects.filter(
-            service=Service.GITHUB_ENTERPRISE.value,
-            service_id=service_id,
-            username=username,
-        )
-
-        assert owner_set.exists()
-
-        owner = owner_set.first()
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == None
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_repositories_creates_new_owner_if_dne(self):
-        username, service_id = "newuser", 123456
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": 4,
-                    "repository_selection": "all",
-                    "account": {"id": service_id, "login": username},
-                },
-                "repository_selection": "all",
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner_set = Owner.objects.filter(
-            service=Service.GITHUB_ENTERPRISE.value,
-            service_id=service_id,
-            username=username,
-        )
-
-        assert owner_set.exists()
-
-        owner = owner_set.first()
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == 4
-        assert installation.repository_service_ids == None
-
-    def test_installation_with_deleted_action_nulls_values(self):
+    def test_installation_events_with_deleted_action_nulls_values(self):
         # Should set integration_id to null for owner,
         # and set using_integration=False and bot=null for repos
         owner = OwnerFactory(service=Service.GITHUB_ENTERPRISE.value)
         repo1 = RepositoryFactory(author=owner)
         repo2 = RepositoryFactory(author=owner)
 
-        owner.integration_id = 12
-        owner.save()
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            owner.integration_id = 12
+            owner.save()
 
-        repo1.using_integration, repo2.using_integration = True, True
-        repo1.bot, repo2.bot = owner, owner
+            repo1.using_integration, repo2.using_integration = True, True
+            repo1.bot, repo2.bot = owner, owner
 
-        repo1.save()
-        repo2.save()
+            repo1.save()
+            repo2.save()
 
-        ghapp_installation = GithubAppInstallation(
-            installation_id=25,
-            repository_service_ids=[repo1.service_id, repo2.service_id],
-            owner=owner,
-        )
-        ghapp_installation.save()
-
-        assert owner.github_app_installations.exists()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 25,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "account": {"id": owner.service_id, "login": owner.username}
+                    },
+                    "action": "deleted",
+                    "sender": {"type": "User"},
                 },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "action": "deleted",
-                "sender": {"type": "User"},
-            },
-        )
+            )
 
-        owner.refresh_from_db()
-        repo1.refresh_from_db()
-        repo2.refresh_from_db()
+            owner.refresh_from_db()
+            repo1.refresh_from_db()
+            repo2.refresh_from_db()
 
-        assert owner.integration_id == None
-        assert repo1.using_integration == False
-        assert repo2.using_integration == False
+            assert owner.integration_id == None
+            assert repo1.using_integration == False
+            assert repo2.using_integration == False
 
-        assert repo1.bot == None
-        assert repo2.bot == None
-
-        assert not owner.github_app_installations.exists()
+            assert repo1.bot == None
+            assert repo2.bot == None
 
     @patch(
         "services.task.TaskService.refresh",
         lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
     )
-    def test_installation_repositories_update_existing_ghapp(self):
-        # Should set integration_id to null for owner,
-        # and set using_integration=False and bot=null for repos
-        owner = OwnerFactory(service=Service.GITHUB_ENTERPRISE.value)
-        repo1 = RepositoryFactory(author=owner)
-        repo2 = RepositoryFactory(author=owner)
-        installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=[repo1.service_id], installation_id=12
-        )
-
-        owner.integration_id = 12
-        owner.save()
-
-        repo1.using_integration, repo2.using_integration = True, True
-        repo1.bot, repo2.bot = owner, owner
-
-        repo1.save()
-        repo2.save()
-
-        installation.save()
-
-        assert owner.github_app_installations.exists()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": 12,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repositories_added": [{"id": repo2.service_id}],
-                "repositories_removed": [{"id": repo1.service_id}],
-                "repository_selection": "selected",
-                "action": "added",
-                "sender": {"type": "User"},
-            },
-        )
-
-        installation.refresh_from_db()
-        assert installation.installation_id == 12
-        assert installation.repository_service_ids == [repo2.service_id]
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_repositories_update_existing_ghapp_all_repos(self):
-        # Should set integration_id to null for owner,
-        # and set using_integration=False and bot=null for repos
-        owner = OwnerFactory(service=Service.GITHUB_ENTERPRISE.value)
-        repo1 = RepositoryFactory(author=owner)
-        repo2 = RepositoryFactory(author=owner)
-        installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=[repo1.service_id], installation_id=12
-        )
-
-        owner.integration_id = 12
-        owner.save()
-
-        repo1.using_integration, repo2.using_integration = True, True
-        repo1.bot, repo2.bot = owner, owner
-
-        repo1.save()
-        repo2.save()
-
-        installation.save()
-
-        assert owner.github_app_installations.exists()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": 12,
-                    "repository_selection": "all",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repositories_added": [{"id": repo2.service_id}],
-                "repositories_removed": [],
-                "repository_selection": "all",
-                "action": "deleted",
-                "sender": {"type": "User"},
-            },
-        )
-
-        installation.refresh_from_db()
-        assert installation.installation_id == 12
-        assert installation.repository_service_ids == None
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_with_other_actions_sets_owner_itegration_id_if_none(
+    def test_installation_events_with_other_actions_sets_owner_itegration_id_if_none(
         self,
     ):
-        installation_id = 44
+        integration_id = 44
         owner = OwnerFactory(service=Service.GITHUB_ENTERPRISE.value)
 
-        owner.integration_id = None
-        owner.save()
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            owner.integration_id = None
+            owner.save()
 
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": installation_id,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "id": integration_id,
+                        "account": {"id": owner.service_id, "login": owner.username},
+                    },
+                    "action": "added",
+                    "sender": {"type": "User"},
                 },
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-                "action": "added",
-                "sender": {"type": "User"},
-            },
-        )
+            )
 
-        owner.refresh_from_db()
+            owner.refresh_from_db()
 
-        assert owner.integration_id == installation_id
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == installation_id
-        assert installation.repository_service_ids == ["12321", "12343"]
-
-    @patch(
-        "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration: None,
-    )
-    def test_installation_repositories_with_other_actions_sets_owner_itegration_id_if_none(
-        self,
-    ):
-        installation_id = 44
-        owner = OwnerFactory(service=Service.GITHUB_ENTERPRISE.value)
-
-        owner.integration_id = None
-        owner.save()
-
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-            data={
-                "installation": {
-                    "id": installation_id,
-                    "repository_selection": "all",
-                    "account": {"id": owner.service_id, "login": owner.username},
-                },
-                "repository_selection": "all",
-                "action": "added",
-                "sender": {"type": "User"},
-            },
-        )
-
-        owner.refresh_from_db()
-
-        assert owner.integration_id == installation_id
-
-        ghapp_installations_set = GithubAppInstallation.objects.filter(
-            owner_id=owner.ownerid
-        )
-        assert ghapp_installations_set.count() == 1
-        installation = ghapp_installations_set.first()
-        assert installation.installation_id == installation_id
-        assert installation.repository_service_ids == None
+            assert owner.integration_id == integration_id
 
     @patch("services.task.TaskService.refresh")
-    def test_installation_trigger_refresh_with_other_actions(self, refresh_mock):
+    def test_installation_events_trigger_refresh_with_other_actions(self, refresh_mock):
         owner = OwnerFactory(service=Service.GITHUB_ENTERPRISE.value)
 
-        response = self._post_event_data(
-            event=GitHubWebhookEvents.INSTALLATION,
-            data={
-                "installation": {
-                    "id": 11,
-                    "repository_selection": "selected",
-                    "account": {"id": owner.service_id, "login": owner.username},
+        for event in [
+            GitHubWebhookEvents.INSTALLATION,
+            GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
+        ]:
+            response = self._post_event_data(
+                event=event,
+                data={
+                    "installation": {
+                        "id": 11,
+                        "account": {"id": owner.service_id, "login": owner.username},
+                    },
+                    "action": "added",
+                    "sender": {"type": "User"},
                 },
-                "action": "added",
-                "sender": {"type": "User"},
-                "repositories": [{"id": "12321"}, {"id": "12343"}],
-            },
-        )
+            )
 
         refresh_mock.assert_has_calls(
             [
+                call(
+                    ownerid=owner.ownerid,
+                    username=owner.username,
+                    sync_teams=False,
+                    sync_repos=True,
+                    using_integration=True,
+                ),
                 call(
                     ownerid=owner.ownerid,
                     username=owner.username,

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -3,7 +3,6 @@ import logging
 import re
 from contextlib import suppress
 from hashlib import sha1, sha256
-from typing import Optional
 
 from django.utils.crypto import constant_time_compare
 from rest_framework import status
@@ -13,11 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.metrics import metrics
 
-from codecov_auth.models import (
-    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-    GithubAppInstallation,
-    Owner,
-)
+from codecov_auth.models import Owner
 from core.models import Branch, Commit, Pull, Repository
 from services.archive import ArchiveService
 from services.billing import BillingService
@@ -146,10 +141,7 @@ class GithubWebhookHandler(APIView):
                     author__ownerid=owner.ownerid, service_id=repo_service_id
                 )
             except Repository.DoesNotExist:
-                default_ghapp_installation = owner.github_app_installations.filter(
-                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME
-                ).first()
-                if default_ghapp_installation or owner.integration_id:
+                if owner.integration_id:
                     log.info(
                         "Repository no found but owner is using integration, creating repository"
                     )
@@ -397,38 +389,7 @@ class GithubWebhookHandler(APIView):
 
         return Response()
 
-    def _handle_installation_repository_events(self, request, *args, **kwargs):
-        # https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation_repositories
-        service_id = request.data["installation"]["account"]["id"]
-        username = request.data["installation"]["account"]["login"]
-        owner, _ = Owner.objects.get_or_create(
-            service=self.service_name, service_id=service_id, username=username
-        )
-        installation_id = request.data["installation"]["id"]
-        ghapp_installation, _ = GithubAppInstallation.objects.get_or_create(
-            installation_id=installation_id, owner=owner
-        )
-
-        all_repos_affected = request.data.get("repository_selection") == "all"
-        if all_repos_affected:
-            ghapp_installation.repository_service_ids = None
-        else:
-            repo_list_to_save = set(ghapp_installation.repository_service_ids or [])
-            repositories_added_service_ids = set(
-                map(lambda obj: obj["id"], request.data.get("repositories_added", []))
-            )
-            repositories_removed_service_ids = set(
-                map(lambda obj: obj["id"], request.data.get("repositories_removed", []))
-            )
-            repo_list_to_save = repo_list_to_save.union(
-                repositories_added_service_ids
-            ).difference(repositories_removed_service_ids)
-            ghapp_installation.repository_service_ids = list(repo_list_to_save)
-        ghapp_installation.save()
-
-    def _handle_installation_events(
-        self, request, *args, event=GitHubWebhookEvents.INSTALLATION, **kwargs
-    ):
+    def _handle_installation_events(self, request, *args, **kwargs):
         service_id = request.data["installation"]["account"]["id"]
         username = request.data["installation"]["account"]["login"]
         action = request.data.get("action")
@@ -437,55 +398,18 @@ class GithubWebhookHandler(APIView):
             service=self.service_name, service_id=service_id, username=username
         )
 
-        installation_id = request.data["installation"]["id"]
-
-        # TODO: Consider adding "suspend" action here?
-        # https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation
         if action == "deleted":
-
-            if event == GitHubWebhookEvents.INSTALLATION:
-                ghapp_installation: Optional[
-                    GithubAppInstallation
-                ] = owner.github_app_installations.filter(
-                    installation_id=installation_id
-                ).first()
-                if ghapp_installation is not None:
-                    ghapp_installation.delete()
-            # Deprecated flow - BEGIN
             owner.integration_id = None
             owner.save()
             owner.repository_set.all().update(using_integration=False, bot=None)
-            # Deprecated flow - END
             log.info(
                 "Owner deleted app integration",
                 extra=dict(ownerid=owner.ownerid, github_webhook_event=self.event),
             )
         else:
-            # GithubWebhookEvents.INSTALLTION_REPOSITORIES also execute this code
-            # because of deprecated flow. But the GithubAppInstallation shouldn't be changed
-            if event == GitHubWebhookEvents.INSTALLATION:
-                ghapp_installation, _ = GithubAppInstallation.objects.get_or_create(
-                    installation_id=installation_id, owner=owner
-                )
-                affects_all_repositories = (
-                    request.data["installation"]["repository_selection"] == "all"
-                )
-                if affects_all_repositories:
-                    ghapp_installation.repository_service_ids = None
-                else:
-                    repositories_service_ids = list(
-                        map(lambda obj: obj["id"], request.data.get("repositories", []))
-                    )
-                    ghapp_installation.repository_service_ids = repositories_service_ids
-                ghapp_installation.save()
-
-            # This flow is deprecated and should be removed once the
-            # work on github app integration model is complete and backfilled
-            # Deprecated flow - BEGIN
             if owner.integration_id is None:
                 owner.integration_id = request.data["installation"]["id"]
                 owner.save()
-            # Deprecated flow - END
 
             log.info(
                 "Triggering refresh task to sync repos",
@@ -504,21 +428,11 @@ class GithubWebhookHandler(APIView):
 
     def installation(self, request, *args, **kwargs):
         _incr_event(GitHubWebhookEvents.INSTALLATION)
-        return self._handle_installation_events(
-            request, *args, **kwargs, event=GitHubWebhookEvents.INSTALLATION
-        )
+        return self._handle_installation_events(request, *args, **kwargs)
 
     def installation_repositories(self, request, *args, **kwargs):
         _incr_event(GitHubWebhookEvents.INSTALLATION_REPOSITORIES)
-        self._handle_installation_repository_events(request, *args, **kwargs)
-        # This is kept to preserve the logic for deprecated usage of owner.installation_id
-        # It can be removed once the move to codecov_auth.GithubAppInstallation is complete
-        return self._handle_installation_events(
-            request,
-            *args,
-            **kwargs,
-            event=GitHubWebhookEvents.INSTALLATION_REPOSITORIES,
-        )
+        return self._handle_installation_events(request, *args, **kwargs)
 
     def organization(self, request, *args, **kwargs):
         action = request.data.get("action")


### PR DESCRIPTION
This reverts commit 86178ba3e3a4f1f57cd0e957c25d5979766376b6.

This commit caused auth issues with `/graphql` endpoint in which users were not authenticated and couldn't see source code.

Revertign for now while we figure out the exact issue and fix it.

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
