### PR TITLE
 Skip OwnerNotActivated error on unconfigured repos

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -460,7 +460,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
     @patch("services.activation.is_activated")
     @patch("services.activation.try_auto_activate")
-    def test_resolve_inactive__user_on_unconfigured_repo(
+    def test_resolve_inactive_user_on_unconfigured_repo(
         self, try_auto_activate, is_activated
     ):
         repo = RepositoryFactory(
@@ -479,10 +479,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             variables={"name": repo.name},
         )
 
-        assert data["me"]["owner"]["repository"] == {
-            "__typename": "OwnerNotActivatedError",
-            "message": "You must be activated in the org",
-        }
+        assert data["me"]["owner"]["repository"] == {{"name": "test-one"}}
 
     def test_repository_not_found(self):
         data = self.gql_request(

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -469,6 +469,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             activated=False,
             private=True,
             name="test-one",
+            coverageEnabled=True,
+            BundleAnalysisEnabled=False,
         )
 
         is_activated.return_value = False

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -479,7 +479,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             variables={"name": repo.name},
         )
 
-        assert data["me"]["owner"]["repository"] == {{"name": "test-one"}}
+        assert data["me"]["owner"]["repository"]["name"] == "test-one"
 
     def test_repository_not_found(self):
         data = self.gql_request(

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -405,7 +405,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             author=self.owner,
             active=True,
             private=True,
-            coverage_enabled=False,
+            coverage_enabled=True,
             bundle_analysis_enabled=True,
         )
 
@@ -450,7 +450,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             author=self.owner,
             active=True,
             private=True,
-            coverage_enabled=False,
+            coverage_enabled=True,
             bundle_analysis_enabled=True,
         )
 

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -469,8 +469,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             activated=False,
             private=True,
             name="test-one",
-            coverageEnabled=True,
-            BundleAnalysisEnabled=False,
+            coverage_enabled=True,
+            bundle_analysis_enabled=False,
         )
 
         is_activated.return_value = False

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -405,6 +405,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             author=self.owner,
             active=True,
             private=True,
+            coverage_enabled=False,
+            bundle_analysis_enabled=True,
         )
 
         self.gql_request(
@@ -425,6 +427,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             author=self.owner,
             active=True,
             private=True,
+            coverage_enabled=True,
+            bundle_analysis_enabled=True,
         )
 
         is_activated.return_value = False
@@ -446,6 +450,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             author=self.owner,
             active=True,
             private=True,
+            coverage_enabled=False,
+            bundle_analysis_enabled=True,
         )
 
         data = self.gql_request(

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -108,7 +108,7 @@ def resolve_ownerid(owner, info) -> int:
 @owner_bindable.field("repository")
 async def resolve_repository(owner, info, name):
     command = info.context["executor"].get_command("repository")
-    repository = await command.fetch_repository(owner, name)
+    repository: Optional[Repository] = await command.fetch_repository(owner, name)
 
     if repository is None:
         return NotFoundError()

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -114,9 +114,11 @@ async def resolve_repository(owner, info, name):
         return NotFoundError()
 
     current_owner = info.context["request"].current_owner
-    is_configured_repo = repository.active or repository.activated
+    has_products_enabled = (
+        repository.bundleAnalysisEnabled and repository.coverageEnabled
+    )
 
-    if repository.private and is_configured_repo:
+    if repository.private and has_products_enabled:
         await sync_to_async(activation.try_auto_activate)(owner, current_owner)
         is_owner_activated = await sync_to_async(activation.is_activated)(
             owner, current_owner

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -115,7 +115,7 @@ async def resolve_repository(owner, info, name):
 
     current_owner = info.context["request"].current_owner
     has_products_enabled = (
-        repository.bundleAnalysisEnabled and repository.coverageEnabled
+        repository.bundle_analysis_enabled and repository.coverage_enabled
     )
 
     if repository.private and has_products_enabled:


### PR DESCRIPTION
This is a follow up to https://github.com/codecov/engineering-team/issues/1253. 

On the front end, we want to show an error inside a page instead of letting `NetworkErrorBoundary` overwrite the whole page. Furthermore, we need repository information to conditionally render Coverage and Bundle Analysis setup tabs regardless of the owner's activation status. 

With this change, we do not throw an `OwnerNotActivated` error if the repo is not configured, enabling us to display onboarding tabs on the front end without throwing a page level error. 

More information about the project [here](https://www.notion.so/sentry/Seats-Allocations-Epic-733b98e82b2345c59e830e65d70ea8b1). 

Please note that this must be merged before https://github.com/codecov/gazebo/pull/2794.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
