### PR TITLE
fix: Resolve float() not accepting None value

### DIFF
--- a/api/public/v2/component/views.py
+++ b/api/public/v2/component/views.py
@@ -43,7 +43,9 @@ class ComponentViewSet(viewsets.ViewSet, RepoPropertyMixin):
         components_with_coverage = []
         for component in components:
             component_report = component_filtered_report(report, [component])
-            coverage = round(float(component_report.totals.coverage), 2)
+            coverage = None
+            if component_report.totals.coverage is not None:
+                coverage = round(float(component_report.totals.coverage), 2)
             components_with_coverage.append(
                 {
                     "component_id": component.component_id,


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Resolves: https://github.com/codecov/internal-issues/issues/462

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
