### PR TITLE
fix scheduled details key w/ stripe version upgrade

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -216,7 +216,6 @@ class ScheduleDetailSerializer(serializers.Serializer):
     scheduled_phase = serializers.SerializerMethodField()
 
     def get_scheduled_phase(self, schedule):
-        print("le schedule", schedule)
         if len(schedule["phases"]) > 1:
             return StripeScheduledPhaseSerializer(schedule["phases"][-1]).data
         else:

--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -199,7 +199,7 @@ class StripeScheduledPhaseSerializer(serializers.Serializer):
     quantity = serializers.SerializerMethodField()
 
     def get_plan(self, phase):
-        plan_id = phase["plans"][0]["plan"]
+        plan_id = phase["items"][0]["plan"]
         stripe_plan_dict = settings.STRIPE_PLAN_IDS
         plan_name = list(stripe_plan_dict.keys())[
             list(stripe_plan_dict.values()).index(plan_id)
@@ -208,7 +208,7 @@ class StripeScheduledPhaseSerializer(serializers.Serializer):
         return marketing_plan_name
 
     def get_quantity(self, phase):
-        return phase["plans"][0]["quantity"]
+        return phase["items"][0]["quantity"]
 
 
 class ScheduleDetailSerializer(serializers.Serializer):
@@ -216,6 +216,7 @@ class ScheduleDetailSerializer(serializers.Serializer):
     scheduled_phase = serializers.SerializerMethodField()
 
     def get_scheduled_phase(self, schedule):
+        print("le schedule", schedule)
         if len(schedule["phases"]) > 1:
             return StripeScheduledPhaseSerializer(schedule["phases"][-1]).data
         else:

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -203,7 +203,7 @@ class AccountViewSetTests(APITestCase):
             {},
             {
                 "start_date": schedule_params["start_date"],
-                "plans": [
+                "items": [
                     {
                         "plan": schedule_params["stripe_plan_id"],
                         "quantity": schedule_params["quantity"],
@@ -295,15 +295,15 @@ class AccountViewSetTests(APITestCase):
         phases = [
             {
                 "start_date": 123689126536,
-                "plans": [{"plan": "test_plan_123", "quantity": 4}],
+                "items": [{"plan": "test_plan_123", "quantity": 4}],
             },
             {
                 "start_date": 123689126636,
-                "plans": [{"plan": "test_plan_456", "quantity": 5}],
+                "items": [{"plan": "test_plan_456", "quantity": 5}],
             },
             {
                 "start_date": schedule_params["start_date"],
-                "plans": [
+                "items": [
                     {
                         "plan": schedule_params["stripe_plan_id"],
                         "quantity": schedule_params["quantity"],

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -522,7 +522,7 @@ class StripeWebhookHandlerTests(APITestCase):
                         "subscription": subscription_id,
                         "phases": [
                             {},
-                            {"plans": [{"plan": new_plan, "quantity": new_quantity}]},
+                            {"items": [{"plan": new_plan, "quantity": new_quantity}]},
                         ],
                     }
                 },

--- a/billing/views.py
+++ b/billing/views.py
@@ -95,7 +95,7 @@ class StripeWebhookHandler(APIView):
         if schedule["subscription"]:
             subscription = stripe.Subscription.retrieve(schedule["subscription"])
             scheduled_phase = schedule["phases"][1]
-            scheduled_plan = scheduled_phase["plans"][0]
+            scheduled_plan = scheduled_phase["items"][0]
             plan_id = scheduled_plan["plan"]
             stripe_plan_dict = settings.STRIPE_PLAN_IDS
             plan_name = list(stripe_plan_dict.keys())[

--- a/docker/Dockerfile-proxy
+++ b/docker/Dockerfile-proxy
@@ -7,13 +7,15 @@ ENV FRP_VERSION=v0.51.3
 RUN apt-get update
 RUN apt-get install -y curl
 
-RUN addgroup -S frp \
-    && adduser -D -S -h /var/frp -s /sbin/nologin -G frp frp \
-    && curl -fSL https://github.com/fatedier/frp/releases/download/${FRP_VERSION}/frp_${FRP_VERSION:1}_linux_amd64.tar.gz -o frp.tar.gz \
-    && tar -zxv -f frp.tar.gz \
-    && rm -rf frp.tar.gz \
-    && mv frp_*_linux_amd64 /frp \
-    && chown -R frp:frp /frp
+SHELL ["/bin/bash", "-c"]
+
+RUN addgroup --system frp \
+&& adduser --debug --system --home /var/frp --shell /sbin/nologin --ingroup frp frp \
+&& curl -fSL https://github.com/fatedier/frp/releases/download/${FRP_VERSION}/frp_${FRP_VERSION:1}_linux_amd64.tar.gz -o frp.tar.gz \
+&& tar -zxv -f frp.tar.gz \
+&& rm -rf frp.tar.gz \
+&& mv frp_*_linux_amd64 /frp \
+&& chown -R frp:frp /frp
 
 COPY --chown=frp:frp docker/frpc-entrypoint.sh /frp/entrypoint.sh
 RUN chmod 755 /frp/entrypoint.sh

--- a/services/billing.py
+++ b/services/billing.py
@@ -255,7 +255,7 @@ class StripeService(AbstractPaymentService):
         current_subscription_end_date = subscription["current_period_end"]
 
         subscription_item = subscription["items"]["data"][0]
-        current_plan = subscription_item["plan"]["name"]
+        current_plan = subscription_item["plan"]["id"]
         current_quantity = subscription_item["quantity"]
 
         stripe.SubscriptionSchedule.modify(
@@ -265,10 +265,10 @@ class StripeService(AbstractPaymentService):
                 {
                     "start_date": current_subscription_start_date,
                     "end_date": current_subscription_end_date,
-                    "plans": [
+                    "items": [
                         {
-                            "plan": settings.STRIPE_PLAN_IDS[current_plan],
-                            "price": settings.STRIPE_PLAN_IDS[current_plan],
+                            "plan": current_plan,
+                            "price": current_plan,
                             "quantity": current_quantity,
                         }
                     ],
@@ -277,7 +277,7 @@ class StripeService(AbstractPaymentService):
                 {
                     "start_date": current_subscription_end_date,
                     "end_date": current_subscription_end_date + SCHEDULE_RELEASE_OFFSET,
-                    "plans": [
+                    "items": [
                         {
                             "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
                             "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -138,7 +138,7 @@ class MockSubscription(object):
                 {
                     "quantity": subscription_params["quantity"],
                     "id": subscription_params["id"],
-                    "plan": {"name": subscription_params["name"]},
+                    "plan": {"id": subscription_params["name"]},
                 }
             ]
         }
@@ -195,14 +195,10 @@ class StripeServiceTests(TestCase):
                 {
                     "start_date": subscription_params["start_date"],
                     "end_date": subscription_params["end_date"],
-                    "plans": [
+                    "items": [
                         {
-                            "plan": settings.STRIPE_PLAN_IDS[
-                                subscription_params["name"]
-                            ],
-                            "price": settings.STRIPE_PLAN_IDS[
-                                subscription_params["name"]
-                            ],
+                            "plan": subscription_params["name"],
+                            "price": subscription_params["name"],
                             "quantity": subscription_params["quantity"],
                         }
                     ],
@@ -212,7 +208,7 @@ class StripeServiceTests(TestCase):
                     "start_date": subscription_params["end_date"],
                     "end_date": subscription_params["end_date"]
                     + SCHEDULE_RELEASE_OFFSET,
-                    "plans": [
+                    "items": [
                         {
                             "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
                             "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],


### PR DESCRIPTION
### Purpose/Motivation
We recently majorly bumped our stripe version and some api calls stopped working. This fixes the scheduled detail serializer one.

### What does this PR do?
- adjusts tests + logic for scheduled phase serializer

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
