### PR TITLE
Bundle Analysis: delete old code

### DIFF
--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -707,7 +707,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
             query_commit
             % """
             compareWithParent { __typename ... on Comparison { state } }
-            bundleAnalysisCompareWithParent { __typename ... on BundleAnalysisComparison { sizeDelta } }
+            bundleAnalysisCompareWithParent { __typename ... on BundleAnalysisComparison { bundleChange { size { uncompress } } } }
             """
         )
         variables = {
@@ -818,17 +818,9 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
             bundleAnalysisCompareWithParent {
                 __typename
                 ... on BundleAnalysisComparison {
-                    sizeDelta
-                    sizeTotal
-                    loadTimeDelta
-                    loadTimeTotal
                     bundles {
                         name
                         changeType
-                        sizeDelta
-                        sizeTotal
-                        loadTimeDelta
-                        loadTimeTotal
                         bundleData {
                             size {
                                 uncompress
@@ -864,58 +856,34 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
         commit = data["owner"]["repository"]["commit"]
         assert commit["bundleAnalysisCompareWithParent"] == {
             "__typename": "BundleAnalysisComparison",
-            "sizeDelta": 36555,
-            "sizeTotal": 201720,
-            "loadTimeDelta": 0.1,
-            "loadTimeTotal": 0.5,
             "bundles": [
                 {
                     "name": "b1",
                     "changeType": "changed",
-                    "sizeDelta": 5,
-                    "sizeTotal": 20,
-                    "loadTimeDelta": 0.0,
-                    "loadTimeTotal": 0.0,
                     "bundleData": {"size": {"uncompress": 20}},
                     "bundleChange": {"size": {"uncompress": 5}},
                 },
                 {
                     "name": "b2",
                     "changeType": "changed",
-                    "sizeDelta": 50,
-                    "sizeTotal": 200,
-                    "loadTimeDelta": 0.0,
-                    "loadTimeTotal": 0.0,
                     "bundleData": {"size": {"uncompress": 200}},
                     "bundleChange": {"size": {"uncompress": 50}},
                 },
                 {
                     "name": "b3",
                     "changeType": "added",
-                    "sizeDelta": 1500,
-                    "sizeTotal": 1500,
-                    "loadTimeDelta": 0.0,
-                    "loadTimeTotal": 0.0,
                     "bundleData": {"size": {"uncompress": 1500}},
                     "bundleChange": {"size": {"uncompress": 1500}},
                 },
                 {
                     "name": "b5",
                     "changeType": "changed",
-                    "sizeDelta": 50000,
-                    "sizeTotal": 200000,
-                    "loadTimeDelta": 0.1,
-                    "loadTimeTotal": 0.5,
                     "bundleData": {"size": {"uncompress": 200000}},
                     "bundleChange": {"size": {"uncompress": 50000}},
                 },
                 {
                     "name": "b4",
                     "changeType": "removed",
-                    "sizeDelta": -15000,
-                    "sizeTotal": 0,
-                    "loadTimeDelta": -0.0,
-                    "loadTimeTotal": 0.0,
                     "bundleData": {"size": {"uncompress": 0}},
                     "bundleChange": {"size": {"uncompress": -15000}},
                 },
@@ -958,7 +926,11 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
             bundleAnalysisCompareWithParent {
                 __typename
                 ... on BundleAnalysisComparison {
-                    sizeTotal
+                    bundleData {
+                        size {
+                            uncompress
+                        }
+                    }
                 }
             }
             """
@@ -1013,7 +985,11 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
             bundleAnalysisCompareWithParent {
                 __typename
                 ... on BundleAnalysisComparison {
-                    sizeTotal
+                    bundleData {
+                        size {
+                            uncompress
+                        }
+                    }
                 }
             }
             """
@@ -1084,12 +1060,8 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                                 bundleAnalysisReport {
                                     __typename
                                     ... on BundleAnalysisReport {
-                                        sizeTotal
-                                        loadTimeTotal
                                         bundles {
                                             name
-                                            sizeTotal
-                                            loadTimeTotal
                                             assets(filters: $filters) {
                                                 normalizedName
                                             }
@@ -1143,13 +1115,9 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
 
         assert commit["bundleAnalysisReport"] == {
             "__typename": "BundleAnalysisReport",
-            "sizeTotal": 201720,
-            "loadTimeTotal": 0.5,
             "bundles": [
                 {
                     "name": "b1",
-                    "sizeTotal": 20,
-                    "loadTimeTotal": 0.0,
                     "assets": [
                         {"normalizedName": "assets/react-*.svg"},
                         {"normalizedName": "assets/index-*.css"},
@@ -1171,8 +1139,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                 },
                 {
                     "name": "b2",
-                    "sizeTotal": 200,
-                    "loadTimeTotal": 0.0,
                     "assets": [
                         {"normalizedName": "assets/react-*.svg"},
                         {"normalizedName": "assets/index-*.css"},
@@ -1194,8 +1160,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                 },
                 {
                     "name": "b3",
-                    "sizeTotal": 1500,
-                    "loadTimeTotal": 0.0,
                     "assets": [
                         {"normalizedName": "assets/react-*.svg"},
                         {"normalizedName": "assets/index-*.css"},
@@ -1217,8 +1181,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                 },
                 {
                     "name": "b5",
-                    "sizeTotal": 200000,
-                    "loadTimeTotal": 0.5,
                     "assets": [
                         {"normalizedName": "assets/react-*.svg"},
                         {"normalizedName": "assets/index-*.css"},

--- a/graphql_api/tests/test_pull.py
+++ b/graphql_api/tests/test_pull.py
@@ -94,7 +94,11 @@ pull_request_detail_query_with_bundle_analysis = """
     bundleAnalysisCompareWithBase {
         __typename
         ... on BundleAnalysisComparison {
-            sizeDelta
+            bundleChange {
+                size {
+                    uncompress
+                }
+            }
         }
     }
     behindBy
@@ -105,7 +109,11 @@ pull_request_bundle_analysis_missing_reports = """
     bundleAnalysisCompareWithBase {
         __typename
         ... on BundleAnalysisComparison {
-            sizeDelta
+            bundleChange {
+                size {
+                    uncompress
+                }
+            }
         }
     }
 """
@@ -453,7 +461,11 @@ class TestPullRequestList(GraphQLTestHelper, TransactionTestCase):
             bundleAnalysisCompareWithBase {
                 __typename
                 ... on BundleAnalysisComparison {
-                    sizeTotal
+                    bundleData {
+                        size {
+                            uncompress
+                        }
+                    }
                 }
             }
         """
@@ -463,7 +475,11 @@ class TestPullRequestList(GraphQLTestHelper, TransactionTestCase):
         assert pull == {
             "bundleAnalysisCompareWithBase": {
                 "__typename": "BundleAnalysisComparison",
-                "sizeTotal": 201720,
+                "bundleData": {
+                    "size": {
+                        "uncompress": 201720,
+                    }
+                },
             }
         }
 

--- a/graphql_api/types/bundle_analysis/base.graphql
+++ b/graphql_api/types/bundle_analysis/base.graphql
@@ -30,8 +30,6 @@ type BundleAsset {
 
 type BundleReport {
   name: String!
-  sizeTotal: Int!
-  loadTimeTotal: Float!
   moduleExtensions: [String!]!
   moduleCount: Int!
   assets(filters: BundleAnalysisReportFilters): [BundleAsset]!

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -84,18 +84,6 @@ def resolve_name(bundle_report: BundleReport, info) -> str:
     return bundle_report.name
 
 
-# TODO: depreacted with Issue 1199
-@bundle_report_bindable.field("sizeTotal")
-def resolve_size_total(bundle_report: BundleReport, info) -> int:
-    return bundle_report.size_total
-
-
-# TODO: depreacted with Issue 1199
-@bundle_report_bindable.field("loadTimeTotal")
-def resolve_load_time_total(bundle_report: BundleReport, info) -> float:
-    return bundle_report.load_time_total
-
-
 @bundle_report_bindable.field("moduleExtensions")
 def resolve_module_extensions(bundle_report: BundleReport, info) -> List[str]:
     return bundle_report.module_extensions

--- a/graphql_api/types/bundle_analysis/comparison.graphql
+++ b/graphql_api/types/bundle_analysis/comparison.graphql
@@ -8,10 +8,6 @@ union BundleAnalysisComparisonResult =
 
 type BundleAnalysisComparison {
   bundles: [BundleComparison]!
-  sizeDelta: Int!
-  sizeTotal: Int!
-  loadTimeDelta: Float!
-  loadTimeTotal: Float!
   bundleData: BundleData!
   bundleChange: BundleData!
 }
@@ -19,10 +15,6 @@ type BundleAnalysisComparison {
 type BundleComparison {
   name: String!
   changeType: String!
-  sizeDelta: Int!
-  sizeTotal: Int!
-  loadTimeDelta: Float!
-  loadTimeTotal: Float!
   bundleData: BundleData!
   bundleChange: BundleData!
 }

--- a/graphql_api/types/bundle_analysis/comparison.py
+++ b/graphql_api/types/bundle_analysis/comparison.py
@@ -34,30 +34,6 @@ def resolve_bundle_analysis_comparison_result_type(obj, *_):
         return "MissingBaseReport"
 
 
-@bundle_analysis_comparison_bindable.field("sizeDelta")
-def resolve_size_delta(bundles_analysis_comparison: BundleAnalysisComparison, info):
-    return bundles_analysis_comparison.size_delta
-
-
-@bundle_analysis_comparison_bindable.field("sizeTotal")
-def resolve_size_total(bundles_analysis_comparison: BundleAnalysisComparison, info):
-    return bundles_analysis_comparison.size_total
-
-
-@bundle_analysis_comparison_bindable.field("loadTimeDelta")
-def resolve_load_time_delta(
-    bundles_analysis_comparison: BundleAnalysisComparison, info
-):
-    return bundles_analysis_comparison.load_time_delta
-
-
-@bundle_analysis_comparison_bindable.field("loadTimeTotal")
-def resolve_load_time_total(
-    bundles_analysis_comparison: BundleAnalysisComparison, info
-):
-    return bundles_analysis_comparison.load_time_total
-
-
 @bundle_analysis_comparison_bindable.field("bundles")
 def resolve_bundles(bundles_analysis_comparison: BundleAnalysisComparison, info):
     return bundles_analysis_comparison.bundles
@@ -85,26 +61,6 @@ def resolve_name(bundle_comparison: BundleComparison, info):
 @bundle_comparison_bindable.field("changeType")
 def resolve_change_type(bundle_comparison: BundleComparison, info):
     return bundle_comparison.change_type
-
-
-@bundle_comparison_bindable.field("sizeDelta")
-def resolve_size_delta(bundle_comparison: BundleComparison, info):
-    return bundle_comparison.size_delta
-
-
-@bundle_comparison_bindable.field("sizeTotal")
-def resolve_size_total(bundle_comparison: BundleComparison, info):
-    return bundle_comparison.size_total
-
-
-@bundle_comparison_bindable.field("loadTimeDelta")
-def resolve_load_time_delta(bundle_comparison: BundleComparison, info):
-    return bundle_comparison.load_time_delta
-
-
-@bundle_comparison_bindable.field("loadTimeTotal")
-def resolve_load_time_total(bundle_comparison: BundleComparison, info):
-    return bundle_comparison.load_time_total
 
 
 @bundle_comparison_bindable.field("bundleData")

--- a/graphql_api/types/bundle_analysis/report.graphql
+++ b/graphql_api/types/bundle_analysis/report.graphql
@@ -3,8 +3,6 @@ union BundleAnalysisReportResult =
   | MissingHeadReport
 
 type BundleAnalysisReport {
-  sizeTotal: Int!
-  loadTimeTotal: Float!
   bundles: [BundleReport]!
   bundleData: BundleData!
   bundle(name: String!): BundleReport

--- a/graphql_api/types/bundle_analysis/report.py
+++ b/graphql_api/types/bundle_analysis/report.py
@@ -17,20 +17,6 @@ def resolve_bundle_analysis_report_result_type(obj, *_):
         return "MissingHeadReport"
 
 
-# TODO: depreacted with Issue 1199
-@bundle_analysis_report_bindable.field("sizeTotal")
-def resolve_size_total(bundles_analysis_report: BundleAnalysisReport, info) -> int:
-    return bundles_analysis_report.size_total
-
-
-# TODO: depreacted with Issue 1199
-@bundle_analysis_report_bindable.field("loadTimeTotal")
-def resolve_load_time_total(
-    bundles_analysis_report: BundleAnalysisReport, info
-) -> float:
-    return bundles_analysis_report.load_time_total
-
-
 @bundle_analysis_report_bindable.field("bundles")
 def resolve_bundles(
     bundles_analysis_report: BundleAnalysisReport, info


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

These fields are being deprecated by `bundleData` and `bundleChange`. The app is no longer calling these fields anymore, it is safe to remove now.

### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/1199

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
