### PR TITLE
fix: Update available plan to remove trial condition

### DIFF
--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -849,62 +849,6 @@ class AccountViewSetTests(APITestCase):
             == "Quantity or plan for paid plan must be different from the existing one"
         )
 
-    def test_update_team_plan_must_fail_if_not_trialing(self):
-        self.current_owner.plan = PlanName.BASIC_PLAN_NAME.value
-        self.current_owner.plan_user_count = 1
-        self.current_owner.trial_status = TrialStatus.NOT_STARTED
-        self.current_owner.save()
-        desired_plans = [
-            {"value": PlanName.TEAM_MONTHLY.value, "quantity": 1},
-            {"value": PlanName.TEAM_YEARLY.value, "quantity": 1},
-        ]
-
-        for desired_plan in desired_plans:
-            response = self._update(
-                kwargs={
-                    "service": self.current_owner.service,
-                    "owner_username": self.current_owner.username,
-                },
-                data={"plan": desired_plan},
-            )
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert response.json() == {
-                "plan": {
-                    "value": [
-                        f"Invalid value for plan: {desired_plan['value']}; must be one of ['users-basic', 'users-pr-inappm', 'users-pr-inappy']"
-                    ]
-                }
-            }
-
-    def test_update_team_plan_must_fail_if_cannot_trial(self):
-        self.current_owner.plan = PlanName.BASIC_PLAN_NAME.value
-        self.current_owner.plan_user_count = 1
-        self.current_owner.trial_status = TrialStatus.CANNOT_TRIAL
-        self.current_owner.save()
-        desired_plans = [
-            {"value": PlanName.TEAM_MONTHLY.value, "quantity": 1},
-            {"value": PlanName.TEAM_YEARLY.value, "quantity": 1},
-        ]
-
-        for desired_plan in desired_plans:
-            response = self._update(
-                kwargs={
-                    "service": self.current_owner.service,
-                    "owner_username": self.current_owner.username,
-                },
-                data={"plan": desired_plan},
-            )
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert response.json() == {
-                "plan": {
-                    "value": [
-                        f"Invalid value for plan: {desired_plan['value']}; must be one of ['users-basic', 'users-pr-inappm', 'users-pr-inappy']"
-                    ]
-                }
-            }
-
     def test_update_team_plan_must_fail_if_too_many_activated_users_during_trial(self):
         self.current_owner.plan = PlanName.BASIC_PLAN_NAME.value
         self.current_owner.plan_user_count = 1
@@ -975,13 +919,10 @@ class AccountViewSetTests(APITestCase):
             )
 
             assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert response.json() == {
-                "plan": {
-                    "value": [
-                        f"Invalid value for plan: {desired_plan['value']}; must be one of ['users-basic', 'users-pr-inappm', 'users-pr-inappy']"
-                    ]
-                }
-            }
+            assert (
+                response.data["plan"]["non_field_errors"][0]
+                == "Quantity for Team plan cannot exceed 10"
+            )
 
     def test_update_quantity_must_be_at_least_2_if_paid_plan(self):
         desired_plan = {"value": PlanName.CODECOV_PRO_YEARLY.value, "quantity": 1}
@@ -1285,7 +1226,7 @@ class AccountViewSetTests(APITestCase):
         assert res.json() == {
             "plan": {
                 "value": [
-                    "Invalid value for plan: users-sentrym; must be one of ['users-basic', 'users-pr-inappm', 'users-pr-inappy']"
+                    "Invalid value for plan: users-sentrym; must be one of ['users-basic', 'users-pr-inappm', 'users-pr-inappy', 'users-teamm', 'users-teamy']"
                 ]
             }
         }

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -551,6 +551,8 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
             {"planName": "users-basic"},
             {"planName": "users-pr-inappm"},
             {"planName": "users-pr-inappy"},
+            {"planName": "users-teamm"},
+            {"planName": "users-teamy"},
         ]
 
     def test_owner_query_with_no_service(self):

--- a/plan/service.py
+++ b/plan/service.py
@@ -126,18 +126,12 @@ class PlanService:
         if owner and sentry.is_sentry_user(owner=owner):
             available_plans += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
 
-        # If user is already in team plan or is/have trialed
-        if (
-            self.plan_name in TEAM_PLAN_REPRESENTATIONS
-            or self.trial_status == TrialStatus.EXPIRED.value
-            or self.trial_status == TrialStatus.ONGOING.value
-        ):
             # If number of activated users is less than or equal to TEAM_PLAN_MAX_USERS
-            if (
-                self.plan_activated_users is None
-                or len(self.plan_activated_users) <= TEAM_PLAN_MAX_USERS
-            ):
-                available_plans += TEAM_PLAN_REPRESENTATIONS.values()
+        if (
+            self.plan_activated_users is None
+            or len(self.plan_activated_users) <= TEAM_PLAN_MAX_USERS
+        ):
+            available_plans += TEAM_PLAN_REPRESENTATIONS.values()
 
         return available_plans
 

--- a/plan/test_plan.py
+++ b/plan/test_plan.py
@@ -347,6 +347,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result = []
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result += TEAM_PLAN_REPRESENTATIONS.values()
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -362,6 +363,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result.append(FREE_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result += TEAM_PLAN_REPRESENTATIONS.values()
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -389,6 +391,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result = []
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result += TEAM_PLAN_REPRESENTATIONS.values()
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -406,6 +409,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result += TEAM_PLAN_REPRESENTATIONS.values()
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -439,6 +443,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result += TEAM_PLAN_REPRESENTATIONS.values()
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -693,6 +698,7 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
         self.expected_result = []
         self.expected_result.append(BASIC_PLAN)
         self.expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
+        self.expected_result += TEAM_PLAN_REPRESENTATIONS.values()
         assert (
             self.plan_service.available_plans(owner=self.owner) == self.expected_result
         )


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
We want to roll out the team plan to all orgs that has less than 11 activated users.  

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1122

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.
- Remove trial conditions to serve this plan to basic and free users 
- Fix tests 

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
