### PR TITLE
add getting components from yaml GQL

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -592,7 +592,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(
             query_repository
             % """
-                componentsYaml(term: null) {
+                componentsYaml(term_id: null) {
                     id
                     name
                 }
@@ -629,7 +629,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(
             query_repository
             % """
-                componentsYaml(term: "blah") {
+                componentsYaml(term_id: "blah") {
                     id
                     name
                 }

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -592,7 +592,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(
             query_repository
             % """
-                componentsYaml(term_id: null) {
+                componentsYaml(termId: null) {
                     id
                     name
                 }
@@ -629,7 +629,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(
             query_repository
             % """
-                componentsYaml(term_id: "blah") {
+                componentsYaml(termId: "blah") {
                     id
                     name
                 }

--- a/graphql_api/types/component/component.graphql
+++ b/graphql_api/types/component/component.graphql
@@ -10,3 +10,8 @@ type ComponentMeasurements {
     percentChange: Float
     measurements: [Measurement!]!
 }
+
+type ComponentsYaml {
+    id: String!
+    name: String!
+}

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -79,6 +79,9 @@ type Repository {
     filters: ComponentMeasurementsSetFilters
     orderingDirection: OrderingDirection
   ): [ComponentMeasurements!]!
+  componentsYaml(
+    term: String
+  ): [ComponentsYaml]!
 }
 
 type PullConnection {

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -80,7 +80,7 @@ type Repository {
     orderingDirection: OrderingDirection
   ): [ComponentMeasurements!]!
   componentsYaml(
-    term: String
+    term_id: String
   ): [ComponentsYaml]!
 }
 

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -80,7 +80,7 @@ type Repository {
     orderingDirection: OrderingDirection
   ): [ComponentMeasurements!]!
   componentsYaml(
-    term_id: String
+    termId: String
   ): [ComponentsYaml]!
 }
 

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -447,3 +447,28 @@ def resolve_component_measurements(
         key=lambda c: c.name,
         reverse=ordering_direction == OrderingDirection.DESC,
     )
+
+
+@repository_bindable.field("componentsYaml")
+@convert_kwargs_to_snake_case
+def resolve_component_yaml(
+    repository: Repository, info, term: Optional[str]
+) -> List[str]:
+    components = UserYaml.get_final_yaml(
+        owner_yaml=repository.author.yaml,
+        repo_yaml=repository.yaml,
+        ownerid=repository.author.ownerid,
+    ).get_components()
+
+    components = [
+        {
+            "id": c.component_id,
+            "name": c.name,
+        }
+        for c in components
+    ]
+
+    if term:
+        components = filter(lambda c: term in c["id"], components)
+
+    return components

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -452,7 +452,7 @@ def resolve_component_measurements(
 @repository_bindable.field("componentsYaml")
 @convert_kwargs_to_snake_case
 def resolve_component_yaml(
-    repository: Repository, info, term: Optional[str]
+    repository: Repository, info, term_id: Optional[str]
 ) -> List[str]:
     components = UserYaml.get_final_yaml(
         owner_yaml=repository.author.yaml,
@@ -468,7 +468,7 @@ def resolve_component_yaml(
         for c in components
     ]
 
-    if term:
-        components = filter(lambda c: term in c["id"], components)
+    if term_id:
+        components = filter(lambda c: term_id in c["id"], components)
 
     return components


### PR DESCRIPTION
Add a new GQL field in Repository to get all components in the YAML, returning the `id` and `name`, allow searching by a term
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
