### PR TITLE
feat: add back uses invoice checkbox

### DIFF
--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.models import LogEntry
 from django.db.models.fields import BLANK_CHOICE_DASH
-from django.forms import Select
+from django.forms import CheckboxInput, Select
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.utils.html import format_html
@@ -234,6 +234,7 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
         "plan_provider",
         "plan_user_count",
         "plan_activated_users",
+        "uses_invoice",
         "integration_id",
         "bot",
         "stripe_customer_id",
@@ -248,6 +249,7 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
         form.base_fields["plan"].widget = Select(
             choices=BLANK_CHOICE_DASH + PLANS_CHOICES
         )
+        form.base_fields["uses_invoice"].widget = CheckboxInput()
 
         is_superuser = request.user.is_superuser
 


### PR DESCRIPTION
### Purpose/Motivation
We are adding back the uses_invoice checkbox in the admin

### What does this PR do?
- Adds the uses_invoice field back to the serializer
- Creates the checkbox input for the uses invoice field