### PR TITLE
dev: Upgrade stripe version to latest and add typings

### DIFF
--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-from stripe.error import StripeError
+from stripe import StripeError
 
 from api.internal.tests.test_utils import GetAdminProviderAdapter
 from codecov_auth.models import Service

--- a/api/internal/tests/views/test_invoice_viewset.py
+++ b/api/internal/tests/views/test_invoice_viewset.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-from stripe.error import InvalidRequestError, StripeError
+from stripe import InvalidRequestError, StripeError
 
 from api.internal.tests.test_utils import GetAdminProviderAdapter
 from codecov_auth.tests.factories import OwnerFactory

--- a/billing/views.py
+++ b/billing/views.py
@@ -282,7 +282,7 @@ class StripeWebhookHandler(APIView):
                 self.request.META.get(StripeHTTPHeaders.SIGNATURE),
                 settings.STRIPE_ENDPOINT_SECRET,
             )
-        except stripe.error.SignatureVerificationError as e:
+        except stripe.SignatureVerificationError as e:
             log.warning(f"Stripe webhook event received with invalid signature -- {e}")
             return Response("Invalid signature", status=status.HTTP_400_BAD_REQUEST)
         if self.event.type not in StripeWebhookEvents.subscribed_events:

--- a/codecov/settings_dev.py
+++ b/codecov/settings_dev.py
@@ -29,6 +29,15 @@ STRIPE_PLAN_IDS = {
     "users-teamy": "price_1OCM2cGlVGuVgOrkMWUFjPFz",
 }
 
+STRIPE_PLAN_VALS = {
+    "plan_H6P3KZXwmAbqPS": "users-pr-inappm",
+    "plan_H6P16wij3lUuxg": "users-pr-inappy",
+    "price_1Mj1kYGlVGuVgOrk7jucaZAa": "users-sentrym",
+    "price_1Mj1mMGlVGuVgOrkC0ORc6iW": "users-sentryy",
+    "price_1OCM0gGlVGuVgOrkWDYEBtSL": "users-teamm",
+    "price_1OCM2cGlVGuVgOrkMWUFjPFz": "users-teamy",
+}
+
 CORS_ALLOW_CREDENTIALS = True
 
 CODECOV_URL = "localhost"

--- a/codecov/settings_prod.py
+++ b/codecov/settings_prod.py
@@ -26,6 +26,17 @@ STRIPE_PLAN_IDS = {
     "users-teamy": "price_1NrlXiGlVGuVgOrkgMTw5yno",
 }
 
+STRIPE_PLAN_VALS = {
+    "price_1Gv2B8GlVGuVgOrkFnLunCgc": "users-pr-inappm",
+    "price_1Gv2COGlVGuVgOrkuOYVLIj7": "users-pr-inappy",
+    "price_1MlY9yGlVGuVgOrkHluurBtJ": "users-sentrym",
+    "price_1MlYAYGlVGuVgOrke9SdbBUn": "users-sentryy",
+    "price_1LmjzwGlVGuVgOrkIwlM46EU": "users-enterprisey",
+    "price_1LmjypGlVGuVgOrkzKtNqhwW": "users-enterprisem",
+    "price_1NqPKdGlVGuVgOrkm9OFvtz8": "users-teamm",
+    "price_1NrlXiGlVGuVgOrkgMTw5yno": "users-teamy",
+}
+
 CORS_ALLOW_HEADERS += ["sentry-trace", "baggage"]
 CORS_ALLOW_CREDENTIALS = True
 CODECOV_URL = get_config("setup", "codecov_url", default="https://codecov.io")

--- a/codecov/settings_staging.py
+++ b/codecov/settings_staging.py
@@ -26,6 +26,14 @@ STRIPE_PLAN_IDS = {
     "users-teamm": "price_1OCM0gGlVGuVgOrkWDYEBtSL",
     "users-teamy": "price_1OCM2cGlVGuVgOrkMWUFjPFz",
 }
+STRIPE_PLAN_VALS = {
+    "plan_H6P3KZXwmAbqPS": "users-pr-inappm",
+    "plan_H6P16wij3lUuxg": "users-pr-inappy",
+    "price_1Mj1kYGlVGuVgOrk7jucaZAa": "users-sentrym",
+    "price_1Mj1mMGlVGuVgOrkC0ORc6iW": "users-sentryy",
+    "price_1OCM0gGlVGuVgOrkWDYEBtSL": "users-teamm",
+    "price_1OCM2cGlVGuVgOrkMWUFjPFz": "users-teamy",
+}
 
 CORS_ALLOW_HEADERS += ["sentry-trace", "baggage"]
 CORS_ALLOWED_ORIGIN_REGEXES = [

--- a/plan/service.py
+++ b/plan/service.py
@@ -44,9 +44,11 @@ class PlanService:
         else:
             self.plan_data = USER_PLAN_REPRESENTATIONS[self.current_org.plan]
 
-    def update_plan(self, name: PlanName, user_count: int) -> None:
+    def update_plan(self, name, user_count: int | None) -> None:
         if name not in USER_PLAN_REPRESENTATIONS:
             raise ValueError("Unsupported plan")
+        if not user_count:
+            raise ValueError("Quantity Needed")
         self.current_org.plan = name
         self.current_org.plan_user_count = user_count
         self.plan_data = USER_PLAN_REPRESENTATIONS[self.current_org.plan]

--- a/requirements.in
+++ b/requirements.in
@@ -48,7 +48,7 @@ sentry-sdk>=1.40.0
 sentry-sdk[celery]
 setproctitle
 simplejson
-stripe
+stripe>=9.6.0
 urllib3>=1.26.17
 vcrpy
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -443,7 +443,7 @@ starlette==0.36.2
     # via ariadne
 statsd==3.3.0
     # via shared
-stripe==8.9.0
+stripe==9.6.0
     # via -r requirements.in
 text-unidecode==1.3
     # via faker

--- a/services/billing.py
+++ b/services/billing.py
@@ -297,7 +297,7 @@ class StripeService(AbstractPaymentService):
         """
         Returns `True` if purchasing more seats.
         """
-        return (
+        return bool(
             owner.plan_user_count and owner.plan_user_count < desired_plan["quantity"]
         )
 
@@ -308,7 +308,7 @@ class StripeService(AbstractPaymentService):
         current_plan_info = USER_PLAN_REPRESENTATIONS.get(owner.plan)
         desired_plan_info = USER_PLAN_REPRESENTATIONS.get(desired_plan["value"])
 
-        return (
+        return bool(
             current_plan_info
             and current_plan_info.billing_rate == PlanBillingRate.MONTHLY.value
             and desired_plan_info
@@ -339,7 +339,7 @@ class StripeService(AbstractPaymentService):
         elif owner.plan in TEAM_PLANS and desired_plan["value"] not in TEAM_PLANS:
             return True
 
-        return is_same_term and is_same_seats
+        return bool(is_same_term and is_same_seats)
 
     def _get_proration_params(self, owner: Owner, desired_plan: dict) -> str:
         if (
@@ -361,7 +361,10 @@ class StripeService(AbstractPaymentService):
     @_log_stripe_error
     def create_checkout_session(self, owner: Owner, desired_plan):
         success_url, cancel_url = self._get_success_and_cancel_url(owner)
-        log.info("Creating Stripe Checkout Session for owner: {owner.ownerid}")
+        log.info(
+            "Creating Stripe Checkout Session for owner",
+            extra=dict(owner_id=owner.ownerid),
+        )
 
         if not owner.stripe_customer_id:
             customer_email = owner.email

--- a/services/billing.py
+++ b/services/billing.py
@@ -374,7 +374,7 @@ class StripeService(AbstractPaymentService):
             billing_address_collection="required",
             payment_method_types=["card"],
             payment_method_collection="if_required",
-            client_reference_id=owner.ownerid,
+            client_reference_id=str(owner.ownerid),
             success_url=success_url,
             cancel_url=cancel_url,
             customer=customer,

--- a/services/billing.py
+++ b/services/billing.py
@@ -157,7 +157,9 @@ class StripeService(AbstractPaymentService):
             stripe.SubscriptionSchedule.release(subscription_schedule_id)
 
         stripe.Subscription.modify(
-            owner.stripe_subscription_id, cancel_at_period_end=True, prorate=False
+            owner.stripe_subscription_id,
+            cancel_at_period_end=True,
+            proration_behavior="none",
         )
 
     @_log_stripe_error

--- a/services/billing.py
+++ b/services/billing.py
@@ -252,7 +252,7 @@ class StripeService(AbstractPaymentService):
             )
 
     def _modify_subscription_schedule(
-        self, owner, subscription, subscription_schedule_id, desired_plan
+        self, owner: Owner, subscription, subscription_schedule_id, desired_plan
     ):
         current_subscription_start_date = subscription["current_period_start"]
         current_subscription_end_date = subscription["current_period_end"]

--- a/services/billing.py
+++ b/services/billing.py
@@ -379,14 +379,14 @@ class StripeService(AbstractPaymentService):
             cancel_url=cancel_url,
             customer=customer,
             customer_email=customer_email,
+            mode="subscription",
+            line_items=[
+                {
+                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
+                    "quantity": desired_plan["quantity"],
+                }
+            ],
             subscription_data={
-                "items": [
-                    {
-                        "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                        "quantity": desired_plan["quantity"],
-                    }
-                ],
-                "payment_behavior": "allow_incomplete",
                 "metadata": self._get_checkout_session_and_subscription_metadata(owner),
             },
         )

--- a/services/billing.py
+++ b/services/billing.py
@@ -22,7 +22,7 @@ SCHEDULE_RELEASE_OFFSET = 10
 
 if settings.STRIPE_API_KEY:
     stripe.api_key = settings.STRIPE_API_KEY
-    stripe.api_version = "2023-10-16"
+    stripe.api_version = "2024-04-10"
 
 
 def _log_stripe_error(method):

--- a/services/billing.py
+++ b/services/billing.py
@@ -29,7 +29,7 @@ def _log_stripe_error(method):
     def catch_and_raise(*args, **kwargs):
         try:
             return method(*args, **kwargs)
-        except stripe.error.StripeError as e:
+        except stripe.StripeError as e:
             log.warning(e.user_message)
             raise
 
@@ -91,7 +91,7 @@ class StripeService(AbstractPaymentService):
 
         self.requesting_user = requesting_user
 
-    def _get_checkout_session_and_subscription_metadata(self, owner):
+    def _get_checkout_session_and_subscription_metadata(self, owner: Owner):
         return {
             "service": owner.service,
             "obo_organization": owner.ownerid,
@@ -108,7 +108,7 @@ class StripeService(AbstractPaymentService):
         )
         try:
             invoice = stripe.Invoice.retrieve(invoice_id)
-        except stripe.error.InvalidRequestError as e:
+        except stripe.InvalidRequestError as e:
             log.info(f"invoice {invoice_id} not found for owner {owner.ownerid}")
             return None
         if invoice["customer"] != owner.stripe_customer_id:
@@ -127,7 +127,7 @@ class StripeService(AbstractPaymentService):
             return invoice
 
     @_log_stripe_error
-    def list_filtered_invoices(self, owner, limit=10):
+    def list_filtered_invoices(self, owner: Owner, limit=10):
         log.info(f"Fetching invoices from Stripe for ownerid {owner.ownerid}")
         if owner.stripe_customer_id is None:
             log.info("stripe_customer_id is None, not fetching invoices")
@@ -142,7 +142,7 @@ class StripeService(AbstractPaymentService):
         return list(invoices_filtered_by_status_and_total)
 
     @_log_stripe_error
-    def delete_subscription(self, owner):
+    def delete_subscription(self, owner: Owner):
         subscription = stripe.Subscription.retrieve(owner.stripe_subscription_id)
         subscription_schedule_id = subscription.schedule
 
@@ -164,7 +164,7 @@ class StripeService(AbstractPaymentService):
         )
 
     @_log_stripe_error
-    def get_subscription(self, owner):
+    def get_subscription(self, owner: Owner):
         if not owner.stripe_subscription_id:
             return None
         return stripe.Subscription.retrieve(
@@ -177,7 +177,7 @@ class StripeService(AbstractPaymentService):
         )
 
     @_log_stripe_error
-    def get_schedule(self, owner):
+    def get_schedule(self, owner: Owner):
         if not owner.stripe_subscription_id:
             return None
 

--- a/services/decorators.py
+++ b/services/decorators.py
@@ -30,7 +30,7 @@ def stripe_safe(method):
     def exec_method(*args, **kwargs):
         try:
             return method(*args, **kwargs)
-        except stripe.error.StripeError as e:
+        except stripe.StripeError as e:
             exception = APIException(detail=e.user_message)
             exception.status_code = e.http_status
             raise exception

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1008,19 +1008,19 @@ class StripeServiceTests(TestCase):
             billing_address_collection="required",
             payment_method_types=["card"],
             payment_method_collection="if_required",
-            client_reference_id=owner.ownerid,
+            client_reference_id=str(owner.ownerid),
             customer_email=owner.email,
             customer=None,
             success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
             cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
+            mode="subscription",
+            line_items=[
+                {
+                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
+                    "quantity": desired_quantity,
+                }
+            ],
             subscription_data={
-                "items": [
-                    {
-                        "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                        "quantity": desired_quantity,
-                    }
-                ],
-                "payment_behavior": "allow_incomplete",
                 "metadata": {
                     "service": owner.service,
                     "obo_organization": owner.ownerid,
@@ -1057,19 +1057,19 @@ class StripeServiceTests(TestCase):
             billing_address_collection="required",
             payment_method_types=["card"],
             payment_method_collection="if_required",
-            client_reference_id=owner.ownerid,
+            client_reference_id=str(owner.ownerid),
             customer_email=owner.email,
             customer=None,
             success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
             cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
+            mode="subscription",
+            line_items=[
+                {
+                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
+                    "quantity": desired_quantity,
+                }
+            ],
             subscription_data={
-                "items": [
-                    {
-                        "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                        "quantity": desired_quantity,
-                    }
-                ],
-                "payment_behavior": "allow_incomplete",
                 "metadata": {
                     "service": owner.service,
                     "obo_organization": owner.ownerid,
@@ -1106,19 +1106,19 @@ class StripeServiceTests(TestCase):
             billing_address_collection="required",
             payment_method_types=["card"],
             payment_method_collection="if_required",
-            client_reference_id=owner.ownerid,
+            client_reference_id=str(owner.ownerid),
             customer=owner.stripe_customer_id,
             customer_email=None,
             success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
             cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
+            mode="subscription",
+            line_items=[
+                {
+                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
+                    "quantity": desired_quantity,
+                }
+            ],
             subscription_data={
-                "items": [
-                    {
-                        "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                        "quantity": desired_quantity,
-                    }
-                ],
-                "payment_behavior": "allow_incomplete",
                 "metadata": {
                     "service": owner.service,
                     "obo_organization": owner.ownerid,
@@ -1155,19 +1155,19 @@ class StripeServiceTests(TestCase):
             billing_address_collection="required",
             payment_method_types=["card"],
             payment_method_collection="if_required",
-            client_reference_id=owner.ownerid,
+            client_reference_id=str(owner.ownerid),
             customer=owner.stripe_customer_id,
             customer_email=None,
             success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
             cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
+            mode="subscription",
+            line_items=[
+                {
+                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
+                    "quantity": desired_quantity,
+                }
+            ],
             subscription_data={
-                "items": [
-                    {
-                        "plan": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                        "quantity": desired_quantity,
-                    }
-                ],
-                "payment_behavior": "allow_incomplete",
                 "metadata": {
                     "service": owner.service,
                     "obo_organization": owner.ownerid,

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.test import TestCase
-from stripe.error import InvalidRequestError
+from stripe import InvalidRequestError
 
 from codecov_auth.models import Service
 from codecov_auth.tests.factories import OwnerFactory

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -284,7 +284,9 @@ class StripeServiceTests(TestCase):
         retrieve_subscription_mock.return_value = MockSubscription(subscription_params)
         self.stripe.delete_subscription(owner)
         modify_mock.assert_called_once_with(
-            stripe_subscription_id, cancel_at_period_end=True, prorate=False
+            stripe_subscription_id,
+            cancel_at_period_end=True,
+            proration_behavior="none",
         )
         owner.refresh_from_db()
         assert owner.stripe_subscription_id == stripe_subscription_id
@@ -320,7 +322,9 @@ class StripeServiceTests(TestCase):
         self.stripe.delete_subscription(owner)
         schedule_release_mock.assert_called_once_with(stripe_schedule_id)
         modify_mock.assert_called_once_with(
-            stripe_subscription_id, cancel_at_period_end=True, prorate=False
+            stripe_subscription_id,
+            cancel_at_period_end=True,
+            proration_behavior="none",
         )
         owner.refresh_from_db()
         assert owner.stripe_subscription_id == stripe_subscription_id


### PR DESCRIPTION
### Purpose/Motivation

This initiative stemmed from upgrading python to version 3.12, where in the process we bumped up our stripe version from 2.55.2 -> 8.9. This represented ~6.5 years of stripe versions and associated model updates in the process. Change log from stripe's website can be found [here](https://docs.stripe.com/upgrades).

After the initial merge of that PR, @adrian-codecov and I noticed that there were some issues coming in from sentry; which we thought to have fixed in https://github.com/codecov/codecov-api/pull/563. However, this didn't quell the issues; and in fact surfaced other issues in sentry where certain webhooks around subscription schedules were no longer being processed. Upon doing some additional investigation in the stripe dashboard, we realized that Stripe itself was using the 2017 version of their API when generating webhooks for us to process. 

This meant then that we now had a mismatch between our local version of stripe; the local implementation of stripe, and the dashboard version of stripe, each returning or expecting slightly different objects between them. This PR then hoped to tackle the differing versions once and for all; putting us on the latest version of stripe for API, with version updates for Gazebo and Worker soon to follow. Because API is where the "meat" of our stripe integration is, we believe that even with this single PR and using stripe's "native" dashboard API version update tool we should be good. But for sanity, we will be merging https://github.com/codecov/gazebo/pull/2884 and https://github.com/codecov/worker/pull/456 as well.

**Things that were broken at some point or another:**

- Creating a customer
- Updating a customer
- Creating a subscription
- Updating a subscription

### Links to relevant tickets

Related ticket for tracking https://github.com/codecov/engineering-team/issues/1754

### What does this PR do?

**Fixes:**
- Checkout Session input params to match latest stripe object
- Subscription schedule object keys to pull off plan name correctly
- Stripe errors are now on the stripe object itself from package

**Updates:**
- Removes unnecessary segment stuff in checkout_session_completed
- Removes interpolated logs in favor of dictionary params
- Adds types for all webhook functions
- Adds a new set of keys in the settings mapping stripe values to plan names (TBD if we should remove the original mapping)
- Uses stripe version 9.6 (latest) from 8.9 -- This will match the dashboard version once we upgrade

### Notes to Reviewer

I have been working heavily with @adrian-codecov to test this locally throughout. We feel confident in this PR having flipped the dashboard version to latest and doing quick tests and then flipping back. We will be monitoring this post merge to confirm successful webhooks in the console before we breathe a final sigh of relief.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
