### PR TITLE
fix: Don't drop branch arg from BA upload endpoint

### DIFF
--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -37,6 +37,7 @@ class UploadSerializer(serializers.Serializer):
     job = serializers.CharField(required=False, allow_null=True)
     pr = serializers.CharField(required=False, allow_null=True)
     service = serializers.CharField(required=False, allow_null=True)
+    branch = serializers.CharField(required=False, allow_null=True)
 
 
 class BundleAnalysisView(APIView):


### PR DESCRIPTION
Don't drop the `branch` param in the validator because we actually need it

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
