### PR TITLE
fix: use proper measurement last uploaded

### DIFF
--- a/graphql_api/actions/components.py
+++ b/graphql_api/actions/components.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Iterable, Mapping, Optional
 
+from django.db.models import QuerySet
+
 from codecov_auth.models import Owner
 from core.models import Repository
 from graphql_api.actions.measurements import (
@@ -34,7 +36,7 @@ def component_measurements_last_uploaded(
     repo_id: int,
     measurable_ids: str,
     branch: Optional[str] = None,
-):
+) -> QuerySet:
     return measurements_last_uploaded_by_ids(
         owner_id=owner_id,
         repo_id=repo_id,

--- a/graphql_api/actions/components.py
+++ b/graphql_api/actions/components.py
@@ -1,8 +1,12 @@
 from datetime import datetime
 from typing import Iterable, Mapping, Optional
 
+from codecov_auth.models import Owner
 from core.models import Repository
-from graphql_api.actions.measurements import measurements_by_ids
+from graphql_api.actions.measurements import (
+    measurements_by_ids,
+    measurements_last_uploaded_by_ids,
+)
 from timeseries.models import Interval, MeasurementName
 
 
@@ -21,5 +25,20 @@ def component_measurements(
         interval=interval,
         after=after,
         before=before,
+        branch=branch,
+    )
+
+
+def component_measurements_last_uploaded(
+    owner_id: int,
+    repo_id: int,
+    measurable_ids: str,
+    branch: Optional[str] = None,
+):
+    return measurements_last_uploaded_by_ids(
+        owner_id=owner_id,
+        repo_id=repo_id,
+        measurable_name=MeasurementName.COMPONENT_COVERAGE.value,
+        measurable_ids=measurable_ids,
         branch=branch,
     )

--- a/graphql_api/actions/measurements.py
+++ b/graphql_api/actions/measurements.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Iterable, Mapping, Optional
 
-from django.db.models import Max
+from django.db.models import Max, QuerySet
 
 from core.models import Repository
 from timeseries.helpers import aggregate_measurements, aligned_start_date
@@ -50,7 +50,7 @@ def measurements_last_uploaded_by_ids(
     measurable_name: str,
     measurable_ids: str,
     branch: Optional[str] = None,
-):
+) -> QuerySet:
     queryset = Measurement.objects.filter(
         owner_id=owner_id,
         repo_id=repo_id,

--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -934,7 +934,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
-                            "lastUploaded": "2022-06-22T00:00:00+00:00",
+                            "lastUploaded": "2022-06-22T01:00:00+00:00",
                         },
                         {
                             "__typename": "ComponentMeasurements",
@@ -967,7 +967,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
-                            "lastUploaded": "2022-06-22T00:00:00+00:00",
+                            "lastUploaded": "2022-06-22T01:00:00+00:00",
                         },
                     ]
                 }
@@ -1127,7 +1127,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
-                            "lastUploaded": "2022-06-22T00:00:00+00:00",
+                            "lastUploaded": "2022-06-22T01:00:00+00:00",
                         },
                     ]
                 }
@@ -1241,7 +1241,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
                                     "timestamp": "2022-06-23T00:00:00+00:00",
                                 },
                             ],
-                            "lastUploaded": "2022-06-22T00:00:00+00:00",
+                            "lastUploaded": "2022-06-22T01:00:00+00:00",
                         },
                         {
                             "__typename": "ComponentMeasurements",

--- a/services/components.py
+++ b/services/components.py
@@ -85,12 +85,14 @@ class ComponentMeasurements:
         interval: Interval,
         after: datetime,
         before: datetime,
+        last_measurement: datetime,
     ):
         self.raw_measurements = raw_measurements
         self.component_id = component_id
         self.interval = interval
         self.after = after
         self.before = before
+        self.last_measurement = last_measurement
 
     @cached_property
     def name(self):
@@ -116,5 +118,4 @@ class ComponentMeasurements:
 
     @cached_property
     def last_uploaded(self):
-        if len(self.raw_measurements) > 0:
-            return self.raw_measurements[-1]["timestamp_bin"]
+        return self.last_measurement


### PR DESCRIPTION
### Purpose/Motivation

Don't use the aggregated timestamp from the summaries table, instead use the timestamp from the measurements table, this returns the true timestamp of when the last upload was inserted into the timeseries DB.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
