### PR TITLE
fix: Remove duplicate names for resolvers and tests

### DIFF
--- a/api/internal/tests/views/test_coverage_viewset.py
+++ b/api/internal/tests/views/test_coverage_viewset.py
@@ -334,24 +334,6 @@ class CoverageViewSetTests(APITestCase):
         assert res.status_code == 404
 
     @patch("shared.reports.api_report_service.build_report_from_commit")
-    @patch("services.components.commit_components")
-    def test_tree_not_found_for_components(
-        self, commit_components_mock, build_report_from_commit
-    ):
-        commit_components_mock.return_value = [
-            Component.from_dict(
-                {
-                    "component_id": "c1",
-                    "name": "ComponentOne",
-                    "paths": ["dne.py"],
-                }
-            ),
-        ]
-        build_report_from_commit.return_value = sample_report()
-        res = self._tree(components="Does_not_exist")
-        assert res.status_code == 404
-
-    @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_tree_no_data_for_flags(self, build_report_from_commit):
         build_report_from_commit.return_value = sample_report()
         res = self._tree(flags="Does_not_exist")

--- a/codecov_auth/commands/owner/tests/test_owner.py
+++ b/codecov_auth/commands/owner/tests/test_owner.py
@@ -56,7 +56,7 @@ class OwnerCommandsTest(TransactionTestCase):
         interactor_mock.assert_called_once_with(input_dict)
 
     @patch("codecov_auth.commands.owner.owner.StartTrialInteractor.execute")
-    def test_cancel_trial_delegate_to_interactor(self, interactor_mock):
+    def test_start_trial_delegate_to_interactor(self, interactor_mock):
         org_username = "random_org"
         self.command.start_trial(org_username=org_username)
         interactor_mock.assert_called_once_with(org_username=org_username)

--- a/codecov_auth/tests/unit/test_helpers.py
+++ b/codecov_auth/tests/unit/test_helpers.py
@@ -26,11 +26,12 @@ def test_current_user_part_of_org_when_user_is_owner():
 def test_current_user_part_of_org_when_user_doesnt_have_org():
     org = OwnerFactory()
     current_user = OwnerFactory(organizations=None)
-    assert current_user_part_of_org(current_user, current_user) is False
+    current_user.save()
+    assert current_user_part_of_org(current_user, org) is False
 
 
 @pytest.mark.django_db
-def test_current_user_part_of_org_when_user_doesnt_have_org():
+def test_current_user_part_of_org_when_user_has_org():
     org = OwnerFactory()
     current_user = OwnerFactory(organizations=[org.ownerid])
     current_user.save()

--- a/codecov_auth/tests/unit/views/test_gitlab.py
+++ b/codecov_auth/tests/unit/views/test_gitlab.py
@@ -80,6 +80,11 @@ def test_get_gitlab_already_with_code(client, mocker, db, settings, mock_redis):
             as_tuple=mocker.MagicMock(return_value=("a", "b"))
         ),
     )
+
+    session = client.session
+    session["gitlab_oauth_state"] = "abc"
+    session.save()
+
     url = reverse("gitlab-login")
     mock_redis.setex("oauth-state-abc", 300, "http://localhost:3000/gl")
     res = client.get(url, {"code": "aaaaaaa", "state": "abc"})
@@ -92,7 +97,9 @@ def test_get_gitlab_already_with_code(client, mocker, db, settings, mock_redis):
     assert encryptor.decode(owner.oauth_token) == f"{access_token}: :{refresh_token}"
 
 
-def test_get_gitlab_already_with_code(client, mocker, db, settings, mock_redis):
+def test_get_gitlab_already_with_code_no_session(
+    client, mocker, db, settings, mock_redis
+):
     settings.GITLAB_CLIENT_ID = (
         "testfiuozujcfo5kxgigugr5x3xxx2ukgyandp16x6w566uits7f32crzl4yvmth"
     )

--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -628,7 +628,7 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
         }
 
     @patch("services.report.build_report_from_commit")
-    def test_fetch_path_contents_unknown_flags(self, report_mock):
+    def test_fetch_path_contents_unknown_flags_w_flags(self, report_mock):
         report_mock.return_value = MockReport()
 
         data = self.gql_request(
@@ -641,6 +641,7 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                 "filters": {"flags": ["test-123"]},
             },
         )
+
         assert data == {
             "owner": {
                 "repository": {
@@ -657,7 +658,7 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
         }
 
     @patch("services.report.build_report_from_commit")
-    def test_fetch_path_contents_unknown_flags(self, report_mock):
+    def test_fetch_path_contents_unknown_flags_no_flags(self, report_mock):
         report_mock.return_value = MockNoFlagsReport()
 
         data = self.gql_request(

--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -628,36 +628,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
         }
 
     @patch("services.report.build_report_from_commit")
-    def test_fetch_path_contents_unknown_flags_w_flags(self, report_mock):
-        report_mock.return_value = MockReport()
-
-        data = self.gql_request(
-            query_files,
-            variables={
-                "org": self.org.username,
-                "repo": self.repo.name,
-                "branch": self.branch.name,
-                "path": "",
-                "filters": {"flags": ["test-123"]},
-            },
-        )
-
-        assert data == {
-            "owner": {
-                "repository": {
-                    "branch": {
-                        "head": {
-                            "pathContents": {
-                                "__typename": "UnknownFlags",
-                                "message": "No coverage with chosen flags",
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-    @patch("services.report.build_report_from_commit")
     def test_fetch_path_contents_unknown_flags_no_flags(self, report_mock):
         report_mock.return_value = MockNoFlagsReport()
 

--- a/graphql_api/tests/test_pull_comparison.py
+++ b/graphql_api/tests/test_pull_comparison.py
@@ -979,68 +979,6 @@ class TestPullComparison(TransactionTestCase, GraphQLTestHelper):
 
         compute_comparisons_mock.assert_called_once
 
-    def test_pull_comparison_missing_head_report_deprecated(self):
-        self.head_report.side_effect = comparison.MissingComparisonReport(
-            "Missing head report"
-        )
-
-        query = """
-            pullId
-            compareWithBase {
-                ... on Comparison {
-                    state
-                    impactedFilesDeprecated {
-                        headName
-                    }
-                }
-            }
-        """
-
-        res = self.gql_request(
-            base_query % (self.repository.name, self.pull.pullid, query),
-            owner=self.owner,
-            with_errors=True,
-        )
-        assert res["errors"] is not None
-        assert res["errors"][0]["message"] == "Missing head report"
-        assert (
-            res["data"]["me"]["owner"]["repository"]["pull"]["compareWithBase"][
-                "impactedFilesDeprecated"
-            ]
-            is None
-        )
-
-    def test_pull_comparison_missing_base_report_deprecated(self):
-        self.base_report.side_effect = comparison.MissingComparisonReport(
-            "Missing base report"
-        )
-
-        query = """
-            pullId
-            compareWithBase {
-                ... on Comparison {
-                    state
-                    impactedFilesDeprecated {
-                        headName
-                    }
-                }
-            }
-        """
-
-        res = self.gql_request(
-            base_query % (self.repository.name, self.pull.pullid, query),
-            owner=self.owner,
-            with_errors=True,
-        )
-        assert res["errors"] is not None
-        assert res["errors"][0]["message"] == "Missing base report"
-        assert (
-            res["data"]["me"]["owner"]["repository"]["pull"]["compareWithBase"][
-                "impactedFilesDeprecated"
-            ]
-            is None
-        )
-
     def test_pull_comparison_missing_when_commit_comparison_state_is_errored(self):
         self.commit_comparison.state = CommitComparison.CommitComparisonStates.ERROR
         self.commit_comparison.save()

--- a/graphql_api/tests/test_pull_comparison.py
+++ b/graphql_api/tests/test_pull_comparison.py
@@ -979,7 +979,7 @@ class TestPullComparison(TransactionTestCase, GraphQLTestHelper):
 
         compute_comparisons_mock.assert_called_once
 
-    def test_pull_comparison_missing_head_report(self):
+    def test_pull_comparison_missing_head_report_deprecated(self):
         self.head_report.side_effect = comparison.MissingComparisonReport(
             "Missing head report"
         )
@@ -1010,7 +1010,7 @@ class TestPullComparison(TransactionTestCase, GraphQLTestHelper):
             is None
         )
 
-    def test_pull_comparison_missing_base_report(self):
+    def test_pull_comparison_missing_base_report_deprecated(self):
         self.base_report.side_effect = comparison.MissingComparisonReport(
             "Missing base report"
         )

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -1,4 +1,4 @@
-from typing import List, Mapping
+from typing import List, Mapping, Optional
 
 from ariadne import ObjectType
 
@@ -34,12 +34,12 @@ def resolve_bundle_load_time(bundle_data: BundleData, info) -> BundleLoadTime:
 
 
 @bundle_module_bindable.field("name")
-def resolve_name(bundle_module: ModuleReport, info) -> str:
+def resolve_bundle_module_name(bundle_module: ModuleReport, info) -> str:
     return bundle_module.name
 
 
 @bundle_module_bindable.field("bundleData")
-def resolve_bundle_data(bundle_module: ModuleReport, info) -> int:
+def resolve_bundle_module_bundle_data(bundle_module: ModuleReport, info) -> int:
     return BundleData(bundle_module.size_total)
 
 
@@ -47,7 +47,7 @@ def resolve_bundle_data(bundle_module: ModuleReport, info) -> int:
 
 
 @bundle_asset_bindable.field("name")
-def resolve_name(bundle_asset: AssetReport, info) -> str:
+def resolve_bundle_asset_name(bundle_asset: AssetReport, info) -> str:
     return bundle_asset.name
 
 
@@ -62,7 +62,7 @@ def resolve_extension(bundle_asset: AssetReport, info) -> str:
 
 
 @bundle_asset_bindable.field("bundleData")
-def resolve_bundle_data(bundle_asset: AssetReport, info) -> BundleData:
+def resolve_bundle_asset_bundle_data(bundle_asset: AssetReport, info) -> BundleData:
     return BundleData(bundle_asset.size_total)
 
 
@@ -72,7 +72,9 @@ def resolve_modules(bundle_asset: AssetReport, info) -> List[ModuleReport]:
 
 
 @bundle_asset_bindable.field("moduleExtensions")
-def resolve_module_extensions(bundle_asset: AssetReport, info) -> List[str]:
+def resolve_bundle_asset_module_extensions(
+    bundle_asset: AssetReport, info
+) -> List[str]:
     return bundle_asset.module_extensions
 
 
@@ -110,7 +112,7 @@ def resolve_module_count(bundle_report: BundleReport, info) -> int:
 def resolve_assets(
     bundle_report: BundleReport,
     info,
-    filters: Mapping = None,
+    filters: Optional[Mapping] = None,
 ) -> List[AssetReport]:
     extensions_filter = filters.get("moduleExtensions", None) if filters else None
     return list(bundle_report.assets(extensions_filter))

--- a/graphql_api/types/bundle_analysis/comparison.py
+++ b/graphql_api/types/bundle_analysis/comparison.py
@@ -35,43 +35,49 @@ def resolve_bundle_analysis_comparison_result_type(obj, *_):
 
 
 @bundle_analysis_comparison_bindable.field("sizeDelta")
-def resolve_size_delta(bundles_analysis_comparison: BundleAnalysisComparison, info):
+def resolve_ba_comparison_size_delta(
+    bundles_analysis_comparison: BundleAnalysisComparison, info
+):
     return bundles_analysis_comparison.size_delta
 
 
 @bundle_analysis_comparison_bindable.field("sizeTotal")
-def resolve_size_total(bundles_analysis_comparison: BundleAnalysisComparison, info):
+def resolve_ba_comparison_size_total(
+    bundles_analysis_comparison: BundleAnalysisComparison, info
+):
     return bundles_analysis_comparison.size_total
 
 
 @bundle_analysis_comparison_bindable.field("loadTimeDelta")
-def resolve_load_time_delta(
+def resolve_ba_comparison_load_time_delta(
     bundles_analysis_comparison: BundleAnalysisComparison, info
 ):
     return bundles_analysis_comparison.load_time_delta
 
 
 @bundle_analysis_comparison_bindable.field("loadTimeTotal")
-def resolve_load_time_total(
+def resolve_ba_comparison_load_time_total(
     bundles_analysis_comparison: BundleAnalysisComparison, info
 ):
     return bundles_analysis_comparison.load_time_total
 
 
 @bundle_analysis_comparison_bindable.field("bundles")
-def resolve_bundles(bundles_analysis_comparison: BundleAnalysisComparison, info):
+def resolve_ba_comparison_bundles(
+    bundles_analysis_comparison: BundleAnalysisComparison, info
+):
     return bundles_analysis_comparison.bundles
 
 
 @bundle_analysis_comparison_bindable.field("bundleData")
-def resolve_bundle_data(
+def resolve_ba_comparison_bundle_data(
     bundles_analysis_comparison: BundleAnalysisComparison, info
 ) -> BundleData:
     return BundleData(bundles_analysis_comparison.size_total)
 
 
 @bundle_analysis_comparison_bindable.field("bundleChange")
-def resolve_bundle_delta(
+def resolve_ba_comparison_bundle_delta(
     bundles_analysis_comparison: BundleAnalysisComparison, info
 ) -> BundleData:
     return BundleData(bundles_analysis_comparison.size_delta)

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -37,7 +37,7 @@ def resolve_state(comparison: ComparisonReport, info) -> str:
 @comparison_bindable.field("impactedFilesDeprecated")
 @convert_kwargs_to_snake_case
 @sync_to_async
-def resolve_impacted_files(
+def resolve_impacted_files_deprecated(
     comparison_report: ComparisonReport, info, filters=None
 ) -> List[ImpactedFile]:
     command: CompareCommands = info.context["executor"].get_command("compare")
@@ -240,9 +240,9 @@ def resolve_flag_comparisons_count(comparison: ComparisonReport, info):
 @comparison_bindable.field("hasDifferentNumberOfHeadAndBaseReports")
 @sync_to_async
 def resolve_has_different_number_of_head_and_base_reports(
-    comparison: ComparisonReport, info, **kwargs
+    comparison: ComparisonReport, info, **kwargs  # type: ignore
 ) -> False:
-    # TODO: can we remove the need for `info.context["conmparison"]` here?
+    # TODO: can we remove the need for `info.context["comparison"]` here?
     if "comparison" not in info.context:
         return False
     comparison: Comparison = info.context["comparison"]

--- a/graphql_api/types/file/file.py
+++ b/graphql_api/types/file/file.py
@@ -29,7 +29,7 @@ def get_coverage_type(line_report):
 
 
 @file_bindable.field("coverage")
-def resolve_content(data, info):
+def resolve_coverage(data, info):
     file_report = data.get("file_report")
 
     if not file_report:
@@ -42,7 +42,7 @@ def resolve_content(data, info):
 
 
 @file_bindable.field("totals")
-def resolve_content(data, info):
+def resolve_totals(data, info):
     file_report = data.get("file_report")
     return file_report.totals if file_report else None
 

--- a/graphql_api/types/me/me.py
+++ b/graphql_api/types/me/me.py
@@ -116,7 +116,7 @@ def resolve_business_email(current_owner: Owner, _, **kwargs) -> Optional[str]:
 
 @me_bindable.field("privateAccess")
 @sync_to_async
-def resolve_profile(owner: Owner, info) -> bool:
+def resolve_private_access(owner: Owner, info) -> bool:
     if owner.private_access is None:
         return False
     return owner.private_access

--- a/graphql_api/types/plan/plan.py
+++ b/graphql_api/types/plan/plan.py
@@ -50,7 +50,7 @@ def resolve_plan_name(plan_service: PlanService, info) -> str:
 
 
 @plan_bindable.field("value")
-def resolve_plan_name(plan_service: PlanService, info) -> str:
+def resolve_plan_name_as_value(plan_service: PlanService, info) -> str:
     return plan_service.plan_name
 
 

--- a/graphs/tests/test_badge_handler.py
+++ b/graphs/tests/test_badge_handler.py
@@ -1303,7 +1303,7 @@ class TestBadgeHandler(APITestCase):
         assert response.status_code == status.HTTP_200_OK
 
     @patch("core.models.Commit.full_report", new_callable=PropertyMock)
-    def test_commit_report_null(self, full_report_mock):
+    def test_commit_report_no_flags(self, full_report_mock):
         gh_owner = OwnerFactory(service="github")
         repo = RepositoryFactory(
             author=gh_owner, active=True, private=False, name="repo1"

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -160,7 +160,7 @@ class AssetReport(object):
         return self.asset.size
 
     @cached_property
-    def modules(self) -> ModuleReport:
+    def modules(self) -> List[ModuleReport]:
         return [ModuleReport(module) for module in self.asset.modules()]
 
     @cached_property

--- a/services/tests/test_components.py
+++ b/services/tests/test_components.py
@@ -142,7 +142,7 @@ class ComponentComparisonTest(TransactionTestCase):
         self.comparison = Comparison(self.user, self.base_commit, self.head_commit)
 
     @patch("services.comparison.Comparison.base_report", new_callable=PropertyMock)
-    def test_head_report(self, base_report_mock):
+    def test_base_report(self, base_report_mock):
         report = sample_report()
         base_report_mock.return_value = report
 
@@ -153,9 +153,9 @@ class ComponentComparisonTest(TransactionTestCase):
             }
         )
         component_comparison = ComponentComparison(self.comparison, component_go)
-        assert component_comparison.head_report.files == ["file_1.go"]
+        assert component_comparison.base_report.files == ["file_1.go"]
         assert (
-            component_comparison.head_report.totals.coverage
+            component_comparison.base_report.totals.coverage
             == report.get("file_1.go").totals.coverage
         )
 

--- a/services/tests/test_repo_providers.py
+++ b/services/tests/test_repo_providers.py
@@ -136,7 +136,7 @@ class TestRepoProviderService(InternalAPITest):
     def get_owner_gh(self):
         return Owner.objects.filter(ownerid=self.repo_gh.author.ownerid).first()
 
-    def test_get_torngit_with_names(self):
+    def test_get_torngit_with_names_github(self):
         provider = RepoProviderService().get_by_name(
             self.repo_gh.author,
             self.repo_gh.name,
@@ -145,7 +145,7 @@ class TestRepoProviderService(InternalAPITest):
         )
         assert isinstance(Github(), type(provider))
 
-    def test_get_torngit_with_names(self):
+    def test_get_torngit_with_names_gitlab(self):
         provider = RepoProviderService().get_by_name(
             self.repo_gl.author,
             self.repo_gl.name,

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -2629,7 +2629,10 @@ class UploadHandlerCircleciTokenlessTest(TestCase):
 
     @patch.object(requests, "get")
     def test_circleci_invalid_stop_time(self, mock_get):
-        expected_response = {"vcs_revision": "c739768fcac68144a3a6d82305b9c4106934d31a"}
+        expected_response = {
+            "vcs_revision": "c739768fcac68144a3a6d82305b9c4106934d31a",
+            "stop_time": "",
+        }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.json.return_value = expected_response
 

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -1837,7 +1837,7 @@ class UploadHandlerTravisTokenlessTest(TestCase):
         ]
 
     @patch.object(requests, "get")
-    def test_travis_failed_requests_connection_error(self, mock_get):
+    def test_travis_failed_requests_connection_error_ex(self, mock_get):
         mock_get.side_effect = [
             Exception("Not found"),
             requests.exceptions.HTTPError("Not found"),
@@ -2648,7 +2648,7 @@ class UploadHandlerCircleciTokenlessTest(TestCase):
         ]
 
     @patch.object(requests, "get")
-    def test_circleci_invalid_stop_time(self, mock_get):
+    def test_circleci_invalid_stop_time_gh(self, mock_get):
         expected_response = {
             "vcs_revision": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "vcs_type": "github",


### PR DESCRIPTION
### Purpose/Motivation

When investigating another ticket, I saw that in our repo we sometimes used the same function name for multiple resolvers. This seemed like a clear code error, but then I realized that the resolver "bindable_field" decorator was added to things to maintain that uniqueness.

**However,** one place this wasn't accounted for was in tests. And I found some surprising results post fixing the duplicate test names. **That the tests with duplicate names were not running.** This seemed pretty concerning, since after fixing all the duplicate test names I saw there were 8 failing tests; ranging from a few months to a few years old.

This also made me realize that we don't have a linter on API (or worker / shared if I was looking at the code correctly), and might be something we want to look into adding sooner rather than later.

Anyway, this PR aims to fix all the duplicate function name errors in API, though I may need a bit of help with the remaining failing tests to see if they're still needed or not. My thinking is 3 of the 5 aren't needed anymore? In test_branch.py, and test_pull_comparison.py

## Screenshots

**AFTER Removing the duplicate function names**
<img width="943" alt="Screenshot 2024-04-26 at 4 35 33 PM" src="https://github.com/codecov/codecov-api/assets/159853603/874cbcdb-8b41-42ed-9166-7efa254873bd">

**BEFORE**
<img width="943" alt="Screenshot 2024-04-26 at 4 42 41 PM" src="https://github.com/codecov/codecov-api/assets/159853603/a0f581a6-8bd9-4cf5-bb41-960c4c9070d1">


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
