### PR TITLE
GQL Owners: return null for unauthorized fields

### DIFF
--- a/graphql_api/helpers/mutation.py
+++ b/graphql_api/helpers/mutation.py
@@ -62,11 +62,13 @@ def require_part_of_org(resolver):
     def authenticated_resolver(queried_owner, info, *args, **kwargs):
         current_user = info.context["request"].user
         current_owner = info.context["request"].current_owner
-        if not current_user or not current_user.is_authenticated or not current_owner:
-            raise exceptions.Unauthenticated()
-
-        if not current_user_part_of_org(current_owner, queried_owner):
-            raise exceptions.Unauthorized()
+        if (
+            not current_user
+            or not current_user.is_authenticated
+            or not current_owner
+            or not current_user_part_of_org(current_owner, queried_owner)
+        ):
+            return None
 
         return resolver(queried_owner, info, *args, **kwargs)
 

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -2,12 +2,11 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 
-import pytest
 from django.test import TransactionTestCase
 from django.utils import timezone
 from freezegun import freeze_time
 
-from codecov.commands.exceptions import MissingService, Unauthenticated, Unauthorized
+from codecov.commands.exceptions import MissingService
 from codecov_auth.models import OwnerProfile
 from codecov_auth.tests.factories import (
     GetAdminProviderAdapter,
@@ -280,7 +279,6 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         owner = OwnerFactory(username="random_org_test", service="github")
         query = query_current_user_is_admin % (owner.username)
         data = self.gql_request(query, owner=user, with_errors=True)
-        assert data["errors"][0]["message"] == Unauthorized.message
         assert data["data"]["owner"]["isAdmin"] is None
 
     @patch(

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -69,6 +69,7 @@ def resolve_yaml(owner, info):
 
 
 @owner_bindable.field("plan")
+@require_part_of_org
 def resolve_plan(owner: Owner, info) -> PlanService:
     return PlanService(current_org=owner)
 

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -69,7 +69,6 @@ def resolve_yaml(owner, info):
 
 
 @owner_bindable.field("plan")
-@require_part_of_org
 def resolve_plan(owner: Owner, info) -> PlanService:
     return PlanService(current_org=owner)
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Currently a GQL error will appear for Unauthenticated/Unauthorized requests, this change makes it so that those fields would return null instead. Making this change because the UI calls for unauthorized fields would not spam Sentry errors.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
