### PR TITLE
fix: Handle flare when commit report not available

### DIFF
--- a/graphs/views.py
+++ b/graphs/views.py
@@ -214,6 +214,10 @@ class GraphHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
             )
 
         report = report_service.build_report_from_commit(commit)
+
+        if report is None:
+            raise NotFound("Not found. Note: file for chunks not found in storage")
+
         return report.flare(None, [70, 100])
 
     def get_pull_flare(self, pullid):


### PR DESCRIPTION
### Purpose/Motivation
Fixes an internal server error when trying to retrieve the flare graph when the commit report is not available.

### Links to relevant tickets

https://github.com/codecov/internal-issues/issues/395

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
