### PR TITLE
feat(gazebo-previews): update CORS header for API to allow our self-hosted previews

### DIFF
--- a/codecov/settings_staging.py
+++ b/codecov/settings_staging.py
@@ -35,6 +35,7 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^(https:\/\/)?deploy-preview-\d+--gazebo\.netlify\.app$",
     r"^(https:\/\/)?deploy-preview-\d+--gazebo-staging\.netlify\.app$",
     r"^(https:\/\/)?\w+--gazebo\.netlify\.app$",
+    r"^(https:\/\/)?preview-[\w\d\-]+\.codecov\.dev$",
 ]
 CORS_ALLOW_CREDENTIALS = True
 


### PR DESCRIPTION
https://github.com/codecov/infrastructure-team/issues/174


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
