### PR TITLE
fix: Update OpenAPI type to Array from string

### DIFF
--- a/api/public/v2/repo/views.py
+++ b/api/public/v2/repo/views.py
@@ -51,6 +51,7 @@ class RepositoryViewSet(
                 name="names",
                 type={"type": "array", "items": "string"},
                 explode=True,
+                description="list of repository names",
             )
         ],
     )

--- a/api/public/v2/repo/views.py
+++ b/api/public/v2/repo/views.py
@@ -50,6 +50,7 @@ class RepositoryViewSet(
             OpenApiParameter(
                 name="names",
                 type={"type": "array", "items": "string"},
+                explode=True,
             )
         ],
     )

--- a/api/public/v2/repo/views.py
+++ b/api/public/v2/repo/views.py
@@ -44,7 +44,15 @@ class RepositoryViewSet(
     def get_queryset(self):
         return super().get_queryset().with_recent_coverage()
 
-    @extend_schema(summary="Repository list")
+    @extend_schema(
+        summary="Repository list",
+        parameters=[
+            OpenApiParameter(
+                name="names",
+                type={"type": "array", "items": "string"},
+            )
+        ],
+    )
     def list(self, request, *args, **kwargs):
         """
         Returns a paginated list of repositories for the specified provider service and owner username


### PR DESCRIPTION
### Purpose/Motivation

Update openAPI type from string to array for better clarity on the docs here: https://docs.codecov.com/reference/repos_list

### Links to relevant tickets

closes https://github.com/codecov/feedback/issues/284

### What does this PR do?

- updates repo_list endpoint's names property on the OpenAPI schema from string to array
  - this should hopefully allow us to test names='A'&names='B' on the schema tester


### Screenshots

<img width="429" alt="Screenshot 2024-03-21 at 8 48 05 AM" src="https://github.com/codecov/codecov-api/assets/159853603/9d1daff1-d106-428d-b5d2-75470db82073">


### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
