### PR TITLE
fix: flag filtering for branch contents

### DIFF
--- a/services/path.py
+++ b/services/path.py
@@ -228,6 +228,10 @@ class ReportPaths:
         """
         Returns the report totals for a given prefixed path.
         """
+        # Fixes an issue when filtering by flags does not work in the case where
+        # one flag covers half of the file and another flag covers another half.
+        # Using get_file_totals will return the totals for coverage of all flags
+        # applied to the file instead of just the filter flags being queried
         if self.filter_flags:
             return self.report.get(path.full_path).totals
         else:

--- a/services/path.py
+++ b/services/path.py
@@ -228,7 +228,10 @@ class ReportPaths:
         """
         Returns the report totals for a given prefixed path.
         """
-        return self.report.get_file_totals(path.full_path)
+        if self.filter_flags:
+            return self.report.get(path.full_path).totals
+        else:
+            return self.report.get_file_totals(path.full_path)
 
     def _single_directory_recursive(
         self, paths: Iterable[PrefixedPath]


### PR DESCRIPTION
### Purpose/Motivation

If BranchContents has flag filtering need to build the FilteredReportFiles to get the accurate coverage totals instead of using the current minimal way of processing.

### Links to relevant tickets

https://github.com/codecov/internal-issues/issues/370

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
