### PR TITLE
Conent-security-policy allow GraphQL Playground to render

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -309,6 +309,18 @@ SPECTACULAR_SETTINGS = {
 # frame, iframe, object, or embed. This configuration denies doing so.
 CSP_FRAME_ANCESTORS = "'none'"
 
+# Allows GraphQL Playground to render
+CSP_DEFAULT_SRC = [
+    "'self'",
+    "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
+    "'sha256-eKdXhLyOdPl2/gp1Ob116rCU2Ox54rseyz1MwCmzb6w='",
+    "'sha256-a1pELtDJXf8fPX1YL2JiBM91RQBeIAswunzgwMEsvwA='",
+    "'sha256-cNIcuS0BVLuBVP5rpfeFE42xHz7r5hMyf9YdfknWuCg='",
+    "https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js",
+    "https://cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png",
+    "https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css",
+]
+
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Fixes Playground from being blocked due to new CSP policies.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
