### PR TITLE
refine upload endpoint auth flow, add custom error message

### DIFF
--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -9,6 +9,8 @@ from django.db.models import QuerySet
 from django.utils import timezone
 from jwt import PyJWTError
 from rest_framework import authentication, exceptions
+from rest_framework.exceptions import NotAuthenticated
+from rest_framework.views import exception_handler
 from sentry_sdk import metrics as sentry_metrics
 from shared.metrics import metrics
 from shared.torngit.exceptions import TorngitObjectNotFoundError, TorngitRateLimitError
@@ -25,6 +27,26 @@ from services.repo_providers import RepoProviderService
 from upload.helpers import get_global_tokens, get_repo_with_github_actions_oidc_token
 from upload.views.helpers import get_repository_from_string
 from utils import is_uuid
+
+
+def repo_auth_custom_exception_handler(exc, context):
+    """
+    User arrives here if they have correctly supplied a Token or the Tokenless Headers,
+    but their Token has not matched with any of our Authentication methods. The goal is to
+    give the user something better than "Invalid Token" or "Authentication credentials were not provided."
+    """
+    response = exception_handler(exc, context)
+    if response is not None:
+        try:
+            exc_code = response.data["detail"].code
+        except TypeError:
+            return response
+        if exc_code == NotAuthenticated.default_code:
+            response.data["detail"] = (
+                "Failed token authentication, please double-check that your repository token matches in the Codecov UI, "
+                "or review the docs https://docs.codecov.com/docs/adding-the-codecov-token"
+            )
+    return response
 
 
 class LegacyTokenRepositoryAuth(RepositoryAuthInterface):
@@ -121,12 +143,9 @@ class RepositoryLegacyTokenAuthentication(authentication.TokenAuthentication):
     def authenticate_credentials(self, token):
         try:
             token = UUID(token)
-        except (ValueError, TypeError):
-            raise exceptions.AuthenticationFailed("Invalid token.")
-        try:
             repository = Repository.objects.get(upload_token=token)
-        except Repository.DoesNotExist:
-            raise exceptions.AuthenticationFailed("Invalid token.")
+        except (ValueError, TypeError, Repository.DoesNotExist):
+            return None  # continue to next auth class
         return (
             RepositoryAsUser(repository),
             LegacyTokenRepositoryAuth(repository, {"token": token}),
@@ -173,7 +192,7 @@ class GlobalTokenAuthentication(authentication.TokenAuthentication):
                     "Could not find a repository, try using repo upload token"
                 )
         else:
-            return None
+            return None  # continue to next auth class
         return (
             RepositoryAsUser(repository),
             LegacyTokenRepositoryAuth(repository, {"token": token}),
@@ -194,7 +213,7 @@ class GlobalTokenAuthentication(authentication.TokenAuthentication):
 
 class OrgLevelTokenAuthentication(authentication.TokenAuthentication):
     def authenticate_credentials(self, key):
-        if is_uuid(key):
+        if is_uuid(key):  # else, continue to next auth class
             # Actual verification for org level tokens
             token = OrganizationLevelToken.objects.filter(token=key).first()
 
@@ -216,9 +235,7 @@ class GitHubOIDCTokenAuthentication(authentication.TokenAuthentication):
         try:
             repository = get_repo_with_github_actions_oidc_token(token)
         except (ObjectDoesNotExist, PyJWTError):
-            raise exceptions.AuthenticationFailed(
-                f"Github OIDC Token Auth: Invalid token."
-            )
+            return None  # continue to next auth class
 
         return (
             RepositoryAsUser(repository),
@@ -232,7 +249,7 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
     It allows PRs from external contributors (forks) to upload coverage
     for the upstream repo when running in a PR.
 
-    While it uses the same "shell" (authentication.TOkenAuthentication)
+    While it uses the same "shell" (authentication.TokenAuthentication)
     it doesn't really rely on tokens to authenticate.
     """
 
@@ -288,7 +305,7 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
         fork_slug = request.headers.get("X-Tokenless", None)
         fork_pr = request.headers.get("X-Tokenless-PR", None)
         if fork_slug is None or fork_pr is None:
-            return None
+            return None  # continue to next auth class
         # Get the repo
         repository = self._get_repo_info_from_request_path(request)
         # Tokneless is only for public repos

--- a/codecov_auth/tests/unit/test_repo_authentication.py
+++ b/codecov_auth/tests/unit/test_repo_authentication.py
@@ -68,20 +68,20 @@ class TestRepositoryLegacyTokenAuthentication(object):
     def test_authenticate_credentials_empty(self, db):
         token = None
         authentication = RepositoryLegacyTokenAuthentication()
-        with pytest.raises(exceptions.AuthenticationFailed):
-            authentication.authenticate_credentials(token)
+        res = authentication.authenticate_credentials(token)
+        assert res is None
 
     def test_authenticate_credentials_not_uuid(self, db):
         token = "not-a-uuid"
         authentication = RepositoryLegacyTokenAuthentication()
-        with pytest.raises(exceptions.AuthenticationFailed):
-            authentication.authenticate_credentials(token)
+        res = authentication.authenticate_credentials(token)
+        assert res is None
 
     def test_authenticate_credentials_uuid_no_repo(self, db):
         token = str(uuid.uuid4())
         authentication = RepositoryLegacyTokenAuthentication()
-        with pytest.raises(exceptions.AuthenticationFailed):
-            authentication.authenticate_credentials(token)
+        res = authentication.authenticate_credentials(token)
+        assert res is None
 
     def test_authenticate_credentials_uuid_token_with_repo(self, db):
         repo = RepositoryFactory.create()
@@ -246,15 +246,15 @@ class TestGitHubOIDCTokenAuthentication(object):
         mocked_get_repo_with_token.side_effect = ObjectDoesNotExist()
         token = "the best token"
         authentication = GitHubOIDCTokenAuthentication()
-        with pytest.raises(exceptions.AuthenticationFailed):
-            authentication.authenticate_credentials(token)
+        res = authentication.authenticate_credentials(token)
+        assert res is None
 
     def test_authenticate_credentials_oidc_error(self, mocked_get_repo_with_token, db):
         mocked_get_repo_with_token.side_effect = PyJWTError()
         token = "the best token"
         authentication = GitHubOIDCTokenAuthentication()
-        with pytest.raises(exceptions.AuthenticationFailed):
-            authentication.authenticate_credentials(token)
+        res = authentication.authenticate_credentials(token)
+        assert res is None
 
     def test_authenticate_credentials_oidc_valid(self, mocked_get_repo_with_token, db):
         token = "the best token"

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -194,7 +194,10 @@ def test_upload_bundle_analysis_invalid_token(db, client, mocker, mock_redis):
         format="json",
     )
     assert res.status_code == 401
-    assert res.json() == {"detail": "Invalid token."}
+    assert res.json() == {
+        "detail": "Failed token authentication, please double-check that your repository token matches in the Codecov UI, "
+        "or review the docs https://docs.codecov.com/docs/adding-the-codecov-token"
+    }
     assert not upload.called
 
 

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -551,6 +551,55 @@ def test_uploads_post_github_oidc_auth(
     )
 
 
+def test_uploads_with_bad_token(
+    db,
+    mocker,
+    mock_redis,
+):
+    repository = RepositoryFactory(
+        name="the_repo",
+        author__username="codecov",
+        author__service="github",
+        private=False,
+    )
+    token = "BadToken"
+
+    commit = CommitFactory(repository=repository)
+    commit_report = CommitReport.objects.create(commit=commit, code="code")
+
+    client = APIClient()
+    url = reverse(
+        "new_upload.uploads",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+            commit_report.code,
+        ],
+    )
+    response = client.post(
+        url,
+        {
+            "state": "uploaded",
+            "flags": ["flag1", "flag2"],
+            "version": "version",
+        },
+        headers={"Authorization": f"token {token}"},
+    )
+    assert response.status_code == 401
+    response_json = response.json()
+    upload = ReportSession.objects.filter(
+        report_id=commit_report.id, upload_extras={"format_version": "v1"}
+    ).exists()
+    assert upload is False
+
+    assert (
+        response_json.get("detail")
+        == "Failed token authentication, please double-check that your repository token matches in the Codecov UI, "
+        "or review the docs https://docs.codecov.com/docs/adding-the-codecov-token"
+    )
+
+
 @override_settings(SHELTER_SHARED_SECRET="shelter-shared-secret")
 def test_uploads_post_shelter(db, mocker, mock_redis):
     mocker.patch.object(

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -12,6 +12,7 @@ from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from codecov_auth.authentication.types import RepositoryAsUser
 from codecov_auth.models import Owner, Service
@@ -48,6 +49,9 @@ class BundleAnalysisView(APIView):
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def post(self, request):
         serializer = UploadSerializer(data=request.data)

--- a/upload/views/commits.py
+++ b/upload/views/commits.py
@@ -10,6 +10,7 @@ from codecov_auth.authentication.repo_auth import (
     RepositoryLegacyTokenAuthentication,
     TokenlessAuth,
     TokenlessAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from core.models import Commit
 from services.task import TaskService
@@ -30,6 +31,9 @@ class CommitViews(ListCreateAPIView, GetterMixin):
         RepositoryLegacyTokenAuthentication,
         TokenlessAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def get_queryset(self):
         repository = self.get_repo()

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -15,6 +15,7 @@ from codecov_auth.authentication.repo_auth import (
     GlobalTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from services.repo_providers import RepoProviderService
 from services.task import TaskService
@@ -71,6 +72,9 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def post(self, request, *args, **kwargs):
         serializer = EmptyUploadSerializer(data=request.data)

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -10,6 +10,7 @@ from codecov_auth.authentication.repo_auth import (
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
     TokenlessAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from reports.models import CommitReport, ReportResults
 from services.task import TaskService
@@ -30,6 +31,9 @@ class ReportViews(ListCreateAPIView, GetterMixin):
         RepositoryLegacyTokenAuthentication,
         TokenlessAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def perform_create(self, serializer):
         repository = self.get_repo()
@@ -67,6 +71,9 @@ class ReportResultsView(
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def perform_create(self, serializer):
         repository = self.get_repo()

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -13,6 +13,7 @@ from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from codecov_auth.authentication.types import RepositoryAsUser
 from codecov_auth.models import Owner, Service
@@ -55,6 +56,9 @@ class TestResultsView(
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def post(self, request):
         serializer = UploadSerializer(data=request.data)

--- a/upload/views/upload_completion.py
+++ b/upload/views/upload_completion.py
@@ -9,6 +9,7 @@ from codecov_auth.authentication.repo_auth import (
     GlobalTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from reports.models import ReportSession
 from services.task import TaskService
@@ -26,6 +27,9 @@ class UploadCompletionView(CreateAPIView, GetterMixin):
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
     ]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def post(self, request, *args, **kwargs):
         repo = self.get_repo()

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -17,6 +17,7 @@ from codecov_auth.authentication.repo_auth import (
     RepositoryLegacyTokenAuthentication,
     TokenlessAuth,
     TokenlessAuthentication,
+    repo_auth_custom_exception_handler,
 )
 from codecov_auth.models import OrganizationLevelToken
 from core.models import Commit, Repository
@@ -59,6 +60,9 @@ class UploadViews(ListCreateAPIView, GetterMixin):
         TokenlessAuthentication,
     ]
     throttle_classes = [UploadsPerCommitThrottle, UploadsPerWindowThrottle]
+
+    def get_exception_handler(self):
+        return repo_auth_custom_exception_handler
 
     def perform_create(self, serializer: UploadSerializer):
         repository = self.get_repo()


### PR DESCRIPTION
### Purpose/Motivation
fixes https://github.com/codecov/feedback/issues/344

### What does this PR do?
Got some feedback, made me realize that this flow was being handled incorrectly. According to [Django's docs](https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication),

> Typically the approach you should take is:
> - If authentication is not attempted, return None. Any other authentication schemes also in use will still be checked.
> - If authentication is attempted but fails, raise an AuthenticationFailed exception. An error response will be returned immediately, regardless of any permissions checks, and without checking any other authentication schemes.

I updated the flow to return `None` in a few places, instead of raising an error based on context that the function was assuming. 

Instead, they will continue through the auth flow, so the error is handled by Django's built-in stuff. Then, I added a custom error message for when a user runs into this scenario, in `repo_auth_custom_exception_handler`.
