### PR TITLE
fix: update tokenless string

### DIFF
--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -2764,7 +2764,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             TokenlessUploadHandler("github_actions", params).verify_upload()
         self.assertEqual(
             str(e.exception.detail),
-            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 10 seconds.",
+            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 20s.",
         )
 
         mock_get.reset_mock()
@@ -2774,7 +2774,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             TokenlessUploadHandler("github_actions", params).verify_upload()
         self.assertEqual(
             str(e.exception.detail),
-            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 10 seconds.",
+            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 20s.",
         )
 
         mock_get.reset_mock()

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -2764,7 +2764,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             TokenlessUploadHandler("github_actions", params).verify_upload()
         self.assertEqual(
             str(e.exception.detail),
-            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 20s.",
+            "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 10s.",
         )
 
         mock_get.reset_mock()

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -52,9 +52,12 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
                 retry_after = int(e.retry_after)
             else:
                 retry_after = None
+            time_to_available_str = ''
+            if retry_after is not None:
+                time_to_available_str = f" Expected time to availability: {retry_after}s."
             raise exceptions.Throttled(
-                wait=min(10, retry_after) if type(retry_after) == int else retry_after,
-                detail="Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.",
+                wait=None,
+                detail=f"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.{time_to_available_str}",
             )
         except TorngitClientError as e:
             self.log_warning(message=f"Request client error {e}")

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -52,9 +52,11 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
                 retry_after = int(e.retry_after)
             else:
                 retry_after = None
-            time_to_available_str = ''
+            time_to_available_str = ""
             if retry_after is not None:
-                time_to_available_str = f" Expected time to availability: {retry_after}s."
+                time_to_available_str = (
+                    f" Expected time to availability: {retry_after}s."
+                )
             raise exceptions.Throttled(
                 wait=None,
                 detail=f"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.{time_to_available_str}",


### PR DESCRIPTION
### Purpose/Motivation
Showing the wrong string message before. This will push the retry timing to the user as to not block CIs while still displaying the correct timing.

### Links to relevant tickets
fixes https://github.com/codecov/infrastructure-team/issues/346

### What does this PR do?
- Sets wait to `None`, this will push the behavior to the user. Bash and uploader (I believe) currently do an exp backoff up to 10 seconds. Is this enough time? Absolutely not, but it will not run for 6 hours.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
