### PR TITLE
fix: carefully assign ghapp names

### DIFF
--- a/codecov_auth/models.py
+++ b/codecov_auth/models.py
@@ -510,10 +510,11 @@ class GithubAppInstallation(
 
     def is_configured(self) -> bool:
         """Returns whether this installation is properly configured and can be used"""
-        if self.name == GITHUB_APP_INSTALLATION_DEFAULT_NAME:
-            # The default app is configured in the installation YAML
+        if self.app_id is not None and self.pem_path is not None:
             return True
-        return self.app_id is not None and self.pem_path is not None
+        # The default app is configured in the installation YAML
+        installation_default_app_id = get_config("github", "integration", "id")
+        return self.app_id == installation_default_app_id
 
     def repository_queryset(self) -> BaseManager[Repository]:
         """Returns a QuerySet of repositories covered by this installation"""

--- a/codecov_auth/tests/unit/test_models.py
+++ b/codecov_auth/tests/unit/test_models.py
@@ -4,9 +4,11 @@ from unittest.mock import patch
 import pytest
 from django.forms import ValidationError
 from django.test import TransactionTestCase
+from shared.utils.test_utils import mock_config_helper
 
 from codecov_auth.models import (
     DEFAULT_AVATAR_SIZE,
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     INFINITY,
     SERVICE_BITBUCKET,
     SERVICE_BITBUCKET_SERVER,
@@ -466,6 +468,15 @@ class TestOrganizationLevelTokenModel(TransactionTestCase):
 
 
 class TestGithubAppInstallationModel(TransactionTestCase):
+
+    DEFAULT_APP_ID = 12345
+
+    @pytest.fixture(autouse=True)
+    def mock_default_app_id(self, mocker):
+        mock_config_helper(
+            mocker, configs={"github.integration.id": self.DEFAULT_APP_ID}
+        )
+
     def test_covers_all_repos(self):
         owner = OwnerFactory()
         repo1 = RepositoryFactory(author=owner)
@@ -519,7 +530,11 @@ class TestGithubAppInstallationModel(TransactionTestCase):
     def test_is_configured(self):
         owner = OwnerFactory()
         installation_default = GithubAppInstallation(
-            owner=owner, repository_service_ids=None, installation_id=100
+            owner=owner,
+            repository_service_ids=None,
+            installation_id=123,
+            app_id=self.DEFAULT_APP_ID,
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
         )
         installation_configured = GithubAppInstallation(
             owner=owner,
@@ -536,9 +551,35 @@ class TestGithubAppInstallationModel(TransactionTestCase):
             name="my_other_installation",
             app_id=1234,
         )
+        installation_default_name_not_configured = GithubAppInstallation(
+            owner=owner,
+            repository_service_ids=None,
+            installation_id=100,
+            app_id=121212,
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+        )
+        installation_default_name_not_default_id_configured = GithubAppInstallation(
+            owner=owner,
+            repository_service_ids=None,
+            installation_id=100,
+            app_id=121212,
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            pem_path="some_path",
+        )
         installation_default.save()
         installation_configured.save()
         installation_not_configured.save()
+        installation_default_name_not_configured.save()
+        installation_default_name_not_default_id_configured.save()
         assert installation_default.is_configured() == True
         assert installation_configured.is_configured() == True
         assert installation_not_configured.is_configured() == False
+        assert installation_default_name_not_configured.app_id != self.DEFAULT_APP_ID
+        assert installation_default_name_not_configured.is_configured() == False
+        assert (
+            installation_default_name_not_default_id_configured.app_id
+            != self.DEFAULT_APP_ID
+        )
+        assert (
+            installation_default_name_not_default_id_configured.is_configured() == True
+        )

--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -11,7 +11,12 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 from shared.utils.test_utils import mock_config_helper, mock_metrics
 
-from codecov_auth.models import GithubAppInstallation, Owner, Service
+from codecov_auth.models import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    GithubAppInstallation,
+    Owner,
+    Service,
+)
 from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import (
     BranchFactory,
@@ -40,6 +45,7 @@ class MockedSubscription(object):
 
 
 WEBHOOK_SECRET = b"testixik8qdauiab1yiffydimvi72ekq"
+DEFAULT_APP_ID = 1234
 
 
 class GithubWebhookHandlerTests(APITestCase):
@@ -50,6 +56,10 @@ class GithubWebhookHandlerTests(APITestCase):
     @pytest.fixture(autouse=True)
     def mock_webhook_secret(self, mocker):
         mock_config_helper(mocker, configs={"github.webhook_secret": WEBHOOK_SECRET})
+
+    @pytest.fixture(autouse=True)
+    def mock_default_app_id(self, mocker):
+        mock_config_helper(mocker, configs={"github.integration.id": 1234})
 
     def _post_event_data(self, event, data={}):
         return self.client.post(
@@ -628,7 +638,7 @@ class GithubWebhookHandlerTests(APITestCase):
         assert pull.title == new_title
 
     @patch("services.task.TaskService.refresh")
-    def test_installation_creates_new_owner_if_dne(self, mock_refresh):
+    def test_installation_creates_new_owner_if_dne_default_app(self, mock_refresh):
         username, service_id = "newuser", 123456
 
         response = self._post_event_data(
@@ -638,7 +648,7 @@ class GithubWebhookHandlerTests(APITestCase):
                     "id": 4,
                     "repository_selection": "selected",
                     "account": {"id": service_id, "login": username},
-                    "app_id": 15,
+                    "app_id": DEFAULT_APP_ID,
                 },
                 "repositories": [
                     {"id": "12321", "node_id": "R_kgDOG2tZYQ"},
@@ -662,7 +672,8 @@ class GithubWebhookHandlerTests(APITestCase):
         assert ghapp_installations_set.count() == 1
         installation = ghapp_installations_set.first()
         assert installation.installation_id == 4
-        assert installation.app_id == 15
+        assert installation.app_id == DEFAULT_APP_ID
+        assert installation.name == GITHUB_APP_INSTALLATION_DEFAULT_NAME
         assert installation.repository_service_ids == ["12321", "12343"]
 
         assert mock_refresh.call_count == 1
@@ -683,7 +694,7 @@ class GithubWebhookHandlerTests(APITestCase):
         "services.task.TaskService.refresh",
         lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
-    def test_installation_creates_new_owner_if_dne_all_repos(self):
+    def test_installation_creates_new_owner_if_dne_all_repos_non_default_app(self):
         username, service_id = "newuser", 123456
 
         response = self._post_event_data(
@@ -717,6 +728,8 @@ class GithubWebhookHandlerTests(APITestCase):
         assert ghapp_installations_set.count() == 1
         installation = ghapp_installations_set.first()
         assert installation.installation_id == 4
+        assert installation.app_id == 15
+        assert installation.name == "unconfigured_app"
         assert installation.repository_service_ids == None
 
     @patch(
@@ -754,6 +767,8 @@ class GithubWebhookHandlerTests(APITestCase):
         assert ghapp_installations_set.count() == 1
         installation = ghapp_installations_set.first()
         assert installation.installation_id == 4
+        assert installation.app_id == 15
+        assert installation.name == "unconfigured_app"
         assert installation.repository_service_ids == None
 
     @patch(
@@ -764,7 +779,10 @@ class GithubWebhookHandlerTests(APITestCase):
         owner = OwnerFactory(service=Service.GITHUB.value)
         owner.save()
         installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=["repo1", "repo2"], installation_id=4
+            owner=owner,
+            repository_service_ids=["repo1", "repo2"],
+            installation_id=4,
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
         )
         installation.save()
         assert owner.github_app_installations.count() == 1
@@ -795,6 +813,9 @@ class GithubWebhookHandlerTests(APITestCase):
         )  # no new installations created
         installation = owner.github_app_installations.first()
         assert installation.installation_id == 4
+        # This installation changed names because it's not configured
+        # AND doesn't have the default app id
+        assert installation.name == "unconfigured_app"
         assert installation.repository_service_ids == ["repo1", "repo2", "repo3"]
 
     def test_installation_with_deleted_action_nulls_values(self):
@@ -864,7 +885,10 @@ class GithubWebhookHandlerTests(APITestCase):
         repo1 = RepositoryFactory(author=owner)
         repo2 = RepositoryFactory(author=owner)
         installation = GithubAppInstallation(
-            owner=owner, repository_service_ids=[repo1.service_id], installation_id=12
+            owner=owner,
+            repository_service_ids=[repo1.service_id],
+            installation_id=12,
+            name="custom_app",
         )
 
         owner.integration_id = 12
@@ -905,6 +929,9 @@ class GithubWebhookHandlerTests(APITestCase):
 
         installation.refresh_from_db()
         assert installation.installation_id == 12
+        # This app, even if not configured, was given a custom name
+        # So we don't change its name
+        assert installation.name == "custom_app"
         assert installation.repository_service_ids == [repo2.service_id]
         assert installation.is_repo_covered_by_integration(repo2) is True
 

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -424,14 +424,8 @@ class GithubWebhookHandler(APIView):
 
         Returns the app name that should be used
         """
-        if ghapp.name != GITHUB_APP_INSTALLATION_DEFAULT_NAME:
+        if ghapp.is_configured():
             return ghapp.name
-        installation_default_app_id = get_config("github", "integration", "id")
-        # `app_id` and `installation_default_app_id` should both be ints
-        # But just to avoid differences parsing either the YAML or the request data
-        # Casting them to str for the comparison (str has less change of failing)
-        if str(app_id) == str(installation_default_app_id):
-            return GITHUB_APP_INSTALLATION_DEFAULT_NAME
         return "unconfigured_app"
 
     def _handle_installation_repository_events(self, request, *args, **kwargs):


### PR DESCRIPTION
The configuration for ghapps need to be done carefully before they can
be used. And that process is _manual_.

However it's very simple for a user to simply go and install an app to
their organization and point it's webhooks to us. In this case we would
think it's the default app and break the app.

So now we update the app's names everytime we get a new webhook for it.
Only the configured default app may use the default name, all others,
unless they manually receive a custom name, will be 'unconfigured_app'.

Closes: https://github.com/codecov/engineering-team/issues/1445

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
