### PR TITLE
fix: Resolve null owner

### DIFF
--- a/api/internal/tests/test_permissions.py
+++ b/api/internal/tests/test_permissions.py
@@ -97,6 +97,14 @@ class TestRepositoryPermissionsService(TestCase):
             user = OwnerFactory(organizations=[])
             assert self.permissions_service.user_is_activated(user, owner) is False
 
+    def test_user_is_activated_returns_false_if_owner_is_none(self):
+        user = OwnerFactory()
+        assert self.permissions_service.user_is_activated(user, None) is False
+
+    def test_user_is_activated_returns_false_if_user_is_none(self):
+        owner = OwnerFactory()
+        assert self.permissions_service.user_is_activated(None, owner) is False
+
     def test_user_is_activated_returns_true_when_owner_has_legacy_plan(self):
         user = OwnerFactory()
         owner = OwnerFactory(plan="v4-50m")

--- a/api/shared/permissions.py
+++ b/api/shared/permissions.py
@@ -46,6 +46,8 @@ class RepositoryPermissionsService:
         )
 
     def user_is_activated(self, current_owner, owner):
+        if not current_owner or not owner:
+            return False
         if current_owner.ownerid == owner.ownerid:
             return True
         if owner.has_legacy_plan:


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Resolves https://codecov.sentry.io/issues/5131995858/?referrer=github_integration 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
