### PR TITLE
dev: Add Ruff to API, enable F541 as first rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,19 +44,18 @@ lint:
 	make lint.run
 
 lint.install:
-	python -m pip install --upgrade pip
 	echo "Installing..."
-	pip install -Iv black==22.3.0 isort
+	pip install -Iv ruff
 
 lint.run:
-	black .
-	isort --profile black .
+	ruff check
+	ruff format
 
 lint.check:
 	echo "Linting..."
-	black --check .
+	ruff format
 	echo "Sorting..."
-	isort --profile black --check .
+	ruff check
 
 build.requirements:
 	# if docker pull succeeds, we have already build this version of

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ lint.run:
 
 lint.check:
 	echo "Linting..."
-	ruff format
-	echo "Sorting..."
 	ruff check
+	echo "Sorting..."
+	ruff format --check
 
 build.requirements:
 	# if docker pull succeeds, we have already build this version of

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint.run:
 lint.check:
 	echo "Linting..."
 	ruff check
-	echo "Sorting..."
+	echo "Formatting..."
 	ruff format --check
 
 build.requirements:

--- a/api/internal/feature/views.py
+++ b/api/internal/feature/views.py
@@ -80,9 +80,7 @@ class FeaturesView(APIView):
             # fetch flags not in cache
             missed_feature_flags = FeatureFlag.objects.filter(
                 name__in=cache_misses
-            ).prefetch_related(
-                "variants"
-            )  # include the feature flag variants aswell
+            ).prefetch_related("variants")  # include the feature flag variants aswell
 
             # evaluate the remaining flags
             for feature_flag in missed_feature_flags:
@@ -91,9 +89,9 @@ class FeaturesView(APIView):
                 flag_evaluations[feature_flag.name] = Feature(
                     feature_flag.name, feature_flag, list(feature_flag.variants.all())
                 ).check_value_no_fetch(identifier=identifier)
-                flags_to_add_to_cache[
-                    get_flag_cache_redis_key(feature_flag.name)
-                ] = feature_flag
+                flags_to_add_to_cache[get_flag_cache_redis_key(feature_flag.name)] = (
+                    feature_flag
+                )
 
             # add the new flags to cache
             if len(flags_to_add_to_cache) >= 1:

--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -134,7 +134,7 @@ class PlanSerializer(serializers.Serializer):
         if value not in plan_values:
             if value in SENTRY_PAID_USER_PLAN_REPRESENTATIONS:
                 log.warning(
-                    f"Non-Sentry user attempted to transition to Sentry plan",
+                    "Non-Sentry user attempted to transition to Sentry plan",
                     extra=dict(owner_id=current_owner.pk, plan=value),
                 )
             raise serializers.ValidationError(
@@ -149,11 +149,11 @@ class PlanSerializer(serializers.Serializer):
         if plan["value"] in PAID_PLANS:
             if "quantity" not in plan:
                 raise serializers.ValidationError(
-                    f"Field 'quantity' required for updating to paid plans"
+                    "Field 'quantity' required for updating to paid plans"
                 )
             if plan["quantity"] <= 1:
                 raise serializers.ValidationError(
-                    f"Quantity for paid plan must be greater than 1"
+                    "Quantity for paid plan must be greater than 1"
                 )
 
             plan_service = PlanService(current_org=owner)
@@ -161,7 +161,7 @@ class PlanSerializer(serializers.Serializer):
 
             if plan["quantity"] < owner.activated_user_count and not is_org_trialing:
                 raise serializers.ValidationError(
-                    f"Quantity cannot be lower than currently activated user count"
+                    "Quantity cannot be lower than currently activated user count"
                 )
             if (
                 plan["quantity"] == owner.plan_user_count
@@ -169,7 +169,7 @@ class PlanSerializer(serializers.Serializer):
                 and not is_org_trialing
             ):
                 raise serializers.ValidationError(
-                    f"Quantity or plan for paid plan must be different from the existing one"
+                    "Quantity or plan for paid plan must be different from the existing one"
                 )
             if (
                 plan["value"] in TEAM_PLAN_REPRESENTATIONS

--- a/api/internal/tests/test_charts.py
+++ b/api/internal/tests/test_charts.py
@@ -47,7 +47,7 @@ def generate_random_totals(
         "m": misses,
         "c": coverage,
         "C": complexity,
-        "N": complexity_total
+        "N": complexity_total,
         # Not currenly used: diff, files, sessions, branches, methods
     }
     return totals

--- a/api/shared/compare/mixins.py
+++ b/api/shared/compare/mixins.py
@@ -100,8 +100,8 @@ class CompareViewSetMixin(CompareSlugMixin, viewsets.GenericViewSet):
             elif comparison.pseudo_diff_adjusts_tracked_lines:
                 return Response(
                     data={
-                        "detail": f"Changes found in between %.7s...%.7s (pseudo...base) "
-                        f"which prevent comparing this pull request."
+                        "detail": "Changes found in between %.7s...%.7s (pseudo...base) "
+                        "which prevent comparing this pull request."
                         % (comparison.pull.compared_to, comparison.pull.base)
                     },
                     status=400,

--- a/api/shared/compare/serializers.py
+++ b/api/shared/compare/serializers.py
@@ -203,7 +203,6 @@ class ImpactedFileSerializer(serializers.Serializer):
 
 
 class ImpactedFilesComparisonSerializer(ComparisonSerializer):
-
     files = serializers.SerializerMethodField()
     state = serializers.SerializerMethodField()
 

--- a/api/shared/permissions.py
+++ b/api/shared/permissions.py
@@ -3,8 +3,10 @@ import logging
 from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.http import Http404
-from rest_framework.permissions import SAFE_METHODS  # ['GET', 'HEAD', 'OPTIONS']
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import (
+    SAFE_METHODS,  # ['GET', 'HEAD', 'OPTIONS']
+    BasePermission,
+)
 
 import services.self_hosted as self_hosted
 from api.shared.mixins import InternalPermissionsMixin, SuperPermissionsMixin
@@ -74,10 +76,10 @@ class RepositoryArtifactPermissions(BasePermission):
 
     permissions_service = RepositoryPermissionsService()
     message = (
-        f"Permission denied: some possible reasons for this are (1) the "
-        f"user doesn't have permission to view the specific resource, "
-        f"(2) the organization has a per-user plan or (3) the user is "
-        f"trying to view a private repo but is not activated."
+        "Permission denied: some possible reasons for this are (1) the "
+        "user doesn't have permission to view the specific resource, "
+        "(2) the organization has a per-user plan or (3) the user is "
+        "trying to view a private repo but is not activated."
     )
 
     def has_permission(self, request, view):

--- a/billing/migrations/0001_initial.py
+++ b/billing/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -72,7 +72,7 @@ class StripeWebhookHandlerTests(APITestCase):
                 )
             },
             data=payload,
-            format="json"
+            format="json",
         )
 
     def test_invoice_payment_succeeded_sets_owner_delinquent_false(self):

--- a/billing/views.py
+++ b/billing/views.py
@@ -27,7 +27,7 @@ class StripeWebhookHandler(APIView):
         if updated >= 1:
             log.info(f"Successfully updated info for {updated} customer(s)")
         else:
-            log.warning(f"Could not find customer")
+            log.warning("Could not find customer")
 
     def invoice_payment_succeeded(self, invoice):
         log.info(
@@ -113,7 +113,6 @@ class StripeWebhookHandler(APIView):
             )
 
     def subscription_schedule_released(self, schedule):
-
         subscription = stripe.Subscription.retrieve(schedule["released_subscription"])
         owner = Owner.objects.get(ownerid=subscription.metadata.obo_organization)
         requesting_user_id = subscription.metadata.obo
@@ -201,8 +200,8 @@ class StripeWebhookHandler(APIView):
         if not subscription_schedule_id:
             if subscription.status == "incomplete_expired":
                 log.info(
-                    f"Subscription updated with status change "
-                    f"to 'incomplete_expired' -- cancelling to free",
+                    "Subscription updated with status change "
+                    "to 'incomplete_expired' -- cancelling to free",
                     extra=dict(stripe_subscription_id=subscription.id),
                 )
                 plan_service.set_default_plan_data()
@@ -286,13 +285,13 @@ class StripeWebhookHandler(APIView):
             return Response("Invalid signature", status=status.HTTP_400_BAD_REQUEST)
         if self.event.type not in StripeWebhookEvents.subscribed_events:
             log.warning(
-                f"Unsupported Stripe webhook event received, exiting",
+                "Unsupported Stripe webhook event received, exiting",
                 extra=dict(stripe_webhook_event=self.event.type),
             )
             return Response("Unsupported event type", status=204)
 
         log.info(
-            f"Stripe webhook event received",
+            "Stripe webhook event received",
             extra=dict(stripe_webhook_event=self.event.type),
         )
 

--- a/codecov/admin.py
+++ b/codecov/admin.py
@@ -16,9 +16,9 @@ class AdminMixin(object):
             for changed_field in form.changed_data:
                 prev_value = getattr(old_obj, changed_field)
                 new_value = getattr(new_obj, changed_field)
-                new_obj.changed_fields[
-                    changed_field
-                ] = f"prev value: {prev_value}, new value: {new_value}"
+                new_obj.changed_fields[changed_field] = (
+                    f"prev value: {prev_value}, new value: {new_value}"
+                )
 
         return super().save_model(request, new_obj, form, change)
 

--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -176,7 +176,7 @@ class OrgUploadTokenInline(admin.TabularInline):
         # 0 in this case refers to the 0th index of the inline
         # But there can only ever be 1 token per org, so it's fine to use that.
         return format_html(
-            f'<input type="checkbox" name="organization_tokens-0-REFRESH" id="id_organization_tokens-0-REFRESH">'
+            '<input type="checkbox" name="organization_tokens-0-REFRESH" id="id_organization_tokens-0-REFRESH">'
         )
 
     def has_change_permission(self, request, obj=None):

--- a/codecov_auth/migrations/0001_initial.py
+++ b/codecov_auth/migrations/0001_initial.py
@@ -14,7 +14,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/codecov_auth/migrations/0002_auto_20210817_1346.py
+++ b/codecov_auth/migrations/0002_auto_20210817_1346.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0004_pull_user_provided_base_sha"),
         ("codecov_auth", "0001_initial"),

--- a/codecov_auth/migrations/0003_auto_20210924_1003.py
+++ b/codecov_auth/migrations/0003_auto_20210924_1003.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("codecov_auth", "0002_auto_20210817_1346")]
 
     operations = [

--- a/codecov_auth/migrations/0004_auto_20210930_1429.py
+++ b/codecov_auth/migrations/0004_auto_20210930_1429.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("codecov_auth", "0003_auto_20210924_1003")]
 
     operations = [

--- a/codecov_auth/migrations/0006_auto_20211123_1535.py
+++ b/codecov_auth/migrations/0006_auto_20211123_1535.py
@@ -8,7 +8,6 @@ import codecov_auth.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("codecov_auth", "0005_auto_20211029_1709")]
 
     operations = [

--- a/codecov_auth/migrations/0007_auto_20211129_1228.py
+++ b/codecov_auth/migrations/0007_auto_20211129_1228.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("codecov_auth", "0006_auto_20211123_1535")]
 
     operations = [

--- a/codecov_auth/migrations/0008_auto_20220119_1811.py
+++ b/codecov_auth/migrations/0008_auto_20220119_1811.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("codecov_auth", "0007_auto_20211129_1228")]
 
     operations = [

--- a/codecov_auth/migrations/0009_auto_20220511_1313.py
+++ b/codecov_auth/migrations/0009_auto_20220511_1313.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0008_auto_20220119_1811"),
     ]

--- a/codecov_auth/migrations/0010_owner_is_superuser.py
+++ b/codecov_auth/migrations/0010_owner_is_superuser.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0009_auto_20220511_1313"),
     ]

--- a/codecov_auth/migrations/0012_auto_20220531_1452.py
+++ b/codecov_auth/migrations/0012_auto_20220531_1452.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0011_new_enterprise_plans"),
     ]

--- a/codecov_auth/migrations/0013_alter_owner_organizations.py
+++ b/codecov_auth/migrations/0013_alter_owner_organizations.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0012_auto_20220531_1452"),
     ]

--- a/codecov_auth/migrations/0014_alter_repositorytoken_token_type.py
+++ b/codecov_auth/migrations/0014_alter_repositorytoken_token_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0013_alter_owner_organizations"),
     ]

--- a/codecov_auth/migrations/0015_organizationleveltoken.py
+++ b/codecov_auth/migrations/0015_organizationleveltoken.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0014_alter_repositorytoken_token_type"),
     ]

--- a/codecov_auth/migrations/0016_alter_owner_admins.py
+++ b/codecov_auth/migrations/0016_alter_owner_admins.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0015_organizationleveltoken"),
     ]

--- a/codecov_auth/migrations/0017_alter_organizationleveltoken_token_type.py
+++ b/codecov_auth/migrations/0017_alter_organizationleveltoken_token_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0016_alter_owner_admins"),
     ]

--- a/codecov_auth/migrations/0018_usertoken.py
+++ b/codecov_auth/migrations/0018_usertoken.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0017_alter_organizationleveltoken_token_type"),
     ]

--- a/codecov_auth/migrations/0019_alter_repositorytoken_token_type.py
+++ b/codecov_auth/migrations/0019_alter_repositorytoken_token_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0018_usertoken"),
     ]

--- a/codecov_auth/migrations/0021_owner_max_upload_limit.py
+++ b/codecov_auth/migrations/0021_owner_max_upload_limit.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0020_ownerprofile_default_org"),
     ]

--- a/codecov_auth/migrations/0022_alter_owner_max_upload_limit.py
+++ b/codecov_auth/migrations/0022_alter_owner_max_upload_limit.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0021_owner_max_upload_limit"),
     ]

--- a/codecov_auth/migrations/0023_auto_20230214_1129.py
+++ b/codecov_auth/migrations/0023_auto_20230214_1129.py
@@ -5,7 +5,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0022_alter_owner_max_upload_limit"),
     ]

--- a/codecov_auth/migrations/0024_alter_owner_max_upload_limit.py
+++ b/codecov_auth/migrations/0024_alter_owner_max_upload_limit.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0023_auto_20230214_1129"),
     ]

--- a/codecov_auth/migrations/0026_alter_owner_plan_user_count.py
+++ b/codecov_auth/migrations/0026_alter_owner_plan_user_count.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0025_owner_stripe_coupon_id"),
     ]

--- a/codecov_auth/migrations/0027_auto_20230307_1751.py
+++ b/codecov_auth/migrations/0027_auto_20230307_1751.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0026_alter_owner_plan_user_count"),
     ]

--- a/codecov_auth/migrations/0028_owner_sentry_user_data_owner_sentry_user_id.py
+++ b/codecov_auth/migrations/0028_owner_sentry_user_data_owner_sentry_user_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0027_auto_20230307_1751"),
     ]

--- a/codecov_auth/migrations/0029_ownerprofile_terms_agreement_and_more.py
+++ b/codecov_auth/migrations/0029_ownerprofile_terms_agreement_and_more.py
@@ -6,7 +6,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0028_owner_sentry_user_data_owner_sentry_user_id"),
     ]

--- a/codecov_auth/migrations/0030_owner_trial_end_date_owner_trial_start_date.py
+++ b/codecov_auth/migrations/0030_owner_trial_end_date_owner_trial_start_date.py
@@ -6,7 +6,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0029_ownerprofile_terms_agreement_and_more"),
     ]

--- a/codecov_auth/migrations/0031_user_owner_user.py
+++ b/codecov_auth/migrations/0031_user_owner_user.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0030_owner_trial_end_date_owner_trial_start_date"),
     ]

--- a/codecov_auth/migrations/0032_owner_trial_status.py
+++ b/codecov_auth/migrations/0032_owner_trial_status.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0031_user_owner_user"),
     ]

--- a/codecov_auth/migrations/0033_sentryuser.py
+++ b/codecov_auth/migrations/0033_sentryuser.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0032_owner_trial_status"),
     ]

--- a/codecov_auth/migrations/0040_oktauser.py
+++ b/codecov_auth/migrations/0040_oktauser.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0039_alter_owner_uses_invoice"),
     ]

--- a/codecov_auth/migrations/0042_owner_trial_fired_by.py
+++ b/codecov_auth/migrations/0042_owner_trial_fired_by.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0041_auto_20230918_1825"),
     ]

--- a/codecov_auth/migrations/0043_sync_user_terms_agreement.py
+++ b/codecov_auth/migrations/0043_sync_user_terms_agreement.py
@@ -6,7 +6,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0042_owner_trial_fired_by"),
     ]

--- a/codecov_auth/migrations/0044_remove_owner_agreements_and_alter_user_agreements.py
+++ b/codecov_auth/migrations/0044_remove_owner_agreements_and_alter_user_agreements.py
@@ -6,7 +6,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0043_sync_user_terms_agreement"),
     ]

--- a/codecov_auth/migrations/0046_dedupe_owner_admin_values.py
+++ b/codecov_auth/migrations/0046_dedupe_owner_admin_values.py
@@ -6,7 +6,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0045_remove_ownerprofile_terms_agreement"),
     ]

--- a/codecov_auth/migrations/0047_auto_20231009_1257.py
+++ b/codecov_auth/migrations/0047_auto_20231009_1257.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0046_dedupe_owner_admin_values"),
     ]

--- a/codecov_auth/migrations/0048_githubappinstallation.py
+++ b/codecov_auth/migrations/0048_githubappinstallation.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0047_auto_20231009_1257"),
     ]

--- a/codecov_auth/migrations/0052_githubappinstallation_app_id_and_more.py
+++ b/codecov_auth/migrations/0052_githubappinstallation_app_id_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     # BEGIN;
     # --
     # -- Add field app_id to githubappinstallation

--- a/codecov_auth/migrations/0053_ownerinstallationnametousefortask_and_more.py
+++ b/codecov_auth/migrations/0053_ownerinstallationnametousefortask_and_more.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0052_githubappinstallation_app_id_and_more"),
     ]

--- a/codecov_auth/migrations/0054_update_owners_column_defaults.py
+++ b/codecov_auth/migrations/0054_update_owners_column_defaults.py
@@ -5,7 +5,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("codecov_auth", "0053_ownerinstallationnametousefortask_and_more"),
     ]

--- a/codecov_auth/tests/test_admin.py
+++ b/codecov_auth/tests/test_admin.py
@@ -33,7 +33,7 @@ class OwnerAdminTest(TestCase):
     def test_owner_admin_detail_page(self):
         owner = OwnerFactory()
         response = self.client.get(
-            reverse(f"admin:codecov_auth_owner_change", args=[owner.pk])
+            reverse("admin:codecov_auth_owner_change", args=[owner.pk])
         )
         self.assertEqual(response.status_code, 200)
 
@@ -43,7 +43,7 @@ class OwnerAdminTest(TestCase):
 
         with self.subTest("more than one user selected"):
             response = self.client.post(
-                reverse(f"admin:codecov_auth_owner_changelist"),
+                reverse("admin:codecov_auth_owner_changelist"),
                 {
                     "action": "impersonate_owner",
                     ACTION_CHECKBOX_NAME: [
@@ -59,7 +59,7 @@ class OwnerAdminTest(TestCase):
 
         with self.subTest("one user selected"):
             response = self.client.post(
-                reverse(f"admin:codecov_auth_owner_changelist"),
+                reverse("admin:codecov_auth_owner_changelist"),
                 {
                     "action": "impersonate_owner",
                     ACTION_CHECKBOX_NAME: [owner_to_impersonate.pk],
@@ -91,7 +91,6 @@ class OwnerAdminTest(TestCase):
 
     @patch("codecov_auth.admin.admin.ModelAdmin.get_deleted_objects")
     def test_confirmation_deleted_objects(self, mocked_deleted_objs):
-
         user_to_delete = OwnerFactory()
         deleted_objs = [
             'Owner: <a href="/admin/codecov_auth/owner/{}/change/">{};</a>'.format(
@@ -133,7 +132,7 @@ class OwnerAdminTest(TestCase):
 
     def test_inline_orgwide_tokens_display(self):
         owner = OwnerFactory()
-        request_url = reverse(f"admin:codecov_auth_owner_change", args=[owner.ownerid])
+        request_url = reverse("admin:codecov_auth_owner_change", args=[owner.ownerid])
         request = RequestFactory().get(request_url)
         request.user = self.staff_user
         inlines = self.owner_admin.get_inline_instances(request, owner)
@@ -146,7 +145,7 @@ class OwnerAdminTest(TestCase):
         owner_in_cloud_plan.save()
         org_token.save()
         request_url = reverse(
-            f"admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
+            "admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
         )
         request = RequestFactory().get(request_url)
         request.user = self.staff_user
@@ -168,7 +167,7 @@ class OwnerAdminTest(TestCase):
         owner = OwnerFactory()
         assert owner.plan not in ENTERPRISE_CLOUD_USER_PLAN_REPRESENTATIONS
         assert OrganizationLevelToken.objects.filter(owner=owner).count() == 0
-        request_url = reverse(f"admin:codecov_auth_owner_change", args=[owner.ownerid])
+        request_url = reverse("admin:codecov_auth_owner_change", args=[owner.ownerid])
         request = RequestFactory().get(request_url)
         request.user = self.staff_user
         inlines = self.owner_admin.get_inline_instances(request, owner)
@@ -184,7 +183,7 @@ class OwnerAdminTest(TestCase):
             == 0
         )
         request_url = reverse(
-            f"admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
+            "admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
         )
         request = RequestFactory().get(request_url)
         request.user = self.staff_user
@@ -203,7 +202,7 @@ class OwnerAdminTest(TestCase):
         owner_in_cloud_plan.save()
         org_token.save()
         request_url = reverse(
-            f"admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
+            "admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
         )
         fake_data = {
             "staff": ["true"],
@@ -240,7 +239,7 @@ class OwnerAdminTest(TestCase):
         owner_in_cloud_plan.save()
         org_token.save()
         request_url = reverse(
-            f"admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
+            "admin:codecov_auth_owner_change", args=[owner_in_cloud_plan.ownerid]
         )
         fake_data = {
             "staff": ["true"],
@@ -348,16 +347,14 @@ class UserAdminTest(TestCase):
 
     def test_user_admin_list_page(self):
         user = UserFactory()
-        res = self.client.get(reverse(f"admin:codecov_auth_user_changelist"))
+        res = self.client.get(reverse("admin:codecov_auth_user_changelist"))
         assert res.status_code == 200
         assert user.name in res.content.decode("utf-8")
         assert user.email in res.content.decode("utf-8")
 
     def test_user_admin_detail_page(self):
         user = UserFactory()
-        res = self.client.get(
-            reverse(f"admin:codecov_auth_user_change", args=[user.pk])
-        )
+        res = self.client.get(reverse("admin:codecov_auth_user_change", args=[user.pk]))
         assert res.status_code == 200
         assert user.name in res.content.decode("utf-8")
         assert user.email in res.content.decode("utf-8")
@@ -375,7 +372,7 @@ class SentryUserAdminTest(TestCase):
 
     def test_user_admin_list_page(self):
         sentry_user = SentryUserFactory()
-        res = self.client.get(reverse(f"admin:codecov_auth_sentryuser_changelist"))
+        res = self.client.get(reverse("admin:codecov_auth_sentryuser_changelist"))
         assert res.status_code == 200
         content = res.content.decode("utf-8")
         assert sentry_user.name in res.content.decode("utf-8")
@@ -384,7 +381,7 @@ class SentryUserAdminTest(TestCase):
     def test_user_admin_detail_page(self):
         sentry_user = SentryUserFactory()
         res = self.client.get(
-            reverse(f"admin:codecov_auth_sentryuser_change", args=[sentry_user.pk])
+            reverse("admin:codecov_auth_sentryuser_change", args=[sentry_user.pk])
         )
         assert res.status_code == 200
         assert sentry_user.name in res.content.decode("utf-8")

--- a/codecov_auth/tests/test_migrations.py
+++ b/codecov_auth/tests/test_migrations.py
@@ -4,7 +4,6 @@ from utils.test_utils import TestMigrations
 
 
 class Migration0046Test(TestMigrations):
-
     migrate_from = "0045_remove_ownerprofile_terms_agreement"
     migrate_to = "0046_dedupe_owner_admin_values"
 

--- a/codecov_auth/tests/unit/test_authentication.py
+++ b/codecov_auth/tests/unit/test_authentication.py
@@ -45,7 +45,7 @@ class UserTokenAuthenticationTests(TestCase):
     def test_bearer_token_auth_invalid_token(self):
         request_factory = APIRequestFactory()
         request = request_factory.get(
-            "", HTTP_AUTHORIZATION=f"Bearer 8f9bc6cb-fd14-43bc-bbb5-be1e7c948f34"
+            "", HTTP_AUTHORIZATION="Bearer 8f9bc6cb-fd14-43bc-bbb5-be1e7c948f34"
         )
 
         authenticator = UserTokenAuthentication()

--- a/codecov_auth/tests/unit/views/test_base.py
+++ b/codecov_auth/tests/unit/views/test_base.py
@@ -128,22 +128,22 @@ def test_get_redirection_url_from_state_give_url(mock_redis):
 
 def test_remove_state_with_with_delay(mock_redis):
     mixin = set_up_mixin()
-    mock_redis.set(f"oauth-state-abc", "http://localhost/gh/codecov")
+    mock_redis.set("oauth-state-abc", "http://localhost/gh/codecov")
     mixin.remove_state("abc", delay=5)
     initial_datetime = datetime.now()
     with freeze_time(initial_datetime) as frozen_time:
-        assert mock_redis.get(f"oauth-state-abc") is not None
+        assert mock_redis.get("oauth-state-abc") is not None
         frozen_time.move_to(initial_datetime + timedelta(seconds=4))
-        assert mock_redis.get(f"oauth-state-abc") is not None
+        assert mock_redis.get("oauth-state-abc") is not None
         frozen_time.move_to(initial_datetime + timedelta(seconds=6))
-        assert mock_redis.get(f"oauth-state-abc") is None
+        assert mock_redis.get("oauth-state-abc") is None
 
 
 def test_remove_state_with_with_no_delay(mock_redis):
     mixin = set_up_mixin()
-    mock_redis.set(f"oauth-state-abc", "http://localhost/gh/codecov")
+    mock_redis.set("oauth-state-abc", "http://localhost/gh/codecov")
     mixin.remove_state("abc")
-    assert mock_redis.get(f"oauth-state-abc") is None
+    assert mock_redis.get("oauth-state-abc") is None
 
 
 class LoginMixinTests(TestCase):
@@ -232,9 +232,9 @@ class LoginMixinTests(TestCase):
     @patch("services.analytics.AnalyticsService.user_signed_in")
     def test_use_marketing_tags_from_cookies(self, user_signed_in_mock):
         owner = OwnerFactory(service_id=89, service="github")
-        self.request.COOKIES[
-            "_marketing_tags"
-        ] = "utm_department=a&utm_campaign=b&utm_medium=c&utm_source=d&utm_content=e&utm_term=f"
+        self.request.COOKIES["_marketing_tags"] = (
+            "utm_department=a&utm_campaign=b&utm_medium=c&utm_source=d&utm_content=e&utm_term=f"
+        )
         self.mixin_instance._get_or_create_owner(
             {
                 "user": {

--- a/codecov_auth/tests/unit/views/test_okta.py
+++ b/codecov_auth/tests/unit/views/test_okta.py
@@ -10,9 +10,8 @@ from django.urls import reverse
 
 from codecov_auth.models import OktaUser
 from codecov_auth.tests.factories import OktaUserFactory, OwnerFactory, UserFactory
-from codecov_auth.views.okta import OktaLoginView
+from codecov_auth.views.okta import OktaLoginView, validate_id_token
 from codecov_auth.views.okta import auth as okta_basic_auth
-from codecov_auth.views.okta import validate_id_token
 
 
 @pytest.fixture
@@ -195,7 +194,6 @@ def test_okta_redirect_to_authorize_invalid_iss(client):
 def test_okta_perform_login(
     client, mocked_okta_token_request, mocked_validate_id_token, db
 ):
-
     state = "test-state"
     session = client.session
     session["okta_oauth_state"] = state

--- a/compare/migrations/0001_initial.py
+++ b/compare/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("core", "0004_pull_user_provided_base_sha")]

--- a/compare/migrations/0002_commitcomparison_patch_totals.py
+++ b/compare/migrations/0002_commitcomparison_patch_totals.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("compare", "0001_initial")]
 
     operations = [

--- a/compare/migrations/0003_commitcomparison_error.py
+++ b/compare/migrations/0003_commitcomparison_error.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("compare", "0002_commitcomparison_patch_totals")]
 
     operations = [

--- a/compare/migrations/0004_flagcomparison.py
+++ b/compare/migrations/0004_flagcomparison.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0003_auto_20211118_1150"),
         ("compare", "0003_commitcomparison_error"),

--- a/compare/migrations/0005_auto_20220713_2210.py
+++ b/compare/migrations/0005_auto_20220713_2210.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("compare", "0004_flagcomparison"),
     ]

--- a/compare/migrations/0006_componentcomparison_and_more.py
+++ b/compare/migrations/0006_componentcomparison_and_more.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("compare", "0005_auto_20220713_2210"),
     ]

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -14,7 +14,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]

--- a/core/migrations/0002_auto_20210517_1223.py
+++ b/core/migrations/0002_auto_20210517_1223.py
@@ -5,7 +5,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0001_initial")]
 
     operations = [

--- a/core/migrations/0003_auto_20210520_0841.py
+++ b/core/migrations/0003_auto_20210520_0841.py
@@ -5,7 +5,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0002_auto_20210517_1223")]
 
     operations = [

--- a/core/migrations/0004_pull_user_provided_base_sha.py
+++ b/core/migrations/0004_pull_user_provided_base_sha.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0003_auto_20210520_0841")]
 
     operations = [

--- a/core/migrations/0005_auto_20210916_0313.py
+++ b/core/migrations/0005_auto_20210916_0313.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0004_pull_user_provided_base_sha")]
 
     operations = [

--- a/core/migrations/0006_version_v4_6_2.py
+++ b/core/migrations/0006_version_v4_6_2.py
@@ -9,7 +9,6 @@ def add_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0005_auto_20210916_0313")]
 
     operations = [migrations.RunPython(add_version)]

--- a/core/migrations/0007_version_v4_6_3.py
+++ b/core/migrations/0007_version_v4_6_3.py
@@ -9,7 +9,6 @@ def add_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0006_version_v4_6_2")]
 
     operations = [migrations.RunPython(add_version)]

--- a/core/migrations/0008_version_v4_6_4.py
+++ b/core/migrations/0008_version_v4_6_4.py
@@ -9,7 +9,6 @@ def add_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0007_version_v4_6_3")]
 
     operations = [migrations.RunPython(add_version)]

--- a/core/migrations/0009_version_v4_6_5.py
+++ b/core/migrations/0009_version_v4_6_5.py
@@ -9,7 +9,6 @@ def add_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0008_version_v4_6_4")]
 
     operations = [migrations.RunPython(add_version)]

--- a/core/migrations/0012_auto_20220511_1732.py
+++ b/core/migrations/0012_auto_20220511_1732.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("core", "0011_add_decoration_type"),

--- a/core/migrations/0015_commiterror.py
+++ b/core/migrations/0015_commiterror.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0014_pull_pulls_author_updatestamp"),
     ]

--- a/core/migrations/0016_version_v4_6_6.py
+++ b/core/migrations/0016_version_v4_6_6.py
@@ -9,7 +9,6 @@ def add_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0015_commiterror")]
 
     operations = [migrations.RunPython(add_version)]

--- a/core/migrations/0021_pull_behind_by_pull_behind_by_commit.py
+++ b/core/migrations/0021_pull_behind_by_pull_behind_by_commit.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0020_commit_commits_repoid_commitid_short_and_more"),
     ]

--- a/core/migrations/0024_alter_commit_timestamp_alter_commit_updatestamp_and_more.py
+++ b/core/migrations/0024_alter_commit_timestamp_alter_commit_updatestamp_and_more.py
@@ -7,7 +7,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0023_alter_commitnotification_decoration_type"),
     ]

--- a/core/migrations/0025_v5_0_1.py
+++ b/core/migrations/0025_v5_0_1.py
@@ -9,7 +9,6 @@ def add_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0024_alter_commit_timestamp_alter_commit_updatestamp_and_more")
     ]

--- a/core/migrations/0026_auto_20230605_1134.py
+++ b/core/migrations/0026_auto_20230605_1134.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0025_v5_0_1"),
     ]

--- a/core/migrations/0027_alter_commit_report_rename_report_commit__report_and_more.py
+++ b/core/migrations/0027_alter_commit_report_rename_report_commit__report_and_more.py
@@ -6,7 +6,6 @@ import core.encoders
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0026_auto_20230605_1134"),
     ]

--- a/core/migrations/0033_alter_pull_flare_rename_flare_pull__flare_and_more.py
+++ b/core/migrations/0033_alter_pull_flare_rename_flare_pull__flare_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0032_auto_20230731_1641"),
     ]

--- a/core/migrations/0036_auto_20231003_1342.py
+++ b/core/migrations/0036_auto_20231003_1342.py
@@ -11,7 +11,6 @@ def update_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0035_auto_20230907_2123"),
     ]

--- a/core/migrations/0037_alter_commitnotification_decoration_type.py
+++ b/core/migrations/0037_alter_commitnotification_decoration_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0036_auto_20231003_1342"),
     ]

--- a/core/migrations/0038_increment_version.py
+++ b/core/migrations/0038_increment_version.py
@@ -11,7 +11,6 @@ def update_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0037_alter_commitnotification_decoration_type"),
     ]

--- a/core/migrations/0040_increment_version.py
+++ b/core/migrations/0040_increment_version.py
@@ -11,7 +11,6 @@ def update_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0039_pull_pulls_repoid_id"),
     ]

--- a/core/migrations/0048_increment_version.py
+++ b/core/migrations/0048_increment_version.py
@@ -11,7 +11,6 @@ def update_version(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0047_increment_version"),
     ]

--- a/graphql_api/actions/path_contents.py
+++ b/graphql_api/actions/path_contents.py
@@ -7,7 +7,7 @@ from services.path import Dir, File
 
 
 def partition_list_into_files_and_directories(
-    items: Iterable[Union[File, Dir]]
+    items: Iterable[Union[File, Dir]],
 ) -> tuple[Union[File, Dir]]:
     files = []
     directories = []
@@ -23,7 +23,7 @@ def partition_list_into_files_and_directories(
 
 
 def sort_list_by_directory(
-    items: Iterable[Union[File, Dir]]
+    items: Iterable[Union[File, Dir]],
 ) -> Iterable[Union[File, Dir]]:
     (files, directories) = partition_list_into_files_and_directories(items=items)
     return directories + files

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -336,9 +336,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 username
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=owner)
         assert data["owner"]["defaultOrgUsername"] == None
 
@@ -358,9 +356,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 username
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=owner)
         assert data["owner"]["defaultOrgUsername"] == organization.username
 
@@ -372,9 +368,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 username
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=owner)
         assert data["owner"]["defaultOrgUsername"] == None
 
@@ -386,9 +380,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 username
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=owner)
         assert data["owner"]["defaultOrgUsername"] == None
 
@@ -401,9 +393,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=self.owner)
         assert data["owner"]["isCurrentUserActivated"] == False
 
@@ -414,9 +404,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         self.client.force_login(user=UserFactory())
         data = self.gql_request(query, owner=None)
         assert data["owner"]["isCurrentUserActivated"] == False
@@ -433,9 +421,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=user)
         assert data["owner"]["isCurrentUserActivated"] == True
 
@@ -449,9 +435,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=user)
         assert data["owner"]["isCurrentUserActivated"] == False
 
@@ -462,9 +446,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query)
         assert data["owner"]["isCurrentUserActivated"] == False
 
@@ -479,9 +461,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=self.owner)
         assert data["owner"]["isCurrentUserActivated"] == True
 
@@ -491,9 +471,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 isCurrentUserActivated
             }
         }
-        """ % (
-            self.owner.username
-        )
+        """ % (self.owner.username)
         data = self.gql_request(query, owner=self.owner)
         assert data["owner"]["isCurrentUserActivated"] == True
 
@@ -513,9 +491,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 }
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["plan"] == {
             "trialStatus": "ONGOING",
@@ -539,9 +515,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 }
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["pretrialPlan"] == {
             "benefits": [
@@ -566,9 +540,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 }
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["availablePlans"] == [
             {"planName": "users-basic"},
@@ -588,9 +560,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 username
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
 
         res = self.gql_request(query, provider="", with_errors=True)
 
@@ -608,9 +578,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 hasPrivateRepos
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
 
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["hasPrivateRepos"] == True
@@ -639,9 +607,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 hasPrivateRepos
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
 
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["hasPrivateRepos"] == False
@@ -656,9 +622,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 hashOwnerid
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
         data = self.gql_request(query, owner=user)
         assert data["owner"]["hashOwnerid"] is not None
 
@@ -670,9 +634,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 username
             }
         }
-        """ % (
-            owner.username
-        )
+        """ % (owner.username)
 
         try:
             self.gql_request(query)

--- a/graphql_api/tests/test_plan.py
+++ b/graphql_api/tests/test_plan.py
@@ -53,9 +53,7 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                 }
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["plan"] == {
             "trialStatus": "ONGOING",
@@ -94,8 +92,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                 }
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["plan"] == {"hasSeatsLeft": True}

--- a/graphql_api/tests/test_plan_representation.py
+++ b/graphql_api/tests/test_plan_representation.py
@@ -46,9 +46,7 @@ class TestPlanRepresentationsType(GraphQLTestHelper, TransactionTestCase):
                 }
             }
         }
-        """ % (
-            current_org.username
-        )
+        """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["pretrialPlan"] == {
             "marketingName": "Developer",

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -140,7 +140,6 @@ async def resolve_compare_with_parent(commit: Commit, info, **kwargs):
         return comparison_error
 
     if commit_comparison and commit_comparison.is_processed:
-
         current_owner = info.context["request"].current_owner
         parent_commit = await CommitLoader.loader(info, commit.repository_id).load(
             commit.parent_commit_id

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -253,7 +253,9 @@ def resolve_flag_comparisons_count(
 @comparison_bindable.field("hasDifferentNumberOfHeadAndBaseReports")
 @sync_to_async
 def resolve_has_different_number_of_head_and_base_reports(
-    comparison: ComparisonReport, info: GraphQLResolveInfo, **kwargs  # type: ignore
+    comparison: ComparisonReport,
+    info: GraphQLResolveInfo,
+    **kwargs,  # type: ignore
 ) -> False:
     # TODO: can we remove the need for `info.context["comparison"]` here?
     if "comparison" not in info.context:

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -39,7 +39,7 @@ def resolve_repositories(
     filters=None,
     ordering=RepositoryOrdering.ID,
     ordering_direction=OrderingDirection.ASC,
-    **kwargs
+    **kwargs,
 ):
     current_owner = info.context["request"].current_owner
     queryset = list_repository_for_owner(current_owner, owner, filters)
@@ -47,7 +47,7 @@ def resolve_repositories(
         queryset,
         ordering=(ordering, RepositoryOrdering.ID),
         ordering_direction=ordering_direction,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -115,7 +115,7 @@ async def resolve_pulls(
     info: GraphQLResolveInfo,
     filters=None,
     ordering_direction=OrderingDirection.DESC,
-    **kwargs
+    **kwargs,
 ):
     command = info.context["executor"].get_command("pull")
     queryset = await command.fetch_pull_requests(repository, filters)
@@ -223,7 +223,7 @@ def resolve_flags(
     info: GraphQLResolveInfo,
     filters: Mapping = None,
     ordering_direction: OrderingDirection = OrderingDirection.ASC,
-    **kwargs
+    **kwargs,
 ):
     queryset = flags_for_repo(repository, filters)
     connection = queryset_to_connection_sync(

--- a/graphs/mixins.py
+++ b/graphs/mixins.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 
 class GraphBadgeAPIMixin(object):
     def get(self, request, *args, **kwargs):
-
         ext = self.kwargs.get("ext")
         if not ext in self.extensions:
             return Response(
@@ -28,8 +27,8 @@ class GraphBadgeAPIMixin(object):
             response["Content-Type"] = "image/svg+xml"
             response["Pragma"] = "no-cache"
             response["Expires"] = "0"
-            response[
-                "Access-Control-Expose-Headers"
-            ] = "Content-Type, Cache-Control, Expires, Etag, Last-Modified"
+            response["Access-Control-Expose-Headers"] = (
+                "Content-Type, Cache-Control, Expires, Etag, Last-Modified"
+            )
             response["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
         return response

--- a/graphs/tests/test_graph_utils.py
+++ b/graphs/tests/test_graph_utils.py
@@ -3,7 +3,6 @@ from graphs.helpers.graph_utils import _tree_height
 
 class TestGraphsUtils(object):
     def test_tree_height(self):
-
         tree = [{"name": "name_0"}]
 
         height = _tree_height(tree)

--- a/labelanalysis/migrations/0001_initial.py
+++ b/labelanalysis/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/labelanalysis/migrations/0002_auto_20230208_1712.py
+++ b/labelanalysis/migrations/0002_auto_20230208_1712.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("labelanalysis", "0001_initial"),
     ]

--- a/labelanalysis/migrations/0003_labelanalysisprocessingerror.py
+++ b/labelanalysis/migrations/0003_labelanalysisprocessingerror.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("labelanalysis", "0002_auto_20230208_1712"),
     ]

--- a/legacy_migrations/migrations/0001_initial.py
+++ b/legacy_migrations/migrations/0001_initial.py
@@ -25,7 +25,6 @@ def forwards_func(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0001_initial")]
 
     operations = [migrations.RunPython(forwards_func)]

--- a/legacy_migrations/migrations/0002_yaml_history_table.py
+++ b/legacy_migrations/migrations/0002_yaml_history_table.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/legacy_migrations/migrations/0003_auto_20230120_1837.py
+++ b/legacy_migrations/migrations/0003_auto_20230120_1837.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("legacy_migrations", "0002_yaml_history_table"),
     ]

--- a/legacy_migrations/migrations/0004_auto_20231024_1937.py
+++ b/legacy_migrations/migrations/0004_auto_20231024_1937.py
@@ -65,7 +65,6 @@ $$ language plpgsql;
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("legacy_migrations", "0003_auto_20230120_1837"),
     ]

--- a/legacy_migrations/migrations/legacy_sql/upgrades/main.py
+++ b/legacy_migrations/migrations/legacy_sql/upgrades/main.py
@@ -49,7 +49,7 @@ def run_sql(schema_editor, current_version):
     if not upgrade_migration_index_to_start_from:
         return
 
-    for (_, upgrade_migration) in UPGRADE_MIGRATIONS_BY_VERSION[
+    for _, upgrade_migration in UPGRADE_MIGRATIONS_BY_VERSION[
         upgrade_migration_index_to_start_from:
     ]:
         upgrade_migration(schema_editor)

--- a/profiling/migrations/0001_initial.py
+++ b/profiling/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("core", "0004_pull_user_provided_base_sha")]

--- a/profiling/migrations/0002_auto_20210817_2007.py
+++ b/profiling/migrations/0002_auto_20210817_2007.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("profiling", "0001_initial")]
 
     operations = [

--- a/profiling/migrations/0003_profilingcommit_commit_sha.py
+++ b/profiling/migrations/0003_profilingcommit_commit_sha.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("profiling", "0002_auto_20210817_2007")]
 
     operations = [

--- a/profiling/migrations/0004_auto_20211011_2047.py
+++ b/profiling/migrations/0004_auto_20211011_2047.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("profiling", "0003_profilingcommit_commit_sha")]
 
     operations = [

--- a/profiling/migrations/0005_auto_20211018_2158.py
+++ b/profiling/migrations/0005_auto_20211018_2158.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("profiling", "0004_auto_20211011_2047")]
 
     operations = [

--- a/reports/migrations/0001_initial.py
+++ b/reports/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("core", "0001_initial")]

--- a/reports/migrations/0002_auto_20211006_2211.py
+++ b/reports/migrations/0002_auto_20211006_2211.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("reports", "0001_initial")]
 
     operations = [

--- a/reports/migrations/0003_auto_20211118_1150.py
+++ b/reports/migrations/0003_auto_20211118_1150.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("reports", "0002_auto_20211006_2211")]
 
     operations = [

--- a/reports/migrations/0004_commitreport_code.py
+++ b/reports/migrations/0004_commitreport_code.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0003_auto_20211118_1150"),
     ]

--- a/reports/migrations/0005_auto_20221114_1428.py
+++ b/reports/migrations/0005_auto_20221114_1428.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0004_commitreport_code"),
     ]

--- a/reports/migrations/0006_auto_20221212_1111.py
+++ b/reports/migrations/0006_auto_20221212_1111.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     atomic = False
 
     dependencies = [

--- a/reports/migrations/0007_auto_20230220_1245.py
+++ b/reports/migrations/0007_auto_20230220_1245.py
@@ -5,7 +5,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0006_auto_20221212_1111"),
     ]

--- a/reports/migrations/0008_auto_20230228_1059.py
+++ b/reports/migrations/0008_auto_20230228_1059.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0007_auto_20230220_1245"),
     ]

--- a/reports/migrations/0009_auto_20230223_1624.py
+++ b/reports/migrations/0009_auto_20230223_1624.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0008_auto_20230228_1059"),
     ]

--- a/reports/migrations/0015_testresultreporttotals.py
+++ b/reports/migrations/0015_testresultreporttotals.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0014_rename_env_test_flags_hash_and_more"),
     ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,61 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["F541"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,11 +32,11 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.8
-target-version = "py38"
+# Assume Python 3.12
+target-version = "py312"
 
 [lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Currently only enabled F541: https://docs.astral.sh/ruff/rules/
 select = ["F541"]
 ignore = []
 

--- a/services/archive.py
+++ b/services/archive.py
@@ -42,7 +42,6 @@ class MinioEndpoints(Enum):
 # Service class for performing archive operations. Meant to work against the
 # underlying StorageService
 class ArchiveService(object):
-
     """
     The root level of the archive. In s3 terms,
     this would be the name of the bucket

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -363,7 +363,7 @@ class LineComparison:
             return None
 
         hit_count = 0
-        for (id, coverage, *rest) in self.head_line_sessions:
+        for id, coverage, *rest in self.head_line_sessions:
             if line_type(coverage) == LineType.hit:
                 hit_count += 1
         if hit_count > 0:
@@ -375,7 +375,7 @@ class LineComparison:
             return None
 
         ids = []
-        for (id, coverage, *rest) in self.head_line_sessions:
+        for id, coverage, *rest in self.head_line_sessions:
             if line_type(coverage) == LineType.hit:
                 ids.append(id)
         if len(ids) > 0:

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -258,7 +258,7 @@ class TaskService(object):
         dataset_names: Iterable[str] = None,
     ):
         log.info(
-            f"Triggering timeseries backfill tasks for repo",
+            "Triggering timeseries backfill tasks for repo",
             extra=dict(
                 repoid=repository.pk,
                 start_date=start_date.isoformat(),
@@ -307,7 +307,7 @@ class TaskService(object):
         end_date: datetime,
     ):
         log.info(
-            f"Triggering dataset backfill",
+            "Triggering dataset backfill",
             extra=dict(
                 dataset_id=dataset.pk,
                 start_date=start_date.isoformat(),
@@ -326,7 +326,7 @@ class TaskService(object):
 
     def delete_timeseries(self, repository_id: int):
         log.info(
-            f"Delete repository timeseries data",
+            "Delete repository timeseries data",
             extra=dict(repository_id=repository_id),
         )
         self._create_signature(
@@ -416,7 +416,7 @@ class TaskService(object):
 
     def delete_component_measurements(self, repoid: int, component_id: str) -> None:
         log.info(
-            f"Delete component measurements data",
+            "Delete component measurements data",
             extra=dict(repository_id=repoid, component_id=component_id),
         )
         self._create_signature(

--- a/services/tests/test_repo_providers.py
+++ b/services/tests/test_repo_providers.py
@@ -266,8 +266,8 @@ class TestRepoProviderService(InternalAPITest):
                     token=encryptor.decrypt_token(repo.bot.oauth_token),
                     verify_ssl="ssl_pem",
                     oauth_consumer_token=dict(
-                        key=getattr(settings, f"GITHUB_CLIENT_ID", "unknown"),
-                        secret=getattr(settings, f"GITHUB_CLIENT_SECRET", "unknown"),
+                        key=getattr(settings, "GITHUB_CLIENT_ID", "unknown"),
+                        secret=getattr(settings, "GITHUB_CLIENT_SECRET", "unknown"),
                     ),
                 ),
             ),
@@ -302,8 +302,8 @@ class TestRepoProviderService(InternalAPITest):
                     token=encryptor.decrypt_token(repo.bot.oauth_token),
                     verify_ssl="REQUESTS_CA_BUNDLE",
                     oauth_consumer_token=dict(
-                        key=getattr(settings, f"GITHUB_CLIENT_ID", "unknown"),
-                        secret=getattr(settings, f"GITHUB_CLIENT_SECRET", "unknown"),
+                        key=getattr(settings, "GITHUB_CLIENT_ID", "unknown"),
+                        secret=getattr(settings, "GITHUB_CLIENT_SECRET", "unknown"),
                     ),
                 ),
             ),

--- a/staticanalysis/migrations/0001_initial.py
+++ b/staticanalysis/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/timeseries/migrations/0001_initial.py
+++ b/timeseries/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/timeseries/migrations/0003_cagg_policies.py
+++ b/timeseries/migrations/0003_cagg_policies.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0002_continuous_aggregates"),
     ]

--- a/timeseries/migrations/0004_measurement_summaries.py
+++ b/timeseries/migrations/0004_measurement_summaries.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0003_cagg_policies"),
     ]

--- a/timeseries/migrations/0005_uniqueness_constraints.py
+++ b/timeseries/migrations/0005_uniqueness_constraints.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0004_measurement_summaries"),
     ]

--- a/timeseries/migrations/0006_auto_20220718_1311.py
+++ b/timeseries/migrations/0006_auto_20220718_1311.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0005_uniqueness_constraints"),
     ]

--- a/timeseries/migrations/0008_auto_20220802_1838.py
+++ b/timeseries/migrations/0008_auto_20220802_1838.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0007_auto_20220727_2011"),
     ]

--- a/timeseries/migrations/0010_auto_20230123_1453.py
+++ b/timeseries/migrations/0010_auto_20230123_1453.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0009_auto_20220804_1305"),
     ]

--- a/timeseries/migrations/0011_measurement_measurable_id.py
+++ b/timeseries/migrations/0011_measurement_measurable_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0010_auto_20230123_1453"),
     ]

--- a/timeseries/migrations/0012_auto_20230501_1929.py
+++ b/timeseries/migrations/0012_auto_20230501_1929.py
@@ -5,7 +5,6 @@ from shared.django_apps.migration_utils import RiskyRunSQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0011_measurement_measurable_id"),
     ]

--- a/timeseries/migrations/0014_remove_measurement_timeseries_measurement_flag_unique_and_more.py
+++ b/timeseries/migrations/0014_remove_measurement_timeseries_measurement_flag_unique_and_more.py
@@ -10,7 +10,6 @@ import core.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("timeseries", "0013_measurable_indexes_caggs"),
     ]

--- a/timeseries/tests/test_admin.py
+++ b/timeseries/tests/test_admin.py
@@ -28,7 +28,7 @@ class DatasetAdminTest(TransactionTestCase):
         self.dataset2 = DatasetFactory(repository_id=self.repo2.pk, backfilled=True)
 
     def test_list_page(self):
-        res = self.client.get(reverse(f"admin:timeseries_dataset_changelist"))
+        res = self.client.get(reverse("admin:timeseries_dataset_changelist"))
         assert res.status_code == 200
 
     def test_backfill_page(self):

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -321,7 +321,7 @@ def determine_repo_for_upload(upload_params):
                 author__username=upload_params.get("owner"),
             )
         except ObjectDoesNotExist:
-            raise NotFound(f"Could not find a repository, try using repo upload token")
+            raise NotFound("Could not find a repository, try using repo upload token")
     else:
         raise ValidationError(
             "Need either a token or service to determine target repository"
@@ -808,7 +808,6 @@ def get_agent_from_headers(headers):
 
 
 def get_version_from_headers(headers):
-
     try:
         return headers["User-Agent"].split("/")[1]
     except Exception as e:

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -184,7 +184,7 @@ def test_upload_bundle_analysis_invalid_token(db, client, mocker, mock_redis):
     commit = CommitFactory.create(repository=repository)
 
     client = APIClient()
-    client.credentials(HTTP_AUTHORIZATION=f"token 2a869881-9c0f-4754-b790-3f5920be3605")
+    client.credentials(HTTP_AUTHORIZATION="token 2a869881-9c0f-4754-b790-3f5920be3605")
 
     res = client.post(
         reverse("upload-bundle-analysis"),

--- a/upload/throttles.py
+++ b/upload/throttles.py
@@ -57,7 +57,6 @@ class UploadsPerWindowThrottle(BaseThrottle):
                         report__commit=commit
                     ).exists()
                     if not did_commit_uploads_start_already:
-
                         if (
                             query_monthly_coverage_measurements(
                                 plan_service=plan_service

--- a/upload/tokenless/azure.py
+++ b/upload/tokenless/azure.py
@@ -38,7 +38,7 @@ class TokenlessAzureHandler(BaseTokenlessUploadHandler):
             )
         try:
             build = response.json()
-        except (JSONDecodeError) as e:
+        except JSONDecodeError as e:
             log.warning(
                 f"Expected JSON in Azure response, got error {e} instead",
                 extra=dict(
@@ -55,7 +55,6 @@ class TokenlessAzureHandler(BaseTokenlessUploadHandler):
         return build
 
     def verify(self):
-
         if not self.upload_params.get("job"):
             raise NotFound(
                 'Missing "job" argument. Please upload with the Codecov repository upload token to resolve issue.'

--- a/upload/tokenless/circleci.py
+++ b/upload/tokenless/circleci.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 
 
 class TokenlessCircleciHandler(BaseTokenlessUploadHandler):
-
     circleci_token = settings.CIRCLECI_TOKEN
 
     def get_build(self):
@@ -60,7 +59,7 @@ class TokenlessCircleciHandler(BaseTokenlessUploadHandler):
 
         if build.get("vcs_revision", "") != self.upload_params.get("commit"):
             log.warning(
-                f"Failed to fetch commit from CircleCI",
+                "Failed to fetch commit from CircleCI",
                 extra=dict(
                     commit=self.upload_params.get("commit"),
                     vcs_revision=build.get("vcs_revision", ""),

--- a/upload/tokenless/cirrus.py
+++ b/upload/tokenless/cirrus.py
@@ -99,7 +99,7 @@ class TokenlessCirrusHandler(BaseTokenlessUploadHandler):
         # Check repository
         if build["repository"]["owner"] != owner or build["repository"]["name"] != repo:
             log.warning(
-                f"Repository slug does not match Cirrus arguments",
+                "Repository slug does not match Cirrus arguments",
                 extra=dict(
                     build_info=build,
                     commit=commit,
@@ -115,7 +115,7 @@ class TokenlessCirrusHandler(BaseTokenlessUploadHandler):
         # Check commit SHA
         if build["changeIdInRepo"] != commit:
             log.warning(
-                f"Commit sha does not match Github actions arguments",
+                "Commit sha does not match Github actions arguments",
                 extra=dict(
                     build_info=build,
                     commit=commit,
@@ -138,7 +138,7 @@ class TokenlessCirrusHandler(BaseTokenlessUploadHandler):
             now = time.time()
             if now > finishTimestamp:
                 log.warning(
-                    f"Cirrus run is stale",
+                    "Cirrus run is stale",
                     extra=dict(
                         build_info=build,
                         commit=commit,
@@ -148,7 +148,7 @@ class TokenlessCirrusHandler(BaseTokenlessUploadHandler):
                     ),
                 )
                 log.warning(
-                    f"Cirrus run is stale",
+                    "Cirrus run is stale",
                     extra=dict(
                         build_info=build,
                         commit=commit,

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 
 
 class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
-
     actions_token = settings.GITHUB_ACTIONS_TOKEN
     client_id = settings.GITHUB_CLIENT_ID
     client_secret = settings.GITHUB_CLIENT_SECRET
@@ -98,7 +97,7 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
             )
         ):
             self.log_warning(
-                message=f"Repository slug or commit sha do not match Github actions arguments"
+                message="Repository slug or commit sha do not match Github actions arguments"
             )
             raise NotFound(
                 "Repository slug or commit sha do not match Github actions build. Please upload with the Codecov repository upload token to resolve issue."

--- a/upload/tokenless/tokenless.py
+++ b/upload/tokenless/tokenless.py
@@ -20,7 +20,6 @@ log = logging.getLogger(__name__)
 
 
 class TokenlessUploadHandler(object):
-
     ci_verifiers = {
         "appveyor": TokenlessAppveyorHandler,
         "azure_pipelines": TokenlessAzureHandler,

--- a/upload/tokenless/travis.py
+++ b/upload/tokenless/travis.py
@@ -50,7 +50,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
         # if job not found in travis.com try travis.org
         if not travis_dot_com:
             log.info(
-                f"Unable to verify using travis.com, trying travis.org",
+                "Unable to verify using travis.com, trying travis.org",
                 extra=dict(
                     commit=self.upload_params["commit"],
                     repo_name=self.upload_params["repo"],
@@ -125,7 +125,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
             now = datetime.utcnow()
             if not now <= finishTimeWithBuffer:
                 log.warning(
-                    f"Cancelling upload: 4 mins since build",
+                    "Cancelling upload: 4 mins since build",
                     extra=dict(
                         commit=self.upload_params["commit"],
                         repo_name=self.upload_params["repo"],
@@ -138,7 +138,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
             # check if current state is correct (i.e not finished)
             if job["state"] != "started":
                 log.warning(
-                    f"Cancelling upload: job state does not indicate that build is in progress",
+                    "Cancelling upload: job state does not indicate that build is in progress",
                     extra=dict(
                         commit=self.upload_params["commit"],
                         repo_name=self.upload_params["repo"],
@@ -149,7 +149,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
                 raise NotFound(errors["travis"]["tokenless-bad-status"])
 
         log.info(
-            f"Finished travis tokenless upload",
+            "Finished travis tokenless upload",
             extra=dict(
                 commit=self.upload_params["commit"],
                 repo_name=self.upload_params["repo"],

--- a/upload/views/base.py
+++ b/upload/views/base.py
@@ -42,7 +42,7 @@ class GetterMixin(ShelterMixin):
                 "Repository not found",
                 extra=dict(repo_slug=repo_slug),
             )
-            raise ValidationError(f"Repository not found")
+            raise ValidationError("Repository not found")
         return repository
 
     def get_commit(self, repo: Repository) -> Commit:
@@ -76,7 +76,7 @@ class GetterMixin(ShelterMixin):
                 "Report not found",
                 extra=dict(commit_sha=commit.commitid, report_code=report_code),
             )
-            raise ValidationError(f"Report not found")
+            raise ValidationError("Report not found")
         if report.report_type is None:
             report.report_type = CommitReport.ReportType.COVERAGE
             report.save()

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -159,7 +159,7 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
             changed_files = async_to_sync(provider.get_pull_request_files)(pull_id)
         except TorngitClientError:
             log.warning(
-                f"Request client error",
+                "Request client error",
                 extra=dict(
                     commit=commit.commitid,
                     repoid=commit.repository.repoid,
@@ -177,7 +177,7 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
                 )
         except TorngitClientGeneralError:
             log.warning(
-                f"Request client error",
+                "Request client error",
                 extra=dict(
                     commit=commit.commitid,
                     repoid=commit.repository.repoid,

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -69,9 +69,9 @@ class UploadHandler(APIView, ShelterMixin):
         response["Accept"] = "text/*"
         response["Access-Control-Allow-Origin"] = "*"
         response["Access-Control-Allow-Method"] = "POST"
-        response[
-            "Access-Control-Allow-Headers"
-        ] = "Origin, Content-Type, Accept, X-User-Agent"
+        response["Access-Control-Allow-Headers"] = (
+            "Origin, Content-Type, Accept, X-User-Agent"
+        )
 
         return response
 
@@ -91,9 +91,9 @@ class UploadHandler(APIView, ShelterMixin):
         # Set response headers
         response = HttpResponse()
         response["Access-Control-Allow-Origin"] = "*"
-        response[
-            "Access-Control-Allow-Headers"
-        ] = "Origin, Content-Type, Accept, X-User-Agent"
+        response["Access-Control-Allow-Headers"] = (
+            "Origin, Content-Type, Accept, X-User-Agent"
+        )
 
         # Parse request parameters
         request_params = {

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -108,5 +108,5 @@ class ReportResultsView(
                     report_code=self.kwargs.get("report_code"),
                 ),
             )
-            raise ValidationError(f"Report Results not found")
+            raise ValidationError("Report Results not found")
         return report_results

--- a/utils/tests/unit/test_model_utils.py
+++ b/utils/tests/unit/test_model_utils.py
@@ -11,7 +11,6 @@ from utils.model_utils import ArchiveField, ArchiveFieldInterface
 
 class TestArchiveField(object):
     class ClassWithArchiveField(object):
-
         commit: Commit
         id = 1
         external_id = "external_id"

--- a/validate/tests/test_validate.py
+++ b/validate/tests/test_validate.py
@@ -9,7 +9,6 @@ from yaml import YAMLError
 
 
 class TestValidateYamlHandler(APITestCase):
-
     # Wrap get and post client calls
 
     def _get(self):

--- a/validate/views.py
+++ b/validate/views.py
@@ -39,7 +39,7 @@ class V1ValidateYamlHandler(APIView):
 
             if not isinstance(yaml_dict, dict):
                 log.warning(
-                    f"yaml_dict result from loading validate request body is not a dict",
+                    "yaml_dict result from loading validate request body is not a dict",
                     extra=dict(
                         yaml_dict=yaml_dict, request_body=str(self.request.body)
                     ),
@@ -95,7 +95,7 @@ class V2ValidateYamlHandler(V1ValidateYamlHandler):
             yaml_dict = safe_load(self.request.body)
             if not isinstance(yaml_dict, dict):
                 log.warning(
-                    f"yaml_dict result from loading validate request body is not a dict",
+                    "yaml_dict result from loading validate request body is not a dict",
                     extra=dict(
                         yaml_dict=yaml_dict, request_body=str(self.request.body)
                     ),

--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -76,7 +76,7 @@ class GithubWebhookHandlerTests(APITestCase):
                 ).hexdigest(),
             },
             data=data,
-            format="json"
+            format="json",
         )
 
     def setUp(self):
@@ -695,7 +695,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_creates_new_owner_if_dne_all_repos_non_default_app(self):
         username, service_id = "newuser", 123456
@@ -737,7 +743,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
@@ -776,7 +788,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_update_repos_existing_ghapp_installation(self):
         owner = OwnerFactory(service=Service.GITHUB.value)
@@ -879,7 +897,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_update_existing_ghapp(self):
         # Should set integration_id to null for owner,
@@ -991,7 +1015,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_with_other_actions_sets_owner_integration_id_if_none(
         self,
@@ -1036,7 +1066,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_with_other_actions_sets_owner_itegration_id_if_none(
         self,
@@ -1259,7 +1295,7 @@ class GithubWebhookHandlerTests(APITestCase):
                 GitHubHTTPHeaders.SIGNATURE: "",
             },
             data={},
-            format="json"
+            format="json",
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -1278,7 +1314,7 @@ class GithubWebhookHandlerTests(APITestCase):
                 ).hexdigest(),
             },
             data={},
-            format="json"
+            format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -1297,7 +1333,7 @@ class GithubWebhookHandlerTests(APITestCase):
                 ).hexdigest(),
             },
             data={},
-            format="json"
+            format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK

--- a/webhook_handlers/tests/test_github_enterprise.py
+++ b/webhook_handlers/tests/test_github_enterprise.py
@@ -60,7 +60,7 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
                 ).hexdigest(),
             },
             data=data,
-            format="json"
+            format="json",
         )
 
     def setUp(self):
@@ -466,7 +466,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
     @freeze_time("2024-03-28T00:00:00")
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
@@ -509,7 +515,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_creates_new_owner_if_dne_all_repos(self):
         username, service_id = "newuser", 123456
@@ -552,7 +564,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
     @freeze_time("2024-03-28T00:00:00")
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
@@ -648,7 +666,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_update_existing_ghapp(self):
         # Should set integration_id to null for owner,
@@ -698,7 +722,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_update_existing_ghapp_all_repos(self):
         # Should set integration_id to null for owner,
@@ -746,7 +776,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_with_other_actions_sets_owner_itegration_id_if_none(
         self,
@@ -789,7 +825,13 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_with_other_actions_sets_owner_itegration_id_if_none(
         self,
@@ -1017,7 +1059,7 @@ class GithubEnterpriseWebhookHandlerTests(APITestCase):
                 GitHubHTTPHeaders.SIGNATURE: "",
             },
             data={},
-            format="json"
+            format="json",
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -133,7 +133,7 @@ class GithubWebhookHandler(APIView):
                 )
             except Repository.DoesNotExist:
                 log.info(
-                    f"Received event for non-existent repository",
+                    "Received event for non-existent repository",
                     extra=dict(repo_service_id=repo_service_id, repo_slug=repo_slug),
                 )
                 raise NotFound("Repository does not exist")
@@ -158,7 +158,7 @@ class GithubWebhookHandler(APIView):
                         repo_data, owner
                     )[0]
                 log.info(
-                    f"Received event for non-existent repository",
+                    "Received event for non-existent repository",
                     extra=dict(repo_service_id=repo_service_id, repo_slug=repo_slug),
                 )
                 raise NotFound("Repository does not exist")
@@ -210,7 +210,7 @@ class GithubWebhookHandler(APIView):
                 f"Unsupported ref type: {ref_type}, exiting",
                 extra=dict(repoid=repo.repoid, github_webhook_event=self.event),
             )
-            return Response(f"Unsupported ref type")
+            return Response("Unsupported ref type")
         branch_name = self.request.data.get("ref")[11:]
         Branch.objects.filter(
             repository=self._get_repo(request), name=branch_name
@@ -241,7 +241,7 @@ class GithubWebhookHandler(APIView):
                 "Ref is tag, not branch, ignoring push event",
                 extra=dict(repoid=repo.repoid, github_webhook_event=self.event),
             )
-            return Response(f"Unsupported ref type")
+            return Response("Unsupported ref type")
 
         if not repo.active:
             log.debug(
@@ -488,13 +488,12 @@ class GithubWebhookHandler(APIView):
         # TODO: Consider adding "suspend" action here?
         # https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation
         if action == "deleted":
-
             if event == GitHubWebhookEvents.INSTALLATION:
-                ghapp_installation: Optional[
-                    GithubAppInstallation
-                ] = owner.github_app_installations.filter(
-                    installation_id=installation_id
-                ).first()
+                ghapp_installation: Optional[GithubAppInstallation] = (
+                    owner.github_app_installations.filter(
+                        installation_id=installation_id
+                    ).first()
+                )
                 if ghapp_installation is not None:
                     ghapp_installation.delete()
             # Deprecated flow - BEGIN
@@ -510,7 +509,6 @@ class GithubWebhookHandler(APIView):
             # GithubWebhookEvents.INSTALLTION_REPOSITORIES also execute this code
             # because of deprecated flow. But the GithubAppInstallation shouldn't be changed
             if event == GitHubWebhookEvents.INSTALLATION:
-
                 ghapp_installation, _ = GithubAppInstallation.objects.get_or_create(
                     installation_id=installation_id, owner=owner
                 )
@@ -681,7 +679,7 @@ class GithubWebhookHandler(APIView):
         if action == "removed":
             repo = self._get_repo(request)
             log.info(
-                f"Request to remove read permissions for user",
+                "Request to remove read permissions for user",
                 extra=dict(repoid=repo.repoid, github_webhook_event=self.event),
             )
             try:
@@ -690,7 +688,7 @@ class GithubWebhookHandler(APIView):
                 )
             except Owner.DoesNotExist:
                 log.info(
-                    f"Repository permissions unchanged -- owner doesn't exist",
+                    "Repository permissions unchanged -- owner doesn't exist",
                     extra=dict(repoid=repo.repoid, github_webhook_event=self.event),
                 )
                 return Response(status=status.HTTP_404_NOT_FOUND)
@@ -708,7 +706,7 @@ class GithubWebhookHandler(APIView):
                 )
             except (ValueError, AttributeError):
                 log.info(
-                    f"Member didn't have read permissions, didn't update",
+                    "Member didn't have read permissions, didn't update",
                     extra=dict(
                         repoid=repo.repoid,
                         ownerid=member.ownerid,


### PR DESCRIPTION
### Purpose/Motivation

Part of https://www.notion.so/sentry/Migrating-to-Ruff-bf528650b6d14fad8cb9964da7cafcbe proposal, we are moving over to using Ruff for linting and formatting, deprecating isort and black in the process.

This PR simply plugs in ruff into our make lint command and enables a single rule https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/

### Links to relevant tickets

closes https://github.com/codecov/engineering-team/issues/1719

### What does this PR do?

Adds ruff.toml, which is basically our ruff configuration file that is checked against when running the make command. This will allow us to easily update configuration in the future without having to muddy the make command as we add more rules.

Updates the make lint, make install, and make run commands to be Ruff specific, deprecating use of isort and black.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
