### PR TITLE
build: update the CLI version to upload test results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ API_DOMAIN ?= api
 PROXY_NETWORK ?= api_default
 
 # Codecov CLI version to use
-CODECOV_CLI_VERSION := 0.4.1
+CODECOV_CLI_VERSION := 0.5.1
 
 build:
 	make build.requirements


### PR DESCRIPTION
### Purpose/Motivation
Uploading test results in CI is not working

### What does this PR do?
Updates version of the Codecov CLI in the CI to a version that supports uploading test results.
