### PR TITLE
fix: turn Commits endpoint into APIView instead of ListCreateAPIView

### DIFF
--- a/upload/tests/views/test_commits.py
+++ b/upload/tests/views/test_commits.py
@@ -43,22 +43,6 @@ def test_get_repo_not_found(db):
     assert exp.match("Repository not found")
 
 
-def test_get_queryset(db):
-    target_repo = RepositoryFactory(
-        name="the_repo", author__username="codecov", author__service="github"
-    )
-    random_repo = RepositoryFactory()
-    target_commit_1 = CommitFactory(repository=target_repo)
-    target_commit_2 = CommitFactory(repository=target_repo)
-    random_commit = CommitFactory(repository=random_repo)
-    upload_views = CommitViews()
-    upload_views.kwargs = dict(repo="codecov::::the_repo", service="github")
-    recovered_commits = upload_views.get_queryset()
-    assert target_commit_1 in recovered_commits
-    assert target_commit_2 in recovered_commits
-    assert random_commit not in recovered_commits
-
-
 def test_commits_get(client, db):
     repo = RepositoryFactory(name="the-repo")
     commit_1 = CommitFactory(repository=repo)


### PR DESCRIPTION
### Purpose/Motivation
In the previous version of the endpoint's definition, there was a possibility of an IntegrityError. This change is meant to move the get_or_create into CommitViews endpoint.

### What does this PR do?
- Implement the CommitViews endpoint as an APIView instead of a ListCreateAPIView
- Create a new CommitSerializer
- add a get handler that returns the list of matching Commit objects
- add a post handler that possibly creates a new Commit object in the database
