### PR TITLE
fix: handle rate limit error in get pr info fn

### DIFF
--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -214,7 +214,7 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
     """
 
     auth_failed_message = "Not valid tokenless upload"
-    rate_limit_failed_message = "Tokenless has reached GitHub rate limit. Please consider uploading using a token: https://docs.codecov.com/docs/adding-the-codecov-token."
+    rate_limit_failed_message = "Tokenless has reached GitHub rate limit. Please upload using a token: https://docs.codecov.com/docs/adding-the-codecov-token."
 
     def _get_repo_info_from_request_path(self, request) -> Repository:
         path_info = request.get_full_path_info()

--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -214,6 +214,7 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
     """
 
     auth_failed_message = "Not valid tokenless upload"
+    rate_limit_failed_message = "Tokenless has reached GitHub rate limit. Please consider uploading using a token: https://docs.codecov.com/docs/adding-the-codecov-token."
 
     def _get_repo_info_from_request_path(self, request) -> Repository:
         path_info = request.get_full_path_info()
@@ -256,7 +257,9 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
                 retry_after = int(e.reset) - int(now_timestamp)
             elif e.retry_after:
                 retry_after = int(e.retry_after)
-            raise exceptions.Throttled(retry_after)
+            raise exceptions.Throttled(
+                wait=retry_after, detail=self.rate_limit_failed_message
+            )
 
     def authenticate(self, request):
         fork_slug = request.headers.get("X-Tokenless", None)


### PR DESCRIPTION
We want to handle receiving a 429 or 403
status code response from gh that is related
to hitting the gh rate limit.

now we do that when we try to get PR info while
trying to auth with tokenless

we will return a `exceptions.Throttled` which
corresponds to a 429 status code

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1247

### What does this PR do?
- Handle `TorngitRateLimitError` in `get_pull_request_info`
- add tests for `get_pull_request_info` to test it can handle receiving a 429 status code