### PR TITLE
fix: set max wait time at 10 seconds

### DIFF
--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -53,7 +53,7 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
             else:
                 retry_after = None
             raise exceptions.Throttled(
-                wait=retry_after,
+                wait=min(10, retry_after),
                 detail="Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.",
             )
         except TorngitClientError as e:


### PR DESCRIPTION
### Purpose/Motivation
**Problem**
Some users on the bash/v1/uploader/v3 uploaders are running into problems. This seems to be manifesting in that the builds take FOREVER to run.

**Root Cause**
Looking at most logs, you will notice that we fail when pinging Codecov for the upload URL (see image). But wait, it says wait almost 3600 seconds?? That seems wrong. After all we run with the normal retry logic (roughly exponential backoff up to 10 seconds).
This means that the bash/v1/uploader/v3 is receiving a different retry time. You can find that logic [here](https://github.com/codecov/codecov-api/blob/8a02e67e0361426a3ac3e60c9f0c8e4601d4bca1/upload/tokenless/github_actions.py#L56)
```
            raise exceptions.Throttled(
                wait=retry_after,
                detail="Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.",
            )
```

**Solution**
This PR sets the max wait time as 10 seconds.

### Links to relevant tickets
fixes https://github.com/codecov/feedback/issues/354

### What does this PR do?
This PR sets the max wait time as 10 seconds.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
