### PR TITLE
make `is_configured` more rebust

### DIFF
--- a/codecov_auth/models.py
+++ b/codecov_auth/models.py
@@ -514,7 +514,7 @@ class GithubAppInstallation(
             return True
         # The default app is configured in the installation YAML
         installation_default_app_id = get_config("github", "integration", "id")
-        return self.app_id == installation_default_app_id
+        return str(self.app_id) == str(installation_default_app_id)
 
     def repository_queryset(self) -> BaseManager[Repository]:
         """Returns a QuerySet of repositories covered by this installation"""

--- a/codecov_auth/tests/unit/test_models.py
+++ b/codecov_auth/tests/unit/test_models.py
@@ -567,11 +567,16 @@ class TestGithubAppInstallationModel(TransactionTestCase):
             pem_path="some_path",
         )
         installation_default.save()
+
         installation_configured.save()
         installation_not_configured.save()
         installation_default_name_not_configured.save()
         installation_default_name_not_default_id_configured.save()
+
         assert installation_default.is_configured() == True
+        installation_default.app_id = str(self.DEFAULT_APP_ID)
+        assert installation_default.is_configured() == True
+
         assert installation_configured.is_configured() == True
         assert installation_not_configured.is_configured() == False
         assert installation_default_name_not_configured.app_id != self.DEFAULT_APP_ID


### PR DESCRIPTION
Recently an enterprise customer had a ghapp instance of the default
app change names to `unconfigured_app` even though it is the default
app.

One possible explanation is that in the YAML the default app id is a string,
not a number. This small change is to catch that case.

The motivation is:
```
>>> 10 == 10
True
>>> 10 == '10'
False
>>> str(10) == str('10')
True
```

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
