### PR TITLE
feat: add email to the stripe customer serializer

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -99,6 +99,7 @@ class StripeDiscountSerializer(serializers.Serializer):
 class StripeCustomerSerializer(serializers.Serializer):
     id = serializers.CharField()
     discount = StripeDiscountSerializer()
+    email = serializers.CharField()
 
 
 class StripeCardSerializer(serializers.Serializer):

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -31,6 +31,7 @@ class MockSubscription(object):
             },
             "id": "cus_LK&*Hli8YLIO",
             "discount": None,
+            "email": None,
         }
         self.schedule = subscription_params["schedule_id"]
         self.collection_method = subscription_params["collection_method"]
@@ -240,7 +241,7 @@ class AccountViewSetTests(APITestCase):
                 "default_payment_method": None,
                 "cancel_at_period_end": False,
                 "current_period_end": 1633512445,
-                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None},
+                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
                 "collection_method": "charge_automatically",
                 "trial_end": None,
             },
@@ -340,10 +341,7 @@ class AccountViewSetTests(APITestCase):
                 "default_payment_method": None,
                 "cancel_at_period_end": False,
                 "current_period_end": 1633512445,
-                "customer": {
-                    "id": "cus_LK&*Hli8YLIO",
-                    "discount": None,
-                },
+                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
                 "collection_method": "charge_automatically",
                 "trial_end": 1633512445,
             },
@@ -414,10 +412,7 @@ class AccountViewSetTests(APITestCase):
                 "default_payment_method": None,
                 "cancel_at_period_end": False,
                 "current_period_end": 1633512445,
-                "customer": {
-                    "id": "cus_LK&*Hli8YLIO",
-                    "discount": None,
-                },
+                "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
                 "collection_method": "charge_automatically",
                 "trial_end": None,
             },
@@ -590,10 +585,7 @@ class AccountViewSetTests(APITestCase):
                     "last4": "abcd",
                 }
             },
-            "customer": {
-                "id": "cus_LK&*Hli8YLIO",
-                "discount": None,
-            },
+            "customer": {"id": "cus_LK&*Hli8YLIO", "discount": None, "email": None},
             "collection_method": "charge_automatically",
             "trial_end": None,
         }


### PR DESCRIPTION
### Purpose/Motivation
Forgot to add this when making the API ticket to change the billing email from the client

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
