### PR TITLE
add rate limit error handling to TokenlessGithubActionsHandler

### DIFF
--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -1,12 +1,12 @@
 import time
 from datetime import datetime, timedelta
 from json import dumps, loads
-from unittest.mock import ANY, Mock, PropertyMock, call, patch
+from unittest.mock import ANY, PropertyMock, patch
 from urllib.parse import urlencode
 
 import pytest
 import requests
-from celery.canvas import Signature
+import rest_framework
 from ddf import G
 from django.core.exceptions import MultipleObjectsReturned
 from django.test import TestCase, override_settings
@@ -19,6 +19,7 @@ from rest_framework.test import APIRequestFactory, APITestCase
 from shared.torngit.exceptions import (
     TorngitClientGeneralError,
     TorngitObjectNotFoundError,
+    TorngitRateLimitError,
 )
 from shared.utils.test_utils import mock_metrics as utils_mock_metrics
 from simplejson import JSONDecodeError
@@ -26,7 +27,6 @@ from simplejson import JSONDecodeError
 from codecov_auth.models import Owner
 from codecov_auth.tests.factories import OwnerFactory
 from core.models import Commit, Repository
-from core.tests.factories import CommitFactory, PullFactory
 from reports.tests.factories import CommitReportFactory, UploadFactory
 from upload.helpers import (
     determine_repo_for_upload,
@@ -2745,6 +2745,44 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             == "Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue."
         )
         mock_get.assert_called_with("12.34")
+
+    @freeze_time("2024-04-25T00:00:00")
+    @patch("upload.tokenless.github_actions.get", new_callable=PropertyMock)
+    def test_github_actions_rate_limit_error(self, mock_get_torngit):
+        mock_get = mock_get_torngit.return_value.get_workflow_run
+        in_10_s = datetime.now() + timedelta(seconds=10)
+        mock_get.side_effect = [
+            TorngitRateLimitError("error", "err msg", in_10_s.timestamp(), 20)
+        ]
+
+        params = {"build": "12.34", "owner": "owner", "repo": "repo"}
+
+        with self.assertRaises(rest_framework.exceptions.Throttled) as e:
+            TokenlessUploadHandler("github_actions", params).verify_upload()
+        self.assertEqual(
+            str(e.exception.detail),
+            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 10 seconds.",
+        )
+
+        mock_get.reset_mock()
+        mock_get.side_effect = [TorngitRateLimitError("error", "err msg", None, 20)]
+
+        with self.assertRaises(rest_framework.exceptions.Throttled) as e:
+            TokenlessUploadHandler("github_actions", params).verify_upload()
+        self.assertEqual(
+            str(e.exception.detail),
+            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 20 seconds.",
+        )
+
+        mock_get.reset_mock()
+        mock_get.side_effect = [TorngitRateLimitError("error", "err msg", None, None)]
+
+        with self.assertRaises(rest_framework.exceptions.Throttled) as e:
+            TokenlessUploadHandler("github_actions", params).verify_upload()
+        self.assertEqual(
+            str(e.exception.detail),
+            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.",
+        )
 
     @patch(
         "upload.tokenless.github_actions.TokenlessGithubActionsHandler.get_build",

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -3,9 +3,10 @@ from datetime import datetime, timedelta
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
+from rest_framework import exceptions
 from rest_framework.exceptions import NotFound
 from shared.torngit import get
-from shared.torngit.exceptions import TorngitClientError
+from shared.torngit.exceptions import TorngitClientError, TorngitRateLimitError
 
 from upload.tokenless.base import BaseTokenlessUploadHandler
 
@@ -17,6 +18,17 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
     actions_token = settings.GITHUB_ACTIONS_TOKEN
     client_id = settings.GITHUB_CLIENT_ID
     client_secret = settings.GITHUB_CLIENT_SECRET
+
+    def log_warning(self, message):
+        log.warning(
+            message,
+            extra=dict(
+                commit=self.upload_params.get("commit"),
+                repo_name=self.upload_params.get("repo"),
+                job=self.upload_params.get("job"),
+                owner=self.upload_params.get("owner"),
+            ),
+        )
 
     def get_build(self):
         git = get(
@@ -31,29 +43,26 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
             actions_response = async_to_sync(git.get_workflow_run)(
                 self.upload_params.get("build")
             )
-        except TorngitClientError as e:
-            log.warning(
-                f"Request client error {e}",
-                extra=dict(
-                    commit=self.upload_params.get("commit"),
-                    repo_name=self.upload_params.get("repo"),
-                    job=self.upload_params.get("job"),
-                    owner=self.upload_params.get("owner"),
-                ),
+        except TorngitRateLimitError as e:
+            self.log_warning(message=f"Rate limit error {e}")
+            if e.reset:
+                now_timestamp = datetime.now().timestamp()
+                retry_after = int(e.reset) - int(now_timestamp)
+            elif e.retry_after:
+                retry_after = int(e.retry_after)
+            else:
+                retry_after = None
+            raise exceptions.Throttled(
+                wait=retry_after,
+                detail="Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.",
             )
+        except TorngitClientError as e:
+            self.log_warning(message=f"Request client error {e}")
             raise NotFound(
                 "Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue."
             )
         except Exception as e:
-            log.warning(
-                f"Request error {e}",
-                extra=dict(
-                    commit=self.upload_params.get("commit"),
-                    repo_name=self.upload_params.get("repo"),
-                    job=self.upload_params.get("job"),
-                    owner=self.upload_params.get("owner"),
-                ),
-            )
+            self.log_warning(message=f"Request error {e}")
             raise NotFound(
                 "Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue."
             )
@@ -83,14 +92,8 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
                 and self.upload_params.get("pr") == None
             )
         ):
-            log.warning(
-                f"Repository slug or commit sha do not match Github actions arguments",
-                extra=dict(
-                    commit=self.upload_params.get("commit"),
-                    repo_name=self.upload_params.get("repo"),
-                    job=self.upload_params.get("job"),
-                    owner=self.upload_params.get("owner"),
-                ),
+            self.log_warning(
+                message=f"Repository slug or commit sha do not match Github actions arguments"
             )
             raise NotFound(
                 "Repository slug or commit sha do not match Github actions build. Please upload with the Codecov repository upload token to resolve issue."
@@ -111,19 +114,6 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
             finish_time_with_buffer = build_finish_date_obj + timedelta(minutes=10)
             now = datetime.utcnow()
             if not now <= finish_time_with_buffer:
-                log.warning(
-                    "Actions workflow run is stale",
-                    extra=dict(
-                        build=build,
-                        commit=self.upload_params.get("commit"),
-                        finish_time_with_buffer=finish_time_with_buffer,
-                        job=self.upload_params.get("job"),
-                        now=now,
-                        owner=self.upload_params.get("owner"),
-                        repo_name=self.upload_params.get("repo"),
-                        time_diff=now - finish_time_with_buffer,
-                    ),
-                )
                 log.warning(
                     "Actions workflow run is stale",
                     extra=dict(


### PR DESCRIPTION
### Purpose/Motivation
Better errors for users

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1547

### What does this PR do?
Hitting the rate limit for tokenless upload is a special case, adds special handling for this special case, and makes the upload failure more clear to the end user.