### PR TITLE
feat: #1359 - Add Component Measurements Backfilled resolver + tests

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -356,12 +356,17 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             query_repository
             % """
                 componentsMeasurementsActive
+                componentsMeasurementsBackfilled
             """,
             owner=user,
             variables={"name": repo.name},
         )
         assert (
             data["me"]["owner"]["repository"]["componentsMeasurementsActive"] == False
+        )
+        assert (
+            data["me"]["owner"]["repository"]["componentsMeasurementsBackfilled"]
+            == False
         )
 
     @patch("shared.yaml.user_yaml.UserYaml.get_final_yaml")

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -56,6 +56,7 @@ type Repository {
   flagsMeasurementsActive: Boolean!
   flagsMeasurementsBackfilled: Boolean!
   componentsMeasurementsActive: Boolean!
+  componentsMeasurementsBackfilled: Boolean!
   measurements(
     interval: MeasurementInterval!
     after: DateTime

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -295,6 +295,23 @@ def resolve_components_measurements_active(repository: Repository, info) -> bool
     ).exists()
 
 
+@repository_bindable.field("componentsMeasurementsBackfilled")
+@sync_to_async
+def resolve_components_measurements_backfilled(repository: Repository, info) -> bool:
+    if not settings.TIMESERIES_ENABLED:
+        return False
+
+    dataset = Dataset.objects.filter(
+        name=MeasurementName.COMPONENT_COVERAGE.value,
+        repository_id=repository.pk,
+    ).first()
+
+    if not dataset:
+        return False
+
+    return dataset.is_backfilled()
+
+
 @repository_bindable.field("isATSConfigured")
 def resolve_is_ats_configured(repository: Repository, info) -> bool:
     if not repository.yaml or "flag_management" not in repository.yaml:


### PR DESCRIPTION
### Purpose/Motivation

Adds the ComponentMeasurementsBackfilled boolean to the repository model similar to the flagsMeasurementsBackfilled key, with similar UT's as well.

### Links to relevant tickets

closes https://github.com/codecov/engineering-team/issues/1359

### What does this PR do?

Adds a new key to the repository model, and resolver + tests

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
