### PR TITLE
fix: remove branch.refresh_from_db from branch serializer

### DIFF
--- a/api/public/v2/branch/serializers.py
+++ b/api/public/v2/branch/serializers.py
@@ -20,11 +20,12 @@ class BranchDetailSerializer(BranchSerializer):
     )
 
     def get_head_commit(self, branch: Branch) -> CommitDetailSerializer:
-        _ = get_or_update_branch_head(Commit.objects, branch, branch.repository_id)
-        branch.refresh_from_db()
+        branch_head = get_or_update_branch_head(
+            Commit.objects, branch, branch.repository_id
+        )
         commit = (
             Commit.objects.filter(
-                repository_id=branch.repository_id, commitid=branch.head
+                repository_id=branch.repository_id, commitid=branch_head
             )
             .defer("_report")
             .first()


### PR DESCRIPTION
### Purpose/Motivation
using `refresh_from_db` on a branch object causes a similar issue as trying to update a branch object and saving using the django orm due to the primary key of the django model only being part of the actual composite primary key of the postgres table

### Links to relevant tickets
[Relevant ticket](https://codecov.sentry.io/discover/api:9e20c3ff8fa54786822981e267c7530e/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=5215654&query=http.url%3Ahttp%3A%2F%2Fapi.codecov.io%2Fapi%2Fv2%2Fgithub%2Fcodecov%2Frepos%2Fcodecov-demo%2Fbranches%2Fmain%2F+event.type%3Aerror&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29)
 
### What does this PR do?
- remove call to `branch.refresh_from_db`
- replace by using value of branch head returned by `get_or_update_branch_head`
