### PR TITLE
feat: add methods to query + insert coverage measurements

### DIFF
--- a/plan/service.py
+++ b/plan/service.py
@@ -51,6 +51,9 @@ class PlanService:
         self.plan_data = USER_PLAN_REPRESENTATIONS[self.current_org.plan]
         self.current_org.save()
 
+    def current_org(self) -> Owner:
+        return self.current_org
+
     def set_default_plan_data(self) -> None:
         log.info(f"Setting plan to users-basic for owner {self.current_org.ownerid}")
         self.current_org.plan = PlanName.BASIC_PLAN_NAME.value

--- a/plan/test_plan.py
+++ b/plan/test_plan.py
@@ -247,6 +247,7 @@ class PlanServiceTests(TestCase):
         plan_service = PlanService(current_org=current_org)
 
         basic_plan = FREE_PLAN_REPRESENTATIONS[PlanName.BASIC_PLAN_NAME.value]
+        assert plan_service.current_org == current_org
         assert plan_service.trial_status == TrialStatus.NOT_STARTED.value
         assert plan_service.marketing_name == basic_plan.marketing_name
         assert plan_service.plan_name == basic_plan.value

--- a/utils/tests/unit/test_coverage_measurements.py
+++ b/utils/tests/unit/test_coverage_measurements.py
@@ -1,0 +1,99 @@
+from datetime import datetime, timedelta
+
+from django.test import TestCase
+from freezegun import freeze_time
+
+from codecov_auth.models import Owner
+from codecov_auth.tests.factories import OwnerFactory
+from core.tests.factories import CommitFactory, RepositoryFactory
+from plan.service import PlanService
+from reports.tests.factories import CommitReportFactory, UploadFactory
+from user_measurements.models import UserMeasurement
+from utils.uploads_used import (
+    insert_coverage_measurement,
+    query_monthly_coverage_measurements,
+)
+
+
+class CoverageMeasurement(TestCase):
+    def add_upload_measurements_records(
+        self,
+        owner: Owner,
+        quantity: int,
+        report_type="coverage",
+        private=True,
+    ):
+        for _ in range(quantity):
+            repo = RepositoryFactory.create(author=owner, private=private)
+            commit = CommitFactory.create(repository=repo)
+            report = CommitReportFactory.create(commit=commit, report_type=report_type)
+            upload = UploadFactory.create(report=report)
+            insert_coverage_measurement(
+                owner=owner,
+                repo=repo,
+                commit=commit,
+                upload=upload,
+                uploader_used="CLI",
+                private_repo=repo.private,
+                report_type=report.report_type,
+            )
+
+    def test_query_monthly_coverage_measurements(self):
+        owner = OwnerFactory()
+        self.add_upload_measurements_records(owner=owner, quantity=5)
+        plan_service = PlanService(current_org=owner)
+
+        monthly_measurements = query_monthly_coverage_measurements(
+            plan_service=plan_service
+        )
+        assert monthly_measurements == 5
+
+    def test_query_monthly_coverage_measurements_with_a_public_repo(self):
+        owner = OwnerFactory()
+        self.add_upload_measurements_records(owner=owner, quantity=3)
+        self.add_upload_measurements_records(owner=owner, quantity=1, private=False)
+
+        plan_service = PlanService(current_org=owner)
+        monthly_measurements = query_monthly_coverage_measurements(
+            plan_service=plan_service
+        )
+        # Doesn't query the last 3
+        assert monthly_measurements == 3
+
+    def test_query_monthly_coverage_measurements_with_non_coverage_report(self):
+        owner = OwnerFactory()
+        self.add_upload_measurements_records(owner=owner, quantity=3)
+        self.add_upload_measurements_records(
+            owner=owner, quantity=1, report_type="bundle_analysis"
+        )
+
+        plan_service = PlanService(current_org=owner)
+        monthly_measurements = query_monthly_coverage_measurements(
+            plan_service=plan_service
+        )
+        # Doesn't query the last 3
+        assert monthly_measurements == 3
+
+    def test_query_monthly_coverage_measurements_after_30_days(self):
+        owner = OwnerFactory()
+
+        # Uploads before 30 days
+        freezer = freeze_time("2023-10-15T00:00:00")
+        freezer.start()
+        self.add_upload_measurements_records(owner=owner, quantity=3)
+        freezer.stop()
+
+        # Now
+        freezer = freeze_time("2024-02-10T00:00:00")
+        freezer.start()
+        self.add_upload_measurements_records(owner=owner, quantity=5)
+        freezer.stop()
+
+        all_measurements = UserMeasurement.objects.all()
+        assert len(all_measurements) == 8
+
+        plan_service = PlanService(current_org=owner)
+        monthly_measurements = query_monthly_coverage_measurements(
+            plan_service=plan_service
+        )
+        assert monthly_measurements == 5

--- a/utils/tests/unit/test_coverage_measurements.py
+++ b/utils/tests/unit/test_coverage_measurements.py
@@ -133,11 +133,7 @@ class CoverageMeasurement(TestCase):
     def test_query_monthly_coverage_measurements_beyond_monthly_limit(
         self, monthly_uploads_mock
     ):
-        owner = OwnerFactory(
-            trial_status="expired",
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
-        )
+        owner = OwnerFactory()
         self.add_upload_measurements_records(owner=owner, quantity=10)
 
         plan_service = PlanService(current_org=owner)

--- a/utils/uploads_used.py
+++ b/utils/uploads_used.py
@@ -5,8 +5,12 @@ from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
+from codecov_auth.models import Owner
+from core.models import Commit, Repository
 from plan.constants import TrialStatus
-from reports.models import ReportSession
+from plan.service import PlanService
+from reports.models import ReportSession, ReportType
+from user_measurements.models import UserMeasurement
 from utils.config import get_config
 
 log = logging.getLogger(__name__)
@@ -80,3 +84,43 @@ def query_uploads_used(plan_service, limit, owner):
         )
 
     return queryset[:limit].count()
+
+
+def query_monthly_coverage_measurements(plan_service: PlanService) -> int:
+    owner = plan_service.current_org
+    queryset = UserMeasurement.objects.filter(
+        owner=owner,
+        private_repo=True,
+        created_at__gte=timezone.now() - timedelta(days=30),
+        report_type="coverage",
+    )
+    if (
+        plan_service.trial_status == TrialStatus.EXPIRED.value
+        and plan_service.has_trial_dates
+    ):
+        queryset = queryset.filter(
+            Q(created_at__gte=plan_service.trial_end_date)
+            | Q(created_at__lte=plan_service.trial_start_date)
+        )
+    monthly_limit = plan_service.monthly_uploads_limit
+    return queryset[:monthly_limit].count()
+
+
+def insert_coverage_measurement(
+    owner: Owner,
+    repo: Repository,
+    commit: Commit,
+    upload: ReportSession,
+    uploader_used: str,
+    private_repo: bool,
+    report_type: ReportType,
+):
+    return UserMeasurement.objects.create(
+        repo=repo,
+        commit=commit,
+        upload=upload,
+        owner=owner,
+        uploader_used=uploader_used,
+        private_repo=private_repo,
+        report_type=report_type,
+    )


### PR DESCRIPTION
### Purpose/Motivation
We're adding a partitioned with the UserMeasurements models. We want to add some functions to add/query for monthly uploads. This PR adds those + tests

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1174

### What does this PR do?
- adds a query + insert functions using the user measurements model
- adds tests to those

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
