### PR TITLE
feat: measure uploads using sentry metrics

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ python-redis-lock
 pytz
 redis
 requests
-sentry-sdk
+sentry-sdk>=1.40.0
 setproctitle
 simplejson
 stripe

--- a/requirements.txt
+++ b/requirements.txt
@@ -367,7 +367,7 @@ rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
     # via boto3
-sentry-sdk==1.39.1
+sentry-sdk==1.40.4
     # via -r requirements.in
 setproctitle==1.1.10
     # via -r requirements.in

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -175,9 +175,7 @@ def parse_params(data):
                     else (
                         value[7:]
                         if value[:7] == "origin/"
-                        else value[11:]
-                        if value[:11] == "refs/heads/"
-                        else value
+                        else value[11:] if value[:11] == "refs/heads/" else value
                     )
                 ),
             ),
@@ -753,6 +751,7 @@ def validate_activated_repo(repository):
         )
 
 
+# headers["User-Agent"] should look something like this: codecov-cli/0.4.7 or codecov-uploader/0.7.1
 def get_agent_from_headers(headers):
     try:
         return headers["User-Agent"].split("/")[0].split("-")[1]
@@ -763,7 +762,7 @@ def get_agent_from_headers(headers):
                 err=str(e),
             ),
         )
-        return "unsupported-user-agent"
+        return "unknown-user-agent"
 
 
 def get_version_from_headers(headers):
@@ -777,7 +776,7 @@ def get_version_from_headers(headers):
                 err=str(e),
             ),
         )
-        return "unsupported-user-agent"
+        return "unknown-user-agent"
 
 
 def generate_upload_sentry_metrics_tags(

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -65,14 +65,16 @@ def parse_params(data):
             "type": "string",
             "nullable": True,
             "default_setter": (
-                lambda document: document.get("slug")
-                .rsplit("/", 1)[0]
-                .replace(
-                    "/", ":"
-                )  # we use ':' as separator for gitlab subgroups internally
-                if document.get("slug")
-                and len(document.get("slug").rsplit("/", 1)) == 2
-                else None
+                lambda document: (
+                    document.get("slug")
+                    .rsplit("/", 1)[0]
+                    .replace(
+                        "/", ":"
+                    )  # we use ':' as separator for gitlab subgroups internally
+                    if document.get("slug")
+                    and len(document.get("slug").rsplit("/", 1)) == 2
+                    else None
+                )
             ),
         },
         # repo name, we set this by parsing the value of "slug" if provided
@@ -80,10 +82,12 @@ def parse_params(data):
             "type": "string",
             "nullable": True,
             "default_setter": (
-                lambda document: document.get("slug").rsplit("/", 1)[1]
-                if document.get("slug")
-                and len(document.get("slug").rsplit("/", 1)) == 2
-                else None
+                lambda document: (
+                    document.get("slug").rsplit("/", 1)[1]
+                    if document.get("slug")
+                    and len(document.get("slug").rsplit("/", 1)) == 2
+                    else None
+                )
             ),
         },
         # indicates whether the token provided is a global upload token rather than a repository upload token
@@ -91,9 +95,11 @@ def parse_params(data):
         "using_global_token": {
             "type": "boolean",
             "default_setter": (
-                lambda document: True
-                if document.get("token") and document.get("token") in global_tokens
-                else False
+                lambda document: (
+                    True
+                    if document.get("token") and document.get("token") in global_tokens
+                    else False
+                )
             ),
         },
         # --- The following parameters are expected to be provided in the upload request.
@@ -126,9 +132,11 @@ def parse_params(data):
                 lambda value: "travis" if value == "travis-org" else value,
             ),  # if "travis-org" was passed as the service rename it to "travis" before validating
             "default_setter": (
-                lambda document: global_tokens[document.get("token")]
-                if document.get("using_global_token")
-                else None
+                lambda document: (
+                    global_tokens[document.get("token")]
+                    if document.get("using_global_token")
+                    else None
+                )
             ),
         },
         # pull request number
@@ -149,9 +157,9 @@ def parse_params(data):
             "regex": r"^(\d+|false|null|undefined|true)$",
             "nullable": True,
             "coerce": (
-                lambda value: None
-                if value in ["false", "null", "undefined", "true"]
-                else value
+                lambda value: (
+                    None if value in ["false", "null", "undefined", "true"] else value
+                )
             ),
         },
         "build_url": {"type": "string", "regex": r"^https?\:\/\/(.{,200})"},
@@ -160,14 +168,18 @@ def parse_params(data):
             "type": "string",
             "nullable": True,
             "coerce": (
-                lambda value: None
-                if value == "HEAD"
-                # if prefixed with "origin/" or "refs/heads", the prefix will be removed
-                else value[7:]
-                if value[:7] == "origin/"
-                else value[11:]
-                if value[:11] == "refs/heads/"
-                else value,
+                lambda value: (
+                    None
+                    if value == "HEAD"
+                    # if prefixed with "origin/" or "refs/heads", the prefix will be removed
+                    else (
+                        value[7:]
+                        if value[:7] == "origin/"
+                        else value[11:]
+                        if value[:11] == "refs/heads/"
+                        else value
+                    )
+                ),
             ),
         },
         "tag": {"type": "string"},
@@ -183,9 +195,9 @@ def parse_params(data):
             "type": "string",
             "nullable": True,
             "coerce": (
-                lambda value: None
-                if value in ["null", "undefined", "none", "nil"]
-                else value
+                lambda value: (
+                    None if value in ["null", "undefined", "none", "nil"] else value
+                )
             ),
         },
         "name": {"type": "string"},
@@ -739,3 +751,42 @@ def validate_activated_repo(repository):
         raise ValidationError(
             f"This repository has been deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings_url}"
         )
+
+
+def get_agent_from_headers(headers):
+    try:
+        return headers["User-Agent"].split("/")[0].split("-")[1]
+    except Exception as e:
+        log.warning(
+            "Error getting agent from user agent header",
+            extra=dict(
+                err=str(e),
+            ),
+        )
+        return "unsupported-user-agent"
+
+
+def get_version_from_headers(headers):
+
+    try:
+        return headers["User-Agent"].split("/")[1]
+    except Exception as e:
+        log.warning(
+            "Error getting version from user agent header",
+            extra=dict(
+                err=str(e),
+            ),
+        )
+        return "unsupported-user-agent"
+
+
+def generate_upload_sentry_metrics_tags(
+    action, request, repository, is_shelter_request
+):
+    return dict(
+        agent=get_agent_from_headers(request.headers),
+        version=get_version_from_headers(request.headers),
+        action=action,
+        repo_visibility="private" if repository.private is True else "public",
+        is_using_shelter="yes" if is_shelter_request else "no",
+    )

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -175,7 +175,9 @@ def parse_params(data):
                     else (
                         value[7:]
                         if value[:7] == "origin/"
-                        else value[11:] if value[:11] == "refs/heads/" else value
+                        else value[11:]
+                        if value[:11] == "refs/heads/"
+                        else value
                     )
                 ),
             ),

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -433,6 +433,7 @@ def test_uploads_post_shelter(db, mocker, mock_redis):
     upload_task_mock = mocker.patch(
         "upload.views.uploads.UploadViews.trigger_upload_task", return_value=True
     )
+    mock_sentry_metrics = mocker.patch("upload.views.uploads.sentry_metrics.incr")
 
     repository = RepositoryFactory(
         name="the_repo", author__username="codecov", author__service="github"
@@ -464,8 +465,21 @@ def test_uploads_post_shelter(db, mocker, mock_redis):
         },
         headers={
             "X-Shelter-Token": "shelter-shared-secret",
+            "User-Agent": "codecov-cli/0.4.7",
         },
     )
+
+    mock_sentry_metrics.assert_called_with(
+        "upload",
+        tags={
+            "agent": "cli",
+            "version": "0.4.7",
+            "action": "coverage",
+            "repo_visibility": "private",
+            "is_using_shelter": "yes",
+        },
+    )
+
     upload = ReportSession.objects.filter(
         report_id=commit_report.id, upload_extras={"format_version": "v1"}
     ).first()

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -19,6 +19,7 @@ from rest_framework import renderers, status
 from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
+from sentry_sdk import metrics as sentry_metrics
 from shared.metrics import metrics
 
 from codecov.db import sync_to_async
@@ -34,6 +35,7 @@ from upload.helpers import (
     determine_upload_commit_to_use,
     determine_upload_pr_to_use,
     dispatch_upload_task,
+    generate_upload_sentry_metrics_tags,
     insert_commit,
     parse_headers,
     parse_params,
@@ -143,6 +145,16 @@ class UploadHandler(APIView, ShelterMixin):
             response.content = "Found too many repos"
             metrics.incr("uploads.rejected", 1)
             return response
+
+        sentry_metrics.incr(
+            "upload",
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                request=self.request,
+                repository=repository,
+                is_shelter_request=self.is_shelter_request(),
+            ),
+        )
 
         log.info(
             "Found repository for upload request",
@@ -304,9 +316,11 @@ class UploadHandler(APIView, ShelterMixin):
             "build_url": build_url,
             "reportid": reportid,
             "redis_key": redis_key,  # location of report for v2 uploads; this will be "None" for v4 uploads
-            "url": path
-            if path  # If a path was generated for a v4 upload, pass that to the 'url' field, potentially overwriting it
-            else upload_params.get("url"),
+            "url": (
+                path
+                if path  # If a path was generated for a v4 upload, pass that to the 'url' field, potentially overwriting it
+                else upload_params.get("url")
+            ),
             # These values below might be different from the initial request parameters, so overwrite them here to ensure they're up-to-date
             "commit": commitid,
             "branch": branch,

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListCreateAPIView
 from rest_framework.permissions import BasePermission
+from sentry_sdk import metrics as sentry_metrics
 from shared.config import get_config
 from shared.metrics import metrics
 
@@ -22,7 +23,11 @@ from reports.models import CommitReport, ReportSession
 from services.analytics import AnalyticsService
 from services.archive import ArchiveService, MinioEndpoints
 from services.redis_configuration import get_redis_connection
-from upload.helpers import dispatch_upload_task, validate_activated_repo
+from upload.helpers import (
+    dispatch_upload_task,
+    generate_upload_sentry_metrics_tags,
+    validate_activated_repo,
+)
 from upload.serializers import UploadSerializer
 from upload.throttles import UploadsPerCommitThrottle, UploadsPerWindowThrottle
 from upload.views.base import GetterMixin
@@ -58,6 +63,17 @@ class UploadViews(ListCreateAPIView, GetterMixin):
         validate_activated_repo(repository)
         commit = self.get_commit(repository)
         report = self.get_report(commit)
+
+        sentry_metrics.incr(
+            "upload",
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                request=self.request,
+                repository=repository,
+                is_shelter_request=self.is_shelter_request(),
+            ),
+        )
+
         version = (
             serializer.validated_data["version"]
             if "version" in serializer.validated_data


### PR DESCRIPTION
### Purpose/Motivation
Adding Sentry DDM to the various upload endpoints

### Links to relevant tickets
Fixes: https://github.com/codecov/engineering-team/issues/1178

### What does this PR do?
- `generate_upload_sentry_metrics_tags` in upload helpers to generate tags for metrics, tags are:
  - agent: uploader or cli
  - version: which version of the agent
  - action: coverage vs test results
  - private: is the repo the upload is being made to private?
  - is_shelter_request: is the request coming from shelter
- `get_agent_from_headers` and `get_version_from_headers` to parse `User-Agent` header to get agent and version, if it fails to parse it will return `unsupported-user-agent`

Note: My auto formatter went off while saving some of the files and the linter did not undo them, so this PR comes with some formatting changes to some of the files that have not been visited recently.
