### PR TITLE
[admin] allow trial extension for orgs currently on trial

### DIFF
--- a/plan/service.py
+++ b/plan/service.py
@@ -142,7 +142,7 @@ class PlanService:
     def _start_trial_helper(
         self,
         current_owner: Owner,
-        end_date: datetime = None,
+        end_date: Optional[datetime] = None,
         is_extension: bool = False,
     ) -> None:
         start_date = datetime.utcnow()

--- a/plan/service.py
+++ b/plan/service.py
@@ -12,6 +12,7 @@ from plan.constants import (
     SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
     TEAM_PLAN_MAX_USERS,
     TEAM_PLAN_REPRESENTATIONS,
+    TRIAL_PLAN_REPRESENTATION,
     TRIAL_PLAN_SEATS,
     USER_PLAN_REPRESENTATIONS,
     PlanData,
@@ -184,7 +185,10 @@ class PlanService:
         Returns:
             No value
         """
-        if self.plan_name not in FREE_PLAN_REPRESENTATIONS:
+        if (
+            self.plan_name not in FREE_PLAN_REPRESENTATIONS
+            and self.plan_name not in TRIAL_PLAN_REPRESENTATION
+        ):
             raise ValidationError("Cannot trial from a paid plan")
 
         self._start_trial_helper(current_owner, end_date)


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Currently the admin app can extend a org trial, but only after they have expired and turned back to basic plan.
This change allows the orgs' trials to be extended while they're still trialing.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
