### PR TITLE
Add GH action to do mypy check for patch

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   patch-typing-check:
     name: Run Patch Type Check
-    uses: codecov/gha-workflows/.github/workflows/mypy.yml@may_06_mypy
+    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.18

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,14 @@
+name: "Patch typing check"
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+  merge_group:
+
+jobs:
+  patch-typing-check:
+    name: Run Patch Type Check
+    uses: codecov/gha-workflows/.github/workflows/mypy.yml@may_06_mypy


### PR DESCRIPTION
Add mypy type checking in the GH CI. This does type checking for all files that are touched in the PR. This job runs at the same time the other main jobs run, however right now a failure on this does not block mergning (but it is encouraged to not fail the job), eventually it may start blocking merge to main.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
