### PR TITLE
components over time add lastUploaded

### DIFF
--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -790,6 +790,7 @@ query ComponentMeasurements(
                         max
                         timestamp
                     }
+                    lastUploaded
                 }
             }
         }
@@ -933,6 +934,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
+                            "lastUploaded": "2022-06-22T00:00:00+00:00",
                         },
                         {
                             "__typename": "ComponentMeasurements",
@@ -965,6 +967,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
+                            "lastUploaded": "2022-06-22T00:00:00+00:00",
                         },
                     ]
                 }
@@ -990,6 +993,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                             "percentCovered": None,
                             "percentChange": None,
                             "measurements": [],
+                            "lastUploaded": None,
                         },
                         {
                             "__typename": "ComponentMeasurements",
@@ -997,6 +1001,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                             "percentCovered": None,
                             "percentChange": None,
                             "measurements": [],
+                            "lastUploaded": None,
                         },
                     ]
                 }
@@ -1122,6 +1127,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
+                            "lastUploaded": "2022-06-22T00:00:00+00:00",
                         },
                     ]
                 }
@@ -1235,6 +1241,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
+                            "lastUploaded": "2022-06-22T00:00:00+00:00",
                         },
                         {
                             "__typename": "ComponentMeasurements",
@@ -1242,6 +1249,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                             "percentCovered": None,
                             "percentChange": None,
                             "measurements": [],
+                            "lastUploaded": None,
                         },
                     ]
                 }

--- a/graphql_api/types/component/component.graphql
+++ b/graphql_api/types/component/component.graphql
@@ -9,6 +9,7 @@ type ComponentMeasurements {
     percentCovered: Float
     percentChange: Float
     measurements: [Measurement!]!
+    lastUploaded: DateTime
 }
 
 type ComponentsYaml {

--- a/services/components.py
+++ b/services/components.py
@@ -113,3 +113,8 @@ class ComponentMeasurements:
         return fill_sparse_measurements(
             self.raw_measurements, self.interval, self.after, self.before
         )
+
+    @cached_property
+    def last_uploaded(self):
+        if len(self.raw_measurements) > 1:
+            return self.raw_measurements[-1]["timestamp_bin"]


### PR DESCRIPTION
### Purpose/Motivation

Add a last uploaded timestamp to components measurement for the last measurement data point for this measurement ID.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
