### PR TITLE
fix: use get_or_create in CommitSerializer.create

### DIFF
--- a/upload/serializers.py
+++ b/upload/serializers.py
@@ -136,13 +136,12 @@ class CommitSerializer(serializers.ModelSerializer):
         )
 
     def create(self, validated_data):
-        commit = Commit.objects.filter(
-            repository=validated_data.get("repository"),
-            commitid=validated_data.get("commitid"),
-        ).first()
-        if commit:
-            return commit
-        return super().create(validated_data)
+        repo = validated_data.pop("repository", None)
+        commitid = validated_data.pop("commitid", None)
+        commit, _ = Commit.objects.get_or_create(
+            repository=repo, commitid=commitid, defaults=validated_data
+        )
+        return commit
 
 
 class CommitReportSerializer(serializers.ModelSerializer):

--- a/upload/tests/test_serializers.py
+++ b/upload/tests/test_serializers.py
@@ -171,6 +171,33 @@ def test_commit_serializer_contains_expected_fields(transactional_db, mocker):
     assert serializer.data == expected_data
 
 
+def test_commit_serializer_does_not_duplicate(transactional_db, mocker):
+    repository = RepositoryFactory()
+    serializer = CommitSerializer()
+
+    saved_commit1 = serializer.create(
+        {
+            "repository": repository,
+            "commitid": "1234567",
+            "parent_commit_id": "2345678",
+            "pullid": 1,
+            "branch": "test_branch",
+        }
+    )
+
+    saved_commit2 = serializer.create(
+        {
+            "repository": repository,
+            "commitid": "1234567",
+            "parent_commit_id": "2345678",
+            "pullid": 1,
+            "branch": "test_branch",
+        }
+    )
+
+    assert saved_commit1 == saved_commit2
+
+
 def test_invalid_update_data(transactional_db, mocker):
     commit = CommitFactory.create()
     new_data = {"pullid": "1"}


### PR DESCRIPTION
### Purpose/Motivation
there is a possibility of creating commits concurrently if that happens there is a possibility of getting an IntegrityError when trying to create the Commit object

this commit solves this problem by using get_or_create to create the Commit object in the serializer

### What does this PR do?
- remove repository and commitid from validated data so its not included in the defaults
- use `get_or_create` instead of `filter` then `super().create`

