### PR TITLE
fix: last uploaded for components over time

### DIFF
--- a/services/components.py
+++ b/services/components.py
@@ -116,5 +116,5 @@ class ComponentMeasurements:
 
     @cached_property
     def last_uploaded(self):
-        if len(self.raw_measurements) > 1:
+        if len(self.raw_measurements) > 0:
             return self.raw_measurements[-1]["timestamp_bin"]


### PR DESCRIPTION
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
