### PR TITLE
fix: Use Smaller timeout value when regex matching

### DIFF
--- a/services/profiling.py
+++ b/services/profiling.py
@@ -91,7 +91,7 @@ class ProfilingSummary:
             for file in report.files
             if any(
                 map(
-                    lambda regex_patt: regex.match(regex_patt, file, timeout=5),
+                    lambda regex_patt: regex.match(regex_patt, file, timeout=2),
                     compiled_files_paths,
                 )
             )

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -119,7 +119,7 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
             for file in changed_files
             if any(
                 map(
-                    lambda regex_patt: regex.match(regex_patt, file, timeout=5),
+                    lambda regex_patt: regex.match(regex_patt, file, timeout=2),
                     compiled_files_to_ignore,
                 )
             )


### PR DESCRIPTION
### Purpose/Motivation

Aim of this PR is to fail a little bit faster when doing the regex matching.

.NET's native timeout value for regex matching looks to be 2 seconds.


### Links to relevant tickets

### What does this PR do?

- Lowers timeout value from 5 seconds to 2

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
