### PR TITLE
Warn when ghapps flip names

### DIFF
--- a/codecov_auth/models.py
+++ b/codecov_auth/models.py
@@ -512,6 +512,8 @@ class GithubAppInstallation(
         """Returns whether this installation is properly configured and can be used"""
         if self.app_id is not None and self.pem_path is not None:
             return True
+        if self.name == "unconfigured_app":
+            return False
         # The default app is configured in the installation YAML
         installation_default_app_id = get_config("github", "integration", "id")
         return str(self.app_id) == str(installation_default_app_id)

--- a/codecov_auth/tests/unit/test_models.py
+++ b/codecov_auth/tests/unit/test_models.py
@@ -576,6 +576,9 @@ class TestGithubAppInstallationModel(TransactionTestCase):
         assert installation_default.is_configured() == True
         installation_default.app_id = str(self.DEFAULT_APP_ID)
         assert installation_default.is_configured() == True
+        # Unconfigured apps are not configured
+        installation_default.name = "unconfigured_app"
+        assert installation_default.is_configured() == False
 
         assert installation_configured.is_configured() == True
         assert installation_not_configured.is_configured() == False

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -411,9 +411,7 @@ class GithubWebhookHandler(APIView):
 
         return Response()
 
-    def _decide_app_name(
-        self, ghapp: GithubAppInstallation, app_id: Union[str, int]
-    ) -> str:
+    def _decide_app_name(self, ghapp: GithubAppInstallation) -> str:
         """Possibly updated the name of a GithubAppInstallation that has been fetched from DB or created.
         Only the real default installation maybe use the name `GITHUB_APP_INSTALLATION_DEFAULT_NAME`
         (otherwise we break the app)
@@ -426,6 +424,10 @@ class GithubWebhookHandler(APIView):
         """
         if ghapp.is_configured():
             return ghapp.name
+        log.warning(
+            "Github installation is unconfigured. Changing name to 'unconfigured_app'",
+            extra=dict(installation=ghapp.external_id, previous_name=ghapp.name),
+        )
         return "unconfigured_app"
 
     def _handle_installation_repository_events(self, request, *args, **kwargs):
@@ -444,7 +446,7 @@ class GithubWebhookHandler(APIView):
         # Either update or set
         # But this value shouldn't change for the installation, so doesn't matter
         ghapp_installation.app_id = app_id
-        ghapp_installation.name = self._decide_app_name(ghapp_installation, app_id)
+        ghapp_installation.name = self._decide_app_name(ghapp_installation)
 
         all_repos_affected = request.data.get("repository_selection") == "all"
         if all_repos_affected:
@@ -509,9 +511,7 @@ class GithubWebhookHandler(APIView):
                 # Either update or set
                 # But this value shouldn't change for the installation, so doesn't matter
                 ghapp_installation.app_id = app_id
-                ghapp_installation.name = self._decide_app_name(
-                    ghapp_installation, app_id
-                )
+                ghapp_installation.name = self._decide_app_name(ghapp_installation)
 
                 affects_all_repositories = (
                     request.data["installation"]["repository_selection"] == "all"


### PR DESCRIPTION
We had again a situation in staging that the default app flipped names to 'unconfigured_app'.
Not sure why exactly, but it's anoying and disruptive.

These changes emit a warning when the app flips name to unconfigured so we can track better
that situation (but we hope it doesn't happen much) and hopefully get better understanding
on why it's happening.

I also made a change to the `is_configured` function that an app unconfigured is never configured.

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
