### PR TITLE
rename from componentMeasurements to components

### DIFF
--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -778,7 +778,7 @@ query ComponentMeasurements(
 ) {
     owner(username: $name) {
         repository: repositoryDeprecated(name: $repo) {
-            componentMeasurements(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
+            components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
                 __typename
                 ... on ComponentMeasurements {
                     name
@@ -901,7 +901,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
         assert data == {
             "owner": {
                 "repository": {
-                    "componentMeasurements": [
+                    "components": [
                         {
                             "__typename": "ComponentMeasurements",
                             "name": "golang",
@@ -983,7 +983,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
         assert data == {
             "owner": {
                 "repository": {
-                    "componentMeasurements": [
+                    "components": [
                         {
                             "__typename": "ComponentMeasurements",
                             "name": "golang",
@@ -1013,7 +1013,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
             "before": timezone.datetime(2022, 6, 23),
         }
         data = self.gql_request(query_component_measurements, variables=variables)
-        assert data == {"owner": {"repository": {"componentMeasurements": []}}}
+        assert data == {"owner": {"repository": {"components": []}}}
 
     def test_component_measurements_with_filter(self):
         MeasurementFactory(
@@ -1090,7 +1090,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
         assert data == {
             "owner": {
                 "repository": {
-                    "componentMeasurements": [
+                    "components": [
                         {
                             "__typename": "ComponentMeasurements",
                             "name": "python",
@@ -1203,7 +1203,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
         assert data == {
             "owner": {
                 "repository": {
-                    "componentMeasurements": [
+                    "components": [
                         {
                             "__typename": "ComponentMeasurements",
                             "name": "golang",

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -71,7 +71,7 @@ type Repository {
   languages: [String!]
   bundleAnalysisEnabled: Boolean
   coverageEnabled: Boolean
-  componentMeasurements(
+  components(
     interval: MeasurementInterval!
     before: DateTime!
     after: DateTime!

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -400,7 +400,7 @@ def resolve_repository_result_type(obj, *_):
         return "NotFoundError"
 
 
-@repository_bindable.field("componentMeasurements")
+@repository_bindable.field("components")
 @convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_component_measurements(


### PR DESCRIPTION

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
