### PR TITLE
add manual trigger option when clicking sync repos

### DIFF
--- a/codecov_auth/commands/owner/interactors/tests/test_trigger_sync.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_trigger_sync.py
@@ -22,5 +22,8 @@ class IsSyncingInteractorTest(TransactionTestCase):
     async def test_call_is_refreshing(self, mock_trigger_refresh):
         await TriggerSyncInteractor(self.owner, "github").execute()
         mock_trigger_refresh.assert_called_once_with(
-            self.owner.ownerid, self.owner.username, using_integration=False, manual_trigger=True
+            self.owner.ownerid,
+            self.owner.username,
+            using_integration=False,
+            manual_trigger=True,
         )

--- a/codecov_auth/commands/owner/interactors/tests/test_trigger_sync.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_trigger_sync.py
@@ -22,5 +22,5 @@ class IsSyncingInteractorTest(TransactionTestCase):
     async def test_call_is_refreshing(self, mock_trigger_refresh):
         await TriggerSyncInteractor(self.owner, "github").execute()
         mock_trigger_refresh.assert_called_once_with(
-            self.owner.ownerid, self.owner.username, using_integration=False
+            self.owner.ownerid, self.owner.username, using_integration=False, manual_trigger=True
         )

--- a/codecov_auth/commands/owner/interactors/trigger_sync.py
+++ b/codecov_auth/commands/owner/interactors/trigger_sync.py
@@ -16,4 +16,5 @@ class TriggerSyncInteractor(BaseInteractor):
             self.current_owner.ownerid,
             self.current_owner.username,
             using_integration=False,
+            manual_trigger=True,
         )

--- a/services/refresh.py
+++ b/services/refresh.py
@@ -39,11 +39,12 @@ class RefreshService(object):
         sync_teams=True,
         sync_repos=True,
         using_integration=False,
+        manual_trigger=False,
     ):
         if self.is_refreshing(ownerid):
             return
         resp = self.task_service.refresh(
-            ownerid, username, sync_repos, sync_teams, using_integration
+            ownerid, username, sync_repos, sync_teams, using_integration, manual_trigger
         )
         # store in redis the task data to be used for `is_refreshing` logic
         self.redis.setex(self._get_key_name(ownerid), 900, dumps(resp.as_tuple()))

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -200,6 +200,7 @@ class TaskService(object):
         sync_teams=True,
         sync_repos=True,
         using_integration=False,
+        manual_trigger=False,
     ):
         """
         Send sync_teams and/or sync_repos task message
@@ -228,6 +229,7 @@ class TaskService(object):
                         ownerid=ownerid,
                         username=username,
                         using_integration=using_integration,
+                        manual_trigger=manual_trigger,
                     ),
                 )
             )


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Use the `manual_trigger` option when clicking the sync repos button in the UI, this will get propagated to sync languages task to reach out to GH for languages.

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/961

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
