### PR TITLE
fix: apply temp branch fix to all branches

### DIFF
--- a/api/public/v2/tests/test_report_viewset.py
+++ b/api/public/v2/tests/test_report_viewset.py
@@ -94,11 +94,14 @@ class ReportViewSetTestCase(TestCase):
             organizations=[self.org.ownerid],
             permission=[self.repo.repoid],
         )
-        self.commit1 = CommitFactory(
+        # the order in which these commits are created matters
+        # because the branch head is the one that is created
+        # later
+        self.commit2 = CommitFactory(
             author=self.org,
             repository=self.repo,
         )
-        self.commit2 = CommitFactory(
+        self.commit1 = CommitFactory(
             author=self.org,
             repository=self.repo,
         )

--- a/api/public/v2/tests/test_totals_viewset.py
+++ b/api/public/v2/tests/test_totals_viewset.py
@@ -78,11 +78,14 @@ class TotalsViewSetTestCase(TestCase):
             organizations=[self.org.ownerid],
             permission=[self.repo.repoid],
         )
-        self.commit1 = CommitFactory(
+        # the order in which these commits are created matters
+        # because the branch head is the one that is created
+        # later
+        self.commit2 = CommitFactory(
             author=self.org,
             repository=self.repo,
         )
-        self.commit2 = CommitFactory(
+        self.commit1 = CommitFactory(
             author=self.org,
             repository=self.repo,
         )

--- a/graphql_api/types/branch/branch.py
+++ b/graphql_api/types/branch/branch.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from ariadne import ObjectType
 
+from codecov.db import sync_to_async
+
 from core.models import Branch, Commit
 from graphql_api.dataloader.commit import CommitLoader
 from utils.temp_branch_fix import get_or_update_branch_head
@@ -10,14 +12,17 @@ branch_bindable = ObjectType("Branch")
 
 
 @branch_bindable.field("headSha")
+@sync_to_async
 def resolve_head_sha(branch: Branch, info) -> str:
     head = get_or_update_branch_head(Commit.objects, branch, branch.repository_id)
     return head
 
 
 @branch_bindable.field("head")
-def resolve_head_commit(branch: Branch, info) -> Optional[Commit]:
-    head = get_or_update_branch_head(Commit.objects, branch, branch.repository_id)
+async def resolve_head_commit(branch: Branch, info) -> Optional[Commit]:
+    head = await sync_to_async(get_or_update_branch_head)(
+        Commit.objects, branch, branch.repository_id
+    )
     if head:
         loader = CommitLoader.loader(info, branch.repository_id)
-        return loader.load(head)
+        return await loader.load(head)

--- a/graphql_api/types/branch/branch.py
+++ b/graphql_api/types/branch/branch.py
@@ -3,7 +3,6 @@ from typing import Optional
 from ariadne import ObjectType
 
 from codecov.db import sync_to_async
-
 from core.models import Branch, Commit
 from graphql_api.dataloader.commit import CommitLoader
 from utils.temp_branch_fix import get_or_update_branch_head

--- a/graphs/tests/test_badge_handler.py
+++ b/graphs/tests/test_badge_handler.py
@@ -699,7 +699,7 @@ class TestBadgeHandler(APITestCase):
             "s": 1,
         }
         commit_2 = CommitFactory(
-            commitid="81c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8s",
+            commitid="b1c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8",
             repository=repo,
             author=gh_owner,
             totals=commit_2_totals,
@@ -708,7 +708,7 @@ class TestBadgeHandler(APITestCase):
             repository=repo, name="branch1", head=commit_2.commitid
         )
         commit_3 = CommitFactory(
-            commitid="a1c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8s",
+            commitid="a1c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8",
             repository=repo,
             author=gh_owner,
             totals=commit_3_totals,
@@ -754,7 +754,7 @@ class TestBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
         branch_2.refresh_from_db()
-        assert branch_2.head == "a1c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8s"
+        assert branch_2.head == "a1c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8"
 
     def test_badge_with_100_coverage(self):
         gh_owner = OwnerFactory(service="github")

--- a/utils/temp_branch_fix.py
+++ b/utils/temp_branch_fix.py
@@ -6,33 +6,25 @@ def get_or_update_branch_head(
     branch,
     repoid,
 ):
-    # there was a bug that set a large number of branch heads to these two shas, so we are rectifying that issue here
-    if (
-        branch.head == "81c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8"
-        or branch.head == "9587100eacc554aa9c03422e28b269c551dc1a72"
-    ):
-        commit = (
-            commits.filter(branch=branch.name, repository_id=repoid)
-            .defer("_report")
-            .order_by("-timestamp")
-            .first()
+    commit = (
+        commits.filter(branch=branch.name, repository_id=repoid)
+        .defer("_report")
+        .order_by("-timestamp")
+        .first()
+    )
+
+    if commit is None or commit.commitid == branch.head:
+        return branch.head
+
+    # using this raw sql because the current branches table does not allow for updating based on repoid
+    # it only updates based on branch name which means if we were to use the django orm to update this
+    # branch.head, all branches with the same name as the one we are trying to update would have their head
+    # updated to the value of this ones head
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "UPDATE branches SET head = %s WHERE branches.repoid = %s AND branches.branch = %s",
+            [commit.commitid, repoid, branch.name],
         )
 
-        if commit is None:
-            return branch.head
-
-        # using this raw sql because the current branches table does not allow for updating based on repoid
-        # it only updates based on branch name which means if we were to use the django orm to update this
-        # branch.head, all branches with the same name as the one we are trying to update would have their head
-        # updated to the value of this ones head
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "UPDATE branches SET head = %s WHERE branches.repoid = %s AND branches.branch = %s",
-                [commit.commitid, repoid, branch.name],
-            )
-
-        commit_sha = commit.commitid
-        return commit_sha
-
-    else:
-        return branch.head
+    commit_sha = commit.commitid
+    return commit_sha

--- a/utils/temp_branch_fix.py
+++ b/utils/temp_branch_fix.py
@@ -8,7 +8,7 @@ def get_or_update_branch_head(
 ):
     # there was a bug that set a large number of branch heads to these two shas, so we are rectifying that issue here
     if (
-        branch.head == "81c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8s"
+        branch.head == "81c2b4fa3ae9ef615c8f740c5cba95d9851f9ae8"
         or branch.head == "9587100eacc554aa9c03422e28b269c551dc1a72"
     ):
         commit = (


### PR DESCRIPTION
### Purpose/Motivation
We want to apply this fix to all branches, not just branches that have the name `master` or `main`

### What does this PR do?
- removed the check for the commit sha in the temp branch fix
- add a check to exit the function early if the branch head matches the latest commit
