### PR TITLE
fix: handle no uploads check

### DIFF
--- a/graphql_api/dataloader/bundle_analysis.py
+++ b/graphql_api/dataloader/bundle_analysis.py
@@ -46,4 +46,8 @@ def load_bundle_analysis_report(commit: Commit) -> BundleAnalysisReport:
         storage_service=get_appropriate_storage_service(),
         repo_key=ArchiveService.get_archive_hash(commit.repository),
     )
-    return BundleAnalysisReport(loader.load(report.external_id))
+    report = loader.load(report.external_id)
+    if report is None:
+        return MissingHeadReport()
+
+    return BundleAnalysisReport(report)

--- a/graphql_api/dataloader/tests/test_bundle_analysis.py
+++ b/graphql_api/dataloader/tests/test_bundle_analysis.py
@@ -83,6 +83,11 @@ class MockReportLoader:
         return True
 
 
+class MockReportLoaderTwo:
+    def load(self, external_id):
+        return None
+
+
 class BundleAnalysisReportLoader(TransactionTestCase):
     def setUp(self):
         self.repo = RepositoryFactory()
@@ -99,6 +104,12 @@ class BundleAnalysisReportLoader(TransactionTestCase):
         mock_report.return_value = True
         loader = load_bundle_analysis_report(self.commit)
         assert loader == True
+
+    @patch("graphql_api.dataloader.bundle_analysis.BundleAnalysisReportLoader")
+    def test_loader_missing_head_report_two(self, mock_loader):
+        mock_loader.return_value = MockReportLoaderTwo()
+        loader = load_bundle_analysis_report(self.commit)
+        assert loader.message == MissingHeadReport.message
 
     def test_loader_missing_head_report(self):
         head_commit = CommitFactory(repository=self.repo)

--- a/graphql_api/dataloader/tests/test_bundle_analysis.py
+++ b/graphql_api/dataloader/tests/test_bundle_analysis.py
@@ -80,7 +80,7 @@ class BundleAnalysisComparisonLoader(TransactionTestCase):
 
 class MockReportLoader:
     def load(self, external_id):
-        return None
+        return True
 
 
 class BundleAnalysisReportLoader(TransactionTestCase):

--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -916,36 +916,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
             "message": "Missing head report",
         }
 
-    def test_bundle_analysis_missing_report_two(self):
-        # Has commit report, but no SQLite file in the DB
-        CommitReportFactory(
-            commit=self.commit, report_type=CommitReport.ReportType.BUNDLE_ANALYSIS
-        )
-
-        query = (
-            query_commit
-            % """
-            bundleAnalysisReport {
-                __typename
-                ... on MissingHeadReport {
-                    message
-                }
-            }
-            """
-        )
-        variables = {
-            "org": self.org.username,
-            "repo": self.repo.name,
-            "commit": self.commit.commitid,
-        }
-        data = self.gql_request(query, variables=variables)
-        commit = data["owner"]["repository"]["commit"]
-
-        assert commit["bundleAnalysisReport"] == {
-            "__typename": "MissingHeadReport",
-            "message": "Missing head report",
-        }
-
     @patch("graphql_api.dataloader.bundle_analysis.get_appropriate_storage_service")
     def test_bundle_analysis_report(self, get_storage_service):
         storage = MemoryStorageService({})

--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -916,6 +916,36 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
             "message": "Missing head report",
         }
 
+    def test_bundle_analysis_missing_report_two(self):
+        # Has commit report, but no SQLite file in the DB
+        CommitReportFactory(
+            commit=self.commit, report_type=CommitReport.ReportType.BUNDLE_ANALYSIS
+        )
+
+        query = (
+            query_commit
+            % """
+            bundleAnalysisReport {
+                __typename
+                ... on MissingHeadReport {
+                    message
+                }
+            }
+            """
+        )
+        variables = {
+            "org": self.org.username,
+            "repo": self.repo.name,
+            "commit": self.commit.commitid,
+        }
+        data = self.gql_request(query, variables=variables)
+        commit = data["owner"]["repository"]["commit"]
+
+        assert commit["bundleAnalysisReport"] == {
+            "__typename": "MissingHeadReport",
+            "message": "Missing head report",
+        }
+
     @patch("graphql_api.dataloader.bundle_analysis.get_appropriate_storage_service")
     def test_bundle_analysis_report(self, get_storage_service):
         storage = MemoryStorageService({})


### PR DESCRIPTION
### Purpose/Motivation

Handle the case when commit report is created, but can't load report for some reason (eg upload failed)

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/1139

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
