### PR TITLE
disable user-agent prometheus label to decrease load

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -55,8 +55,10 @@ class CustomMetricsWithUA(Metrics):
     """
 
     def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
-        if name in USER_AGENT_METRICS:
-            labelnames = list(labelnames) + ["user_agent"]
+        # TODO: Re-enable a cheaper form of user-agent logging
+        # https://github.com/codecov/engineering-team/issues/1654
+        # if name in USER_AGENT_METRICS:
+        #    labelnames = list(labelnames) + ["user_agent"]
         return super().register_metric(
             metric_cls, name, documentation, labelnames=labelnames, **kwargs
         )
@@ -79,7 +81,9 @@ class AppMetricsAfterMiddlewareWithUA(PrometheusAfterMiddleware):
 
     def label_metric(self, metric, request, response=None, **labels):
         new_labels = labels
-        if metric._name in USER_AGENT_METRICS:
-            new_labels = {"user_agent": request.headers.get("User-Agent", "none")}
-            new_labels.update(labels)
+        # TODO: Re-enable a cheaper form of user-agent logging
+        # https://github.com/codecov/engineering-team/issues/1654
+        # if metric._name in USER_AGENT_METRICS:
+        #     new_labels = {"user_agent": request.headers.get("User-Agent", "none")}
+        #     new_labels.update(labels)
         return super().label_metric(metric, request, response=response, **new_labels)

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -42,6 +42,9 @@ class CounterAssertionSet:
             )
 
 
+# TODO: Re-enable some cheaper form of user-agent logging
+# https://github.com/codecov/engineering-team/issues/1654
+"""
 class PrometheusUserAgentLabelTest(TestCase):
     def test_user_agent_label_added(self):
         user_agent = "iphone"
@@ -129,3 +132,4 @@ class PrometheusUserAgentLabelTest(TestCase):
                             == "none"  # not all requests have User-Agent header defined
                             or sample.labels["user_agent"] == user_agent
                         )
+"""


### PR DESCRIPTION
re-enable in https://github.com/codecov/engineering-team/issues/1654

apparently this label was bringing down prometheus so we are nuking it for now. there are so many distinct UAs that prometheus suffers from a combinatorial explosion of possible label combinations

the skeleton daniel set up to add/test this custom label is still good, just gotta tweak the actual value of the label to scrub some of the minutiae from it

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
