### PR TITLE
test: fix query measurements after 30 days test

### DIFF
--- a/utils/tests/unit/test_coverage_measurements.py
+++ b/utils/tests/unit/test_coverage_measurements.py
@@ -94,9 +94,12 @@ class CoverageMeasurement(TestCase):
         assert len(all_measurements) == 8
 
         plan_service = PlanService(current_org=owner)
+        freezer = freeze_time("2024-03-05T00:00:00")
+        freezer.start()
         monthly_measurements = query_monthly_coverage_measurements(
             plan_service=plan_service
         )
+        freezer.stop()
         assert monthly_measurements == 5
 
     def test_query_monthly_coverage_measurements_excluding_uploads_during_trial(self):


### PR DESCRIPTION
### Purpose/Motivation
This test started failing ater 2024-03-10 because
the time at the query was not frozen to a specific date so it was using the system's actual time and
the measurements were not a part of the last 30 days.

### What does this PR do?
Freezes time around monthly coverage measurements query in test