### PR TITLE
feat: support force flag in empty upload endpoint:

### DIFF
--- a/upload/tests/views/test_empty_upload.py
+++ b/upload/tests/views/test_empty_upload.py
@@ -249,6 +249,44 @@ def test_empty_upload_with_testable_file_with_force(
 @patch("services.task.TaskService.notify")
 @patch("upload.views.empty_upload.final_commit_yaml")
 @patch("services.repo_providers.RepoProviderService.get_adapter")
+def test_empty_upload_with_testable_file_invalid_serializer(
+    mock_repo_provider_service, mock_final_yaml, notify_mock, db, mocker
+):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+    mock_final_yaml.return_value = UserYaml(
+        {"ignore": ["file.py", "another_file.py", "README.md"]}
+    )
+    mock_repo_provider_service.return_value = MockedProviderAdapter(
+        ["README.md", "codecov.yml", "template.txt", "base.py"]
+    )
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    repository.save()
+    commit.save()
+
+    owner = repository.author
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse(
+        "new_upload.empty_upload",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(url, data={"should_force": "hello world"})
+    response_json = response.json()
+    assert response.status_code == 400
+
+
+@patch("services.task.TaskService.notify")
+@patch("upload.views.empty_upload.final_commit_yaml")
+@patch("services.repo_providers.RepoProviderService.get_adapter")
 def test_empty_upload_no_changed_files_in_pr(
     mock_repo_provider_service, mock_final_yaml, notify_mock, db, mocker
 ):


### PR DESCRIPTION
### Purpose/Motivation
Users may want to bypass the files check of the empty upload endpoint and force a passing notification

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1015
CLI change: https://github.com/codecov/codecov-cli/pull/362

### What does this PR do?
Accepts a should_force boolean field in the data for this endpoint, if it's true then we send a passing notification else we do the regular behaviour of this endpoint
