### PR TITLE
chore: use debian base images instead of alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ test_env.install_cli:
 	pip install codecov-cli==$(CODECOV_CLI_VERSION)
 
 test_env.container_prepare:
-	apk add -U curl git build-base jq
+	apt-get -y install git build-essential netcat-traditional
 	make test_env.install_cli
 	git config --global --add safe.directory /app
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # starts the development server using gunicorn
 # NEVER run production with the --reload option command

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ RUN rm /app/codecov/settings_dev.py && \
 RUN rm -rf /app/.github
 RUN rm -rf /app/.circleci
 # Create the codecov user to run the container as
-RUN addgroup -S application && adduser -S codecov -G application
+RUN addgroup --system application \
+    && adduser --system codecov --ingroup application --home /home/codecov
 RUN mkdir -p /config && chown codecov:application /config
 # copy the enterprise settings module.
 WORKDIR /app

--- a/docker/Dockerfile-proxy
+++ b/docker/Dockerfile-proxy
@@ -4,6 +4,8 @@ FROM python:3.9.18-slim-bookworm
 ENV FRP_VERSION=v0.51.3
 
 # RUN apk add --no-cache curl
+RUN apt-get update
+RUN apt-get install -y curl
 
 RUN addgroup -S frp \
 && adduser -D -S -h /var/frp -s /sbin/nologin -G frp frp \

--- a/docker/Dockerfile-proxy
+++ b/docker/Dockerfile-proxy
@@ -1,11 +1,12 @@
 # syntax=docker/dockerfile:1.3
-FROM alpine
+FROM python:3.9.18-slim-bookworm
 
 ENV FRP_VERSION=v0.51.3
 
+# RUN apk add --no-cache curl
+
 RUN addgroup -S frp \
 && adduser -D -S -h /var/frp -s /sbin/nologin -G frp frp \
-&& apk add --no-cache curl \
 && curl -fSL https://github.com/fatedier/frp/releases/download/${FRP_VERSION}/frp_${FRP_VERSION:1}_linux_amd64.tar.gz -o frp.tar.gz \
 && tar -zxv -f frp.tar.gz \
 && rm -rf frp.tar.gz \

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -30,20 +30,13 @@ RUN rm -rf /pip-packages/src
 # RUNTIME STAGE - Copy packages from build stage and install runtime dependencies
 FROM $PYTHON_IMAGE
 
-RUN apk -U upgrade binutils busybox expat libretls && \
-    apk add --no-cache postgresql-libs && \
-    apk add --no-cache --virtual .build-deps gcc \
-    libxslt-dev \
-    libffi-dev \
-    make \
-    curl \
-    && pip install --upgrade pip
-
 # Our postgres driver psycopg2 requires libpq-dev as a runtime dependency
 RUN apt-get update
 RUN apt-get install -y \
     libpq-dev \
-    make
+    make \
+    curl \
+    && pip install --upgrade pip
 
 WORKDIR /pip-packages/
 COPY --from=build /pip-packages/ /pip-packages/

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -42,7 +42,8 @@ RUN apk -U upgrade binutils busybox expat libretls && \
 # Our postgres driver psycopg2 requires libpq-dev as a runtime dependency
 RUN apt-get update
 RUN apt-get install -y \
-    libpq-dev
+    libpq-dev \
+    make
 
 WORKDIR /pip-packages/
 COPY --from=build /pip-packages/ /pip-packages/

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -1,24 +1,26 @@
 # syntax=docker/dockerfile:1.4
-ARG PYTHON_IMAGE=python:3.9.16-alpine3.18
+ARG PYTHON_IMAGE=python:3.9.18-slim-bookworm
+
 # BUILD STAGE - Download dependencies from GitHub that require SSH access
 FROM $PYTHON_IMAGE as build
 
-RUN apk add --update --no-cache \
-    git \
-    openssh \
-    postgresql-dev \
-    musl-dev \
-    libxslt-dev \
-    python3-dev \
+# Pinning a specific nightly version so that builds don't suddenly break if a
+# "this feature is now stabilized" warning is promoted to an error or something.
+# We would like to keep up with nightly if we can.
+ARG RUST_VERSION=nightly-2024-02-22
+ENV RUST_VERSION=${RUST_VERSION}
+
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
     libffi-dev \
-    gcc \
-    libcurl \
-    bash \
-    rust \
-    build-base \
-    cargo \
-    curl-dev \
-    && pip install --upgrade pip
+    libpq-dev \
+    curl
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | bash -s -- -y --default-toolchain $RUST_VERSION
+ENV PATH="/root/.cargo/bin:$PATH"
 
 COPY requirements.txt /
 WORKDIR /pip-packages/
@@ -37,6 +39,10 @@ RUN apk -U upgrade binutils busybox expat libretls && \
     curl \
     && pip install --upgrade pip
 
+# Our postgres driver psycopg2 requires libpq-dev as a runtime dependency
+RUN apt-get update
+RUN apt-get install -y \
+    libpq-dev
 
 WORKDIR /pip-packages/
 COPY --from=build /pip-packages/ /pip-packages/

--- a/enterprise.sh
+++ b/enterprise.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Starts the enterprise gunicorn server (no --reload)
 echo "Starting api"

--- a/prod.sh
+++ b/prod.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Starts the production gunicorn server (no --reload)
 echo "Starting gunicorn in production mode"

--- a/staging.sh
+++ b/staging.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # starts the development server using gunicorn
 # NEVER run production with the --reload option command


### PR DESCRIPTION
fixes https://github.com/codecov/engineering-team/issues/1242

with an alpine/musl image we have to build more packages from source. grpcio takes an eternity to build for example

also apparently alpine/musl images have DNS resolution problems

this uses an official "slim" python image based on debian stable. from a quick glance at uncompressed image sizes on my local machine, this is actually 300mb smaller:
<img width="866" alt="Screenshot 2024-02-23 at 7 48 56 PM" src="https://github.com/codecov/codecov-api/assets/137832199/f453e626-6a4b-482f-a78e-f12aa7b6a569">
<img width="873" alt="Screenshot 2024-02-23 at 7 48 34 PM" src="https://github.com/codecov/codecov-api/assets/137832199/4be20c7e-bbf9-443b-a62c-7342abb16c0d">

i have not rigorously tested this but it seems okay

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.