### PR TITLE
dev: add isort rules for ruff and fix

### DIFF
--- a/api/public/v2/compare/views.py
+++ b/api/public/v2/compare/views.py
@@ -1,6 +1,6 @@
-from distutils.util import strtobool
 from inspect import Parameter
 
+from distutils.util import strtobool
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins

--- a/api/shared/permissions.py
+++ b/api/shared/permissions.py
@@ -1,18 +1,19 @@
 import logging
-
 from typing import Any, Tuple
+
 from asgiref.sync import async_to_sync
 from django.conf import settings
-from django.http import Http404
-from rest_framework.permissions import SAFE_METHODS  # ['GET', 'HEAD', 'OPTIONS']
-from rest_framework.permissions import BasePermission
-from django.http import HttpRequest
+from django.http import Http404, HttpRequest
+from rest_framework.permissions import (
+    SAFE_METHODS,  # ['GET', 'HEAD', 'OPTIONS']
+    BasePermission,
+)
 
-from codecov_auth.models import Owner
-from core.models import Repository
 import services.self_hosted as self_hosted
 from api.shared.mixins import InternalPermissionsMixin, SuperPermissionsMixin
 from api.shared.repo.repository_accessors import RepoAccessors
+from codecov_auth.models import Owner
+from core.models import Repository
 from services.activation import try_auto_activate
 from services.decorators import torngit_safe
 from services.repo_providers import get_generic_adapter_params, get_provider

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -2,10 +2,10 @@ import time
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from pytest import raises
 import stripe
 from django.conf import settings
 from freezegun import freeze_time
+from pytest import raises
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory, APITestCase

--- a/codecov_auth/commands/owner/interactors/tests/test_get_is_current_user_an_admin.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_get_is_current_user_an_admin.py
@@ -1,8 +1,8 @@
-from distutils.util import execute
 from unittest.mock import patch
 
 import pytest
 from asgiref.sync import async_to_sync
+from distutils.util import execute
 from django.test import TransactionTestCase, override_settings
 
 from codecov_auth.tests.factories import GetAdminProviderAdapter, OwnerFactory

--- a/graphql_api/types/config/config.py
+++ b/graphql_api/types/config/config.py
@@ -1,7 +1,7 @@
-from distutils.util import strtobool
 from typing import List
 
 from ariadne import ObjectType
+from distutils.util import strtobool
 from django.conf import settings
 
 import services.self_hosted as self_hosted

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,11 +36,13 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled F541: https://docs.astral.sh/ruff/rules/
-select = ["F541"]
+# Currently only enabled for F541 and I: https://docs.astral.sh/ruff/rules/
+select = ["F541", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
+# The preferred method (for now) w.r.t. fixable rules is to manually update the makefile
+# with --fix and re-run 'make lint'
 fixable = ["ALL"]
 unfixable = []
 

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -37,6 +37,7 @@ from utils import is_uuid
 from utils.config import get_config
 from utils.encryption import encryptor
 from utils.github import get_github_integration_token
+
 from .constants import ci, global_upload_token_providers
 
 is_pull_noted_in_branch = re.compile(r".*(pull|pr)\/(\d+).*")

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -6,8 +6,9 @@ from rest_framework.exceptions import NotAuthenticated
 from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from shared.bundle_analysis.storage import StoragePaths, get_bucket_name
 from sentry_sdk import metrics as sentry_metrics
+from shared.bundle_analysis.storage import StoragePaths, get_bucket_name
+
 from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     OrgLevelTokenAuthentication,

--- a/upload/views/commits.py
+++ b/upload/views/commits.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListCreateAPIView
 from sentry_sdk import metrics as sentry_metrics
+
 from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     GlobalTokenAuthentication,

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -8,8 +8,9 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
-from shared.torngit.exceptions import TorngitClientError, TorngitClientGeneralError
 from sentry_sdk import metrics as sentry_metrics
+from shared.torngit.exceptions import TorngitClientError, TorngitClientGeneralError
+
 from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     GlobalTokenAuthentication,
@@ -21,8 +22,8 @@ from services.repo_providers import RepoProviderService
 from services.task import TaskService
 from services.yaml import final_commit_yaml
 from upload.helpers import (
-    try_to_get_best_possible_bot_token,
     generate_upload_sentry_metrics_tags,
+    try_to_get_best_possible_bot_token,
 )
 from upload.views.base import GetterMixin
 from upload.views.uploads import CanDoCoverageUploadsPermission

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -4,6 +4,7 @@ from django.http import HttpRequest, HttpResponseNotAllowed
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveAPIView
 from sentry_sdk import metrics as sentry_metrics
+
 from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     GlobalTokenAuthentication,

--- a/upload/views/upload_completion.py
+++ b/upload/views/upload_completion.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
 from sentry_sdk import metrics as sentry_metrics
+
 from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     GlobalTokenAuthentication,


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Part of adding more lint rules to API / Shared / Worker -- https://github.com/codecov/engineering-team/issues/1716

This PR simply adds and fixes the "I" rules -- https://docs.astral.sh/ruff/rules/#isort-i

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
