### PR TITLE
add to audience for jwt decoding

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -259,7 +259,7 @@ def get_repo_with_github_actions_oidc_token(token, token_slice=None):
         token,
         signing_key.key,
         algorithms=["RS256"],
-        audience=[settings.CODECOV_API_URL],
+        audience=[settings.CODECOV_API_URL, settings.CODECOV_URL],
     )
     repo = str(data.get("repository")).split("/")[-1]
     log.info(


### PR DESCRIPTION
### Purpose/Motivation
The OIDC tokens coming from GitHub have a different audience. We can support more than 1 when we decode, so I'm proposing adding this one to match what we are receiving.

