### PR TITLE
add QueryMetricsExtension to graphql view

### DIFF
--- a/graphql_api/tests/mutation/test_cancel_trial.py
+++ b/graphql_api/tests/mutation/test_cancel_trial.py
@@ -3,7 +3,7 @@ from prometheus_client import REGISTRY
 
 from codecov_auth.tests.factories import OwnerFactory
 from graphql_api.tests.helper import GraphQLTestHelper
-from graphql_api.views import GQL_HIT_COUNTER, GQL_ERROR_COUNTER, GQL_REQUEST_LATENCIES
+from graphql_api.views import GQL_ERROR_COUNTER, GQL_HIT_COUNTER, GQL_REQUEST_LATENCIES
 from plan.constants import PlanName, TrialStatus
 
 query = """

--- a/graphql_api/tests/mutation/test_cancel_trial.py
+++ b/graphql_api/tests/mutation/test_cancel_trial.py
@@ -1,7 +1,9 @@
 from django.test import TransactionTestCase
+from prometheus_client import REGISTRY
 
 from codecov_auth.tests.factories import OwnerFactory
 from graphql_api.tests.helper import GraphQLTestHelper
+from graphql_api.views import GQL_HIT_COUNTER, GQL_ERROR_COUNTER, GQL_REQUEST_LATENCIES
 from plan.constants import PlanName, TrialStatus
 
 query = """
@@ -37,6 +39,27 @@ class CancelTrialMutationTest(GraphQLTestHelper, TransactionTestCase):
         }
 
     def test_authenticated(self):
+        GQL_HIT_COUNTER.labels(
+            operation_type="mutation", operation_name="CancelTrialInput"
+        )
+        GQL_ERROR_COUNTER.labels(
+            operation_type="mutation", operation_name="CancelTrialInput"
+        )
+        GQL_REQUEST_LATENCIES.labels(
+            operation_type="mutation", operation_name="CancelTrialInput"
+        )
+        before = REGISTRY.get_sample_value(
+            "api_gql_counts_hits_total",
+            labels={"operation_type": "mutation", "operation_name": "CancelTrialInput"},
+        )
+        errors_before = REGISTRY.get_sample_value(
+            "api_gql_counts_errors_total",
+            labels={"operation_type": "mutation", "operation_name": "CancelTrialInput"},
+        )
+        timer_before = REGISTRY.get_sample_value(
+            "api_gql_timers_full_runtime_seconds_count",
+            labels={"operation_type": "mutation", "operation_name": "CancelTrialInput"},
+        )
         trial_status = TrialStatus.ONGOING.value
         owner = OwnerFactory(
             trial_status=trial_status, plan=PlanName.TRIAL_PLAN_NAME.value
@@ -45,3 +68,18 @@ class CancelTrialMutationTest(GraphQLTestHelper, TransactionTestCase):
         assert self._request(owner=owner, org_username=owner.username) == {
             "cancelTrial": None
         }
+        after = REGISTRY.get_sample_value(
+            "api_gql_counts_hits_total",
+            labels={"operation_type": "mutation", "operation_name": "CancelTrialInput"},
+        )
+        errors_after = REGISTRY.get_sample_value(
+            "api_gql_counts_errors_total",
+            labels={"operation_type": "mutation", "operation_name": "CancelTrialInput"},
+        )
+        timer_after = REGISTRY.get_sample_value(
+            "api_gql_timers_full_runtime_seconds_count",
+            labels={"operation_type": "mutation", "operation_name": "CancelTrialInput"},
+        )
+        assert after - before == 1
+        assert errors_after - errors_before == 0
+        assert timer_after - timer_before == 1

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -14,11 +14,13 @@ from codecov.commands.exceptions import MissingService, UnauthorizedGuestAccess
 from codecov_auth.models import OwnerProfile
 from codecov_auth.tests.factories import (
     GetAdminProviderAdapter,
+    OwnerFactory,
     UserFactory,
 )
 from core.tests.factories import CommitFactory, RepositoryFactory
 from plan.constants import PlanName, TrialStatus
 from reports.tests.factories import CommitReportFactory, UploadFactory
+
 from .helper import GraphQLTestHelper, paginate_connection
 
 query_repositories = """{

--- a/graphql_api/tests/test_user.py
+++ b/graphql_api/tests/test_user.py
@@ -3,11 +3,12 @@ from datetime import timedelta
 from django.test import TransactionTestCase
 from django.utils import timezone
 from freezegun import freeze_time
+from prometheus_client import REGISTRY
 
 from codecov_auth.tests.factories import OwnerFactory
 from graphql_api.types.user.user import resolve_customer_intent
-
 from .helper import GraphQLTestHelper
+from ..views import GQL_HIT_COUNTER, GQL_ERROR_COUNTER, GQL_REQUEST_LATENCIES
 
 
 @freeze_time("2023-06-19")
@@ -25,6 +26,21 @@ class UserTestCase(GraphQLTestHelper, TransactionTestCase):
         )
 
     def test_query_user_resolver(self):
+        GQL_HIT_COUNTER.labels(operation_type="unknown_type", operation_name="me")
+        GQL_ERROR_COUNTER.labels(operation_type="unknown_type", operation_name="me")
+        GQL_REQUEST_LATENCIES.labels(operation_type="unknown_type", operation_name="me")
+        before = REGISTRY.get_sample_value(
+            "api_gql_counts_hits_total",
+            labels={"operation_type": "unknown_type", "operation_name": "me"},
+        )
+        errors_before = REGISTRY.get_sample_value(
+            "api_gql_counts_errors_total",
+            labels={"operation_type": "unknown_type", "operation_name": "me"},
+        )
+        timer_before = REGISTRY.get_sample_value(
+            "api_gql_timers_full_runtime_seconds_count",
+            labels={"operation_type": "unknown_type", "operation_name": "me"},
+        )
         query = """{
             me {
                 user {
@@ -49,6 +65,21 @@ class UserTestCase(GraphQLTestHelper, TransactionTestCase):
             "studentUpdatedAt": "2023-06-20T00:00:00",
             "customerIntent": "Business",
         }
+        after = REGISTRY.get_sample_value(
+            "api_gql_counts_hits_total",
+            labels={"operation_type": "unknown_type", "operation_name": "me"},
+        )
+        errors_after = REGISTRY.get_sample_value(
+            "api_gql_counts_errors_total",
+            labels={"operation_type": "unknown_type", "operation_name": "me"},
+        )
+        timer_after = REGISTRY.get_sample_value(
+            "api_gql_timers_full_runtime_seconds_count",
+            labels={"operation_type": "unknown_type", "operation_name": "me"},
+        )
+        assert after - before == 1
+        assert errors_after - errors_before == 0
+        assert timer_after - timer_before == 1
 
     def test_query_null_user_customer_intent_resolver(self):
         null_user = OwnerFactory(user=None, service_id=4)

--- a/graphql_api/tests/test_user.py
+++ b/graphql_api/tests/test_user.py
@@ -7,8 +7,9 @@ from prometheus_client import REGISTRY
 
 from codecov_auth.tests.factories import OwnerFactory
 from graphql_api.types.user.user import resolve_customer_intent
+
+from ..views import GQL_ERROR_COUNTER, GQL_HIT_COUNTER, GQL_REQUEST_LATENCIES
 from .helper import GraphQLTestHelper
-from ..views import GQL_HIT_COUNTER, GQL_ERROR_COUNTER, GQL_REQUEST_LATENCIES
 
 
 @freeze_time("2023-06-19")

--- a/graphql_api/tests/test_views.py
+++ b/graphql_api/tests/test_views.py
@@ -5,11 +5,11 @@ from ariadne import ObjectType, make_executable_schema
 from ariadne.validation import cost_directive
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import ResolverMatch
+from prometheus_client import REGISTRY
 
 from codecov.commands.exceptions import Unauthorized
-
-from ..views import AsyncGraphqlView
 from .helper import GraphQLTestHelper
+from ..views import AsyncGraphqlView, QueryMetricsExtension
 
 
 def generate_schema_that_raise_with(exception):
@@ -53,12 +53,46 @@ class ArianeViewTestCase(GraphQLTestHelper, TestCase):
         return json.loads(res.content)
 
     @override_settings(DEBUG=True)
-    async def test_when_debug_is_true(self):
+    @patch("logging.Logger.info")
+    async def test_when_debug_is_true(self, patched_log):
+        before = REGISTRY.get_sample_value(
+            "api_gql_counts_hits_total",
+            labels={"operation_type": "unknown_type", "operation_name": "unknown_name"},
+        )
+        errors_before = REGISTRY.get_sample_value(
+            "api_gql_counts_errors_total",
+            labels={"operation_type": "unknown_type", "operation_name": "unknown_name"},
+        )
+        timer_before = REGISTRY.get_sample_value(
+            "api_gql_timers_full_runtime_seconds_count",
+            labels={"operation_type": "unknown_type", "operation_name": "unknown_name"},
+        )
         schema = generate_schema_that_raise_with(Exception("hello"))
         data = await self.do_query(schema)
         assert data["errors"] is not None
         assert data["errors"][0]["message"] == "hello"
         assert data["errors"][0]["extensions"] is not None
+        after = REGISTRY.get_sample_value(
+            "api_gql_counts_hits_total",
+            labels={"operation_type": "unknown_type", "operation_name": "unknown_name"},
+        )
+        errors_after = REGISTRY.get_sample_value(
+            "api_gql_counts_errors_total",
+            labels={"operation_type": "unknown_type", "operation_name": "unknown_name"},
+        )
+        timer_after = REGISTRY.get_sample_value(
+            "api_gql_timers_full_runtime_seconds_count",
+            labels={"operation_type": "unknown_type", "operation_name": "unknown_name"},
+        )
+        assert after - before == 1
+        assert errors_after - errors_before == 1
+        assert timer_after - timer_before == 1
+        patched_log.assert_called_with(
+            "Could not match gql query format for logging",
+            extra=dict(
+                query_slice="{ failing }",
+            ),
+        )
 
     @override_settings(DEBUG=False)
     async def test_when_debug_is_false_and_random_exception(self):
@@ -103,5 +137,38 @@ class ArianeViewTestCase(GraphQLTestHelper, TestCase):
                 requested_cost=2000,
                 maximum_cost=1000,
                 request_body=dict(query="{ stuff }"),
+            ),
+        )
+
+    @patch("logging.Logger.info")
+    async def test_query_metrics_extension_set_type_and_name(self, patched_log):
+        extension = QueryMetricsExtension()
+        sample_named_query = "query MySession { operation body }"
+        sample_named_mutation = "mutation($input: CancelTrialInput!) { operation body }"
+        sample_unnamed_query = "{ owner(username: me) { continued operation body } }"
+        sample_wildcard = "{ failing }"
+
+        assert extension.operation_type is None
+        assert extension.operation_name is None
+
+        extension.set_type_and_name(query=sample_named_query)
+        assert extension.operation_type == "query"
+        assert extension.operation_name == "MySession"
+
+        extension.set_type_and_name(query=sample_named_mutation)
+        assert extension.operation_type == "mutation"
+        assert extension.operation_name == "CancelTrialInput"
+
+        extension.set_type_and_name(query=sample_unnamed_query)
+        assert extension.operation_type == "unknown_type"
+        assert extension.operation_name == "owner"
+
+        extension.set_type_and_name(query=sample_wildcard)
+        assert extension.operation_type == "unknown_type"
+        assert extension.operation_name == "unknown_name"
+        patched_log.assert_called_with(
+            "Could not match gql query format for logging",
+            extra=dict(
+                query_slice="{ failing }",
             ),
         )

--- a/graphql_api/views.py
+++ b/graphql_api/views.py
@@ -1,12 +1,14 @@
 import json
 import logging
 import os
-import shutil
+import re
 import socket
+import time
 from asyncio import iscoroutine
 from typing import Any, Collection, Optional
 
 from ariadne import format_error
+from ariadne.types import Extension
 from ariadne.validation import cost_validator
 from ariadne_django.views import GraphQLAsyncView
 from django.conf import settings
@@ -14,15 +16,108 @@ from django.http import HttpResponseBadRequest, HttpResponseNotAllowed, JsonResp
 from graphql import DocumentNode
 from sentry_sdk import capture_exception
 from sentry_sdk import metrics as sentry_metrics
+from shared.metrics import Counter, Histogram
 
 from codecov.commands.exceptions import BaseException
 from codecov.commands.executor import get_executor_from_request
 from codecov.db import sync_to_async
 from services import ServiceException
-
 from .schema import schema
 
 log = logging.getLogger(__name__)
+
+GQL_HIT_COUNTER = Counter(
+    "api_gql_counts_hits",
+    "Number of times API GQL endpoint request starts",
+    ["operation_type", "operation_name"],
+)
+
+GQL_ERROR_COUNTER = Counter(
+    "api_gql_counts_errors",
+    "Number of times API GQL endpoint failed with an exception",
+    ["operation_type", "operation_name"],
+)
+
+GQL_REQUEST_LATENCIES = Histogram(
+    "api_gql_timers_full_runtime_seconds",
+    "Total runtime in seconds of this query",
+    ["operation_type", "operation_name"],
+    buckets=[0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 5, 10, 30],
+)
+
+
+# covers named and 3 unnamed operations (see graphql_api/types/query/query.py)
+GQL_TYPE_AND_NAME_PATTERN = r"^(query|mutation|subscription)(?:\(\$input:|) (\w+)(?:\(| \(|{| {|!)|^(?:{) (me|owner|config)(?:\(| |{)"
+
+
+class QueryMetricsExtension(Extension):
+    """
+    We have named and unnamed operations, we want to collect metrics on both.
+        named operations have an operation_type and operation_name,
+            ex: "query MySession { operation body }"
+            would be tracked as operation_type = query, operation_name = MySession
+        we have `me`, `owner`, and `config` as unnamed operations,
+            ex: "{ owner(username: "%s") { continued operation body } }"
+            this operation would be tracked as operation_type = unknown_type, operation_name = owner
+
+    """
+
+    def __init__(self):
+        self.start_timestamp = None
+        self.end_timestamp = None
+        self.operation_type = None
+        self.operation_name = None
+
+    def set_type_and_name(self, query):
+        operation_type = "unknown_type"  # default value
+        operation_name = "unknown_name"  # default value
+        match_obj = re.match(GQL_TYPE_AND_NAME_PATTERN, query)
+
+        if match_obj:
+            if match_obj.group(1) is not None:
+                operation_type = match_obj.group(1)
+
+            if match_obj.group(2) is not None:
+                operation_name = match_obj.group(2)
+            elif match_obj.group(3) is not None:
+                operation_name = match_obj.group(3)
+
+        self.operation_type = operation_type
+        self.operation_name = operation_name
+        if operation_type == "unknown_type" and operation_name == "unknown_name":
+            query_slice = query[:30] if len(query) > 30 else query
+            log.info(
+                "Could not match gql query format for logging",
+                extra=dict(query_slice=query_slice),
+            )
+
+    def request_started(self, context):
+        """
+        Extension hook executed at request's start.
+        """
+        self.set_type_and_name(query=context["clean_query"])
+        self.start_timestamp = time.perf_counter_ns()
+        GQL_HIT_COUNTER.labels(
+            operation_type=self.operation_type, operation_name=self.operation_name
+        ).inc()
+
+    def request_finished(self, context):
+        """
+        Extension hook executed at request's end.
+        """
+        self.end_timestamp = time.perf_counter_ns()
+        latency = self.end_timestamp - self.start_timestamp
+        GQL_REQUEST_LATENCIES.labels(
+            operation_type=self.operation_type, operation_name=self.operation_name
+        ).observe(latency)
+
+    def has_errors(self, errors, context):
+        """
+        Extension hook executed when GraphQL encountered errors.
+        """
+        GQL_ERROR_COUNTER.labels(
+            operation_type=self.operation_type, operation_name=self.operation_name
+        ).inc(len(errors))
 
 
 class RequestFinalizer:
@@ -41,7 +136,7 @@ class RequestFinalizer:
 
     def _remove_temp_files(self):
         """
-        Some requests causes temporary files to be created in /tmp (eg BundleAnalysis)
+        Some requests cause temporary files to be created in /tmp (eg BundleAnalysis)
         This cleanup step clears all contents of the /tmp directory after each request
         """
         for key in RequestFinalizer.TO_BE_DELETED_FILES:
@@ -66,7 +161,7 @@ class RequestFinalizer:
 
 class AsyncGraphqlView(GraphQLAsyncView):
     schema = schema
-    extensions = []
+    extensions = [QueryMetricsExtension]
 
     def get_validation_rules(
         self,
@@ -84,6 +179,13 @@ class AsyncGraphqlView(GraphQLAsyncView):
 
     validation_rules = get_validation_rules  # type: ignore
 
+    def get_clean_query(self, request_body):
+        # clean up graphql query to remove new lines and extra spaces
+        if "query" in request_body and isinstance(request_body["query"], str):
+            clean_query = request_body["query"].replace("\n", " ")
+            clean_query = clean_query.replace("  ", "").strip()
+            return clean_query
+
     async def get(self, *args, **kwargs):
         if settings.GRAPHQL_PLAYGROUND:
             return await super().get(*args, **kwargs)
@@ -92,17 +194,16 @@ class AsyncGraphqlView(GraphQLAsyncView):
 
     async def post(self, request, *args, **kwargs):
         await self._get_user(request)
-
-        # get request body information
+        # get request body information for logging
         req_body = json.loads(request.body.decode("utf-8")) if request.body else {}
 
-        # get request path information
+        # get request path information for logging
         req_path = request.get_full_path()
 
-        # clean up graphql query to remove new lines and extra spaces
-        if "query" in req_body and isinstance(req_body["query"], str):
-            req_body["query"] = req_body["query"].replace("\n", " ")
-            req_body["query"] = req_body["query"].replace("  ", "").strip()
+        # clean up graphql query for logging, remove new lines and extra spaces
+        cleaned_query = self.get_clean_query(req_body)
+        if cleaned_query:
+            req_body["query"] = cleaned_query
 
         # put everything together for log
         log_data = {
@@ -115,7 +216,6 @@ class AsyncGraphqlView(GraphQLAsyncView):
         log.info("GraphQL Request", extra=log_data)
         sentry_metrics.incr("graphql.info.request_made", tags={"path": req_path})
 
-        # request.user = await get_user(request) or AnonymousUser()
         with RequestFinalizer(request):
             response = await super().post(request, *args, **kwargs)
 
@@ -146,11 +246,13 @@ class AsyncGraphqlView(GraphQLAsyncView):
                     pass
             return response
 
-    def context_value(self, request):
+    def context_value(self, request, *_):
+        request_body = json.loads(request.body.decode("utf-8")) if request.body else {}
         return {
             "request": request,
             "service": request.resolver_match.kwargs["service"],
             "executor": get_executor_from_request(request),
+            "clean_query": self.get_clean_query(request_body) if request_body else "",
         }
 
     def error_formatter(self, error, debug=False):


### PR DESCRIPTION
### Purpose/Motivation
Gives insight into our GraphQL use

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1238

### What does this PR do?
Adds 2 counters and 1 timer to our GQL endpoint, we should be able to see what queries are being used the most and if any are mad slow

### Notes to Reviewer
The hardest part for me was trying to anticipate all the possible formats for our queries, to be able to parse and log them correctly in `set_type_and_name`. I have them listed in `test_query_metrics_extension_set_type_and_name`. If anyone knows of any other patterns we use, let me know and I'll build them in.
