### PR TITLE
fix: use timestamp of commit instead of updatestamp in get_or_update_branch_head

### DIFF
--- a/utils/temp_branch_fix.py
+++ b/utils/temp_branch_fix.py
@@ -14,7 +14,7 @@ def get_or_update_branch_head(
         commit = (
             commits.filter(branch=branch.name, repository_id=repoid)
             .defer("_report")
-            .order_by("-updatestamp")
+            .order_by("-timestamp")
             .first()
         )
 


### PR DESCRIPTION
### Purpose/Motivation
`timestamp` is the field which we were using before to decide if a commit was to be branch's head or not. The issue with ordering by `updatestamp` is that `updatestamp` is nullable which leads to incorrect behaviour where we may pick a commit from very long ago to be the branch head. 

### What does this PR do?
- order by timestamp descending instead of updatestamp descending
