### PR TITLE
Tokenless V3

### DIFF
--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -269,29 +269,28 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
         if match is None:
             return None, None
 
-        # Validate provider
         service = match.group(1)
+        encoded_slug = match.group(2)
+        commitid = match.group(3)
+
+        # Validate provider
         try:
             service_enum = Service(service)
         except ValueError:
             return None, None
 
         # Validate that next group exists and decode slug
-        encoded_slug = match.group(2)
         repo = get_repository_from_string(service_enum, encoded_slug)
-
         if repo is None:
             # Purposefully using the generic message so that we don't tell that
             # we don't have a certain repo
             return None, None
 
-        commitid = match.group(3)
-
         return repo, commitid
 
     def get_branch(self, request, commitid=None):
         if commitid:
-            commit = Commit.objects.get(commitid=commitid)
+            commit = Commit.objects.filter(commitid=commitid).first()
             if not commit:
                 return None
             return commit.branch

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -116,8 +116,9 @@ def test_reports_post_no_auth(db, mocker):
     )
     repository.private = False
     token = "BAD"
-    commit = CommitFactory(repository=repository)
     repository.save()
+    commit = CommitFactory(repository=repository)
+    commit.save()
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION="token " + token)
     url = reverse(
@@ -189,14 +190,16 @@ def test_reports_post_tokenless_fail(client, db, mocker):
     response = client.post(
         url,
         data={"code": "code1"},
-        headers={"X-Tokenless": "someone/bad", "X-Tokenless-PR": "4"},
     )
 
     assert (
         url == f"/upload/github/codecov::::the_repo/commits/{commit.commitid}/reports"
     )
     assert response.status_code == 401
-    assert response.json().get("detail") == "Not valid tokenless upload"
+    assert (
+        response.json().get("detail")
+        == "Failed token authentication, please double-check that your repository token matches in the Codecov UI, or review the docs https://docs.codecov.com/docs/adding-the-codecov-token"
+    )
 
 
 def test_create_report_already_exists(client, db, mocker):

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -331,6 +331,7 @@ def test_uploads_post_tokenless(mock_metrics, db, mocker, mock_redis):
             "state": "uploaded",
             "flags": ["flag1", "flag2"],
             "version": "version",
+            "branch": "someone:branch_name",
         },
     )
     assert response.status_code == 201

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -292,7 +292,14 @@ def test_uploads_post(mock_metrics, db, mocker, mock_redis):
 
 
 @patch("shared.metrics.metrics.incr")
-def test_uploads_post_tokenless(mock_metrics, db, mocker, mock_redis):
+@pytest.mark.parametrize("private", [False, True])
+@pytest.mark.parametrize("branch", ["branch", "fork:branch", "someone/fork:branch"])
+@pytest.mark.parametrize(
+    "branch_sent", [None, "branch", "fork:branch", "someone/fork:branch"]
+)
+def test_uploads_post_tokenless(
+    mock_metrics, db, mocker, mock_redis, private, branch, branch_sent
+):
     presigned_put_mock = mocker.patch(
         "services.archive.StorageService.create_presigned_put",
         return_value="presigned put",
@@ -306,10 +313,10 @@ def test_uploads_post_tokenless(mock_metrics, db, mocker, mock_redis):
         name="the_repo",
         author__username="codecov",
         author__service="github",
-        private=False,
+        private=private,
     )
     commit = CommitFactory(repository=repository)
-    commit.branch = "someone:branch_name"
+    commit.branch = branch
     commit_report = CommitReport.objects.create(commit=commit, code="code")
     repository.save()
     commit_report.save()
@@ -325,87 +332,100 @@ def test_uploads_post_tokenless(mock_metrics, db, mocker, mock_redis):
             commit_report.code,
         ],
     )
-    response = client.post(
-        url,
-        {
+    if branch_sent is not None:
+        data = {
             "state": "uploaded",
             "flags": ["flag1", "flag2"],
             "version": "version",
-            "branch": "someone:branch_name",
-        },
-    )
-    assert response.status_code == 201
-    response_json = response.json()
-    upload = ReportSession.objects.filter(
-        report_id=commit_report.id, upload_extras={"format_version": "v1"}
-    ).first()
-    assert all(
-        map(
-            lambda x: x in response_json.keys(),
-            ["external_id", "created_at", "raw_upload_location", "url"],
-        )
-    )
-    assert (
-        response_json.get("url")
-        == f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/commit/{commit.commitid}"
-    )
-
-    assert ReportSession.objects.filter(
-        report_id=commit_report.id, upload_extras={"format_version": "v1"}
-    ).exists()
-    assert RepositoryFlag.objects.filter(
-        repository_id=repository.repoid, flag_name="flag1"
-    ).exists()
-    assert RepositoryFlag.objects.filter(
-        repository_id=repository.repoid, flag_name="flag2"
-    ).exists()
-    flag1 = RepositoryFlag.objects.filter(
-        repository_id=repository.repoid, flag_name="flag1"
-    ).first()
-    flag2 = RepositoryFlag.objects.filter(
-        repository_id=repository.repoid, flag_name="flag2"
-    ).first()
-    assert UploadFlagMembership.objects.filter(
-        report_session_id=upload.id, flag_id=flag1.id
-    ).exists()
-    assert UploadFlagMembership.objects.filter(
-        report_session_id=upload.id, flag_id=flag2.id
-    ).exists()
-    assert [flag for flag in upload.flags.all()] == [flag1, flag2]
-    mock_metrics.assert_has_calls(
-        [call("upload.cli.version"), call("uploads.accepted", 1)]
-    )
-
-    archive_service = ArchiveService(repository)
-    assert upload.storage_path == MinioEndpoints.raw_with_upload_id.get_path(
-        version="v4",
-        date=upload.created_at.strftime("%Y-%m-%d"),
-        repo_hash=archive_service.storage_hash,
-        commit_sha=commit.commitid,
-        reportid=commit_report.external_id,
-        uploadid=upload.external_id,
-    )
-    presigned_put_mock.assert_called_with("archive", upload.storage_path, 10)
-    upload_task_mock.assert_called()
-    analytics_service_mock.return_value.account_uploaded_coverage_report.assert_called_with(
-        commit.repository.author.ownerid,
-        {
-            "commit": commit.commitid,
-            "branch": commit.branch,
-            "pr": commit.pullid,
-            "repo": commit.repository.name,
-            "repository_name": commit.repository.name,
-            "repository_id": commit.repository.repoid,
-            "service": commit.repository.service,
-            "build": upload.build_code,
-            "build_url": upload.build_url,
-            "flags": "",
-            "owner": commit.repository.author.ownerid,
-            "token": "tokenless_upload",
+            "branch": branch_sent,
+        }
+    else:
+        data = {
+            "state": "uploaded",
+            "flags": ["flag1", "flag2"],
             "version": "version",
-            "uploader_type": "CLI",
-        },
+        }
+    response = client.post(
+        url,
+        data,
     )
+
+    if private is False and ":" in branch:
+        assert response.status_code == 201
+        response_json = response.json()
+        upload = ReportSession.objects.filter(
+            report_id=commit_report.id, upload_extras={"format_version": "v1"}
+        ).first()
+        assert all(
+            map(
+                lambda x: x in response_json.keys(),
+                ["external_id", "created_at", "raw_upload_location", "url"],
+            )
+        )
+        assert (
+            response_json.get("url")
+            == f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/commit/{commit.commitid}"
+        )
+
+        assert ReportSession.objects.filter(
+            report_id=commit_report.id, upload_extras={"format_version": "v1"}
+        ).exists()
+        assert RepositoryFlag.objects.filter(
+            repository_id=repository.repoid, flag_name="flag1"
+        ).exists()
+        assert RepositoryFlag.objects.filter(
+            repository_id=repository.repoid, flag_name="flag2"
+        ).exists()
+        flag1 = RepositoryFlag.objects.filter(
+            repository_id=repository.repoid, flag_name="flag1"
+        ).first()
+        flag2 = RepositoryFlag.objects.filter(
+            repository_id=repository.repoid, flag_name="flag2"
+        ).first()
+        assert UploadFlagMembership.objects.filter(
+            report_session_id=upload.id, flag_id=flag1.id
+        ).exists()
+        assert UploadFlagMembership.objects.filter(
+            report_session_id=upload.id, flag_id=flag2.id
+        ).exists()
+        assert [flag for flag in upload.flags.all()] == [flag1, flag2]
+        mock_metrics.assert_has_calls(
+            [call("upload.cli.version"), call("uploads.accepted", 1)]
+        )
+
+        archive_service = ArchiveService(repository)
+        assert upload.storage_path == MinioEndpoints.raw_with_upload_id.get_path(
+            version="v4",
+            date=upload.created_at.strftime("%Y-%m-%d"),
+            repo_hash=archive_service.storage_hash,
+            commit_sha=commit.commitid,
+            reportid=commit_report.external_id,
+            uploadid=upload.external_id,
+        )
+        presigned_put_mock.assert_called_with("archive", upload.storage_path, 10)
+        upload_task_mock.assert_called()
+        analytics_service_mock.return_value.account_uploaded_coverage_report.assert_called_with(
+            commit.repository.author.ownerid,
+            {
+                "commit": commit.commitid,
+                "branch": commit.branch,
+                "pr": commit.pullid,
+                "repo": commit.repository.name,
+                "repository_name": commit.repository.name,
+                "repository_id": commit.repository.repoid,
+                "service": commit.repository.service,
+                "build": upload.build_code,
+                "build_url": upload.build_url,
+                "flags": "",
+                "owner": commit.repository.author.ownerid,
+                "token": "tokenless_upload",
+                "version": "version",
+                "uploader_type": "CLI",
+            },
+        )
+    else:
+        assert response.status_code == 401
+        assert response.json().get("detail") == "Not valid tokenless upload"
 
 
 @patch("upload.views.uploads.AnalyticsService")
@@ -536,55 +556,6 @@ def test_uploads_post_github_oidc_auth(
             "version": "version",
             "uploader_type": "CLI",
         },
-    )
-
-
-def test_uploads_with_bad_token(
-    db,
-    mocker,
-    mock_redis,
-):
-    repository = RepositoryFactory(
-        name="the_repo",
-        author__username="codecov",
-        author__service="github",
-        private=False,
-    )
-    token = "BadToken"
-
-    commit = CommitFactory(repository=repository)
-    commit_report = CommitReport.objects.create(commit=commit, code="code")
-
-    client = APIClient()
-    url = reverse(
-        "new_upload.uploads",
-        args=[
-            "github",
-            "codecov::::the_repo",
-            commit.commitid,
-            commit_report.code,
-        ],
-    )
-    response = client.post(
-        url,
-        {
-            "state": "uploaded",
-            "flags": ["flag1", "flag2"],
-            "version": "version",
-        },
-        headers={"Authorization": f"token {token}"},
-    )
-    assert response.status_code == 401
-    response_json = response.json()
-    upload = ReportSession.objects.filter(
-        report_id=commit_report.id, upload_extras={"format_version": "v1"}
-    ).exists()
-    assert upload is False
-
-    assert (
-        response_json.get("detail")
-        == "Failed token authentication, please double-check that your repository token matches in the Codecov UI, "
-        "or review the docs https://docs.codecov.com/docs/adding-the-codecov-token"
     )
 
 

--- a/upload/views/commits.py
+++ b/upload/views/commits.py
@@ -9,7 +9,7 @@ from codecov_auth.authentication.repo_auth import (
     GlobalTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
-    TokenlessCommitAuthentication,
+    TokenlessAuthentication,
     repo_auth_custom_exception_handler,
 )
 from core.models import Commit
@@ -30,7 +30,7 @@ class CommitViews(ListCreateAPIView, GetterMixin):
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
-        TokenlessCommitAuthentication,
+        TokenlessAuthentication,
     ]
 
     def get_exception_handler(self):
@@ -42,9 +42,8 @@ class CommitViews(ListCreateAPIView, GetterMixin):
 
     def list(self, request, *args, **kwargs):
         repository = self.get_repo()
-        if (
-            isinstance(self.request.auth, TokenlessCommitAuthentication)
-            and repository.private
+        if repository.private and isinstance(
+            self.request.auth, TokenlessAuthentication
         ):
             raise NotAuthenticated()
         return super().list(request, *args, **kwargs)

--- a/upload/views/commits.py
+++ b/upload/views/commits.py
@@ -1,6 +1,6 @@
 import logging
 
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import NotAuthenticated, ValidationError
 from rest_framework.generics import ListCreateAPIView
 from sentry_sdk import metrics as sentry_metrics
 
@@ -9,8 +9,7 @@ from codecov_auth.authentication.repo_auth import (
     GlobalTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
-    TokenlessAuth,
-    TokenlessAuthentication,
+    TokenlessCommitAuthentication,
     repo_auth_custom_exception_handler,
 )
 from core.models import Commit
@@ -31,7 +30,7 @@ class CommitViews(ListCreateAPIView, GetterMixin):
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
-        TokenlessAuthentication,
+        TokenlessCommitAuthentication,
     ]
 
     def get_exception_handler(self):
@@ -41,32 +40,16 @@ class CommitViews(ListCreateAPIView, GetterMixin):
         repository = self.get_repo()
         return Commit.objects.filter(repository=repository)
 
-    def _possibly_fix_branch_name(self, request) -> None:
-        """Avoids users being able to overwrite coverage info for a branch
-        that exists in the upstream repo with coverage for their fork branch.
-        By pre-pending the fork name to the branch
-        (the CLI might have done this already)
-        """
-        # This only affects tokenless uploads
-        if not isinstance(request.auth, TokenlessAuth):
-            return
-        # Notice that at this point we already validated that this fork_slug
-        # is the correct repo from the head of a PR to the upstream repo
-        # with the git provider
-        fork_slug = request.headers.get("X-Tokenless", None)
-        branch_info = request.data.get("branch")
-        if branch_info is None:
-            # There should always be a branch in the request
-            raise ValidationError("missing branch")
-        # The CLI might have pre-prended the branch with something already
-        if ":" in branch_info:
-            _, branch_info = branch_info.split(":")
-        branch_to_set = f"{fork_slug}:{branch_info}"
-        if request.data.get("branch") != branch_to_set:
-            request.data["branch"] = branch_to_set
+    def list(self, request, *args, **kwargs):
+        repository = self.get_repo()
+        if (
+            isinstance(self.request.auth, TokenlessCommitAuthentication)
+            and repository.private
+        ):
+            raise NotAuthenticated()
+        return super().list(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
-        self._possibly_fix_branch_name(request)
         return super().create(request, *args, **kwargs)
 
     def perform_create(self, serializer):

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -82,6 +82,7 @@ class ReportResultsView(
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
+        TokenlessAuthentication,
     ]
 
     def get_exception_handler(self):


### PR DESCRIPTION
### Purpose/Motivation
We don't want to make GH API calls when doing tokenless anymore

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1574

### What does this PR do?
- Remove GitHub API calls from TokenlessAuthentication
