### PR TITLE
feat: add sentry metrics set to legacy endpoint

### DIFF
--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -69,9 +69,9 @@ class UploadHandler(APIView, ShelterMixin):
         response["Accept"] = "text/*"
         response["Access-Control-Allow-Origin"] = "*"
         response["Access-Control-Allow-Method"] = "POST"
-        response["Access-Control-Allow-Headers"] = (
-            "Origin, Content-Type, Accept, X-User-Agent"
-        )
+        response[
+            "Access-Control-Allow-Headers"
+        ] = "Origin, Content-Type, Accept, X-User-Agent"
 
         return response
 
@@ -91,9 +91,9 @@ class UploadHandler(APIView, ShelterMixin):
         # Set response headers
         response = HttpResponse()
         response["Access-Control-Allow-Origin"] = "*"
-        response["Access-Control-Allow-Headers"] = (
-            "Origin, Content-Type, Accept, X-User-Agent"
-        )
+        response[
+            "Access-Control-Allow-Headers"
+        ] = "Origin, Content-Type, Accept, X-User-Agent"
 
         # Parse request parameters
         request_params = {


### PR DESCRIPTION
### Purpose/Motivation
We want a percentage of orgs using the CLI vs using the uploader.

This sentry metrics set was previously added to the new upload endpoint.

### What does this PR do?
- Add sentry_metrics.set call to the legacy upload endpoint