### PR TITLE
Allow local dev build to run GQL Playground

### DIFF
--- a/codecov/settings_dev.py
+++ b/codecov/settings_dev.py
@@ -2,6 +2,9 @@ import logging
 
 from .settings_base import *
 
+# Remove CSP headers from local development build to allow GQL Playground
+MIDDLEWARE.remove("csp.middleware.CSPMiddleware")
+
 DEBUG = True
 # for shelter add "host.docker.internal" and make sure to map it to localhost
 # in your /etc/hosts


### PR DESCRIPTION

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
