### PR TITLE
dev: Enable most F rules for Ruff

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -1,6 +1,7 @@
 import os
 from urllib.parse import urlparse
 
+import django_prometheus
 import sentry_sdk
 from corsheaders.defaults import default_headers
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -252,7 +253,7 @@ if TIMESERIES_ENABLED:
         }
 
 # See https://django-postgres-extra.readthedocs.io/en/master/settings.html
-POSTGRES_EXTRA_DB_BACKEND_BASE: "django_prometheus.db.backends.postgresql"
+POSTGRES_EXTRA_DB_BACKEND_BASE: "django_prometheus.db.backends.postgresql"  # type: ignore
 
 # Allows to use the pgpartition command
 PSQLEXTRA_PARTITIONING_MANAGER = (

--- a/core/commands/pull/interactors/tests/test_fetch_pull_requests.py
+++ b/core/commands/pull/interactors/tests/test_fetch_pull_requests.py
@@ -3,7 +3,6 @@ from asgiref.sync import async_to_sync
 from django.contrib.auth.models import AnonymousUser
 from django.test import TransactionTestCase
 
-from api.internal import pull
 from core.models import PullStates
 from core.tests.factories import OwnerFactory, PullFactory, RepositoryFactory
 from reports.tests.factories import UploadFactory

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -16,7 +16,7 @@ from codecov_auth.tests.factories import (
     OwnerFactory,
     UserFactory,
 )
-from core.tests.factories import CommitFactory, OwnerFactory, RepositoryFactory
+from core.tests.factories import CommitFactory, RepositoryFactory
 from plan.constants import PlanName, TrialStatus
 from reports.tests.factories import CommitReportFactory, UploadFactory
 

--- a/graphql_api/tests/test_owner_measurements.py
+++ b/graphql_api/tests/test_owner_measurements.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from django.test import TransactionTestCase, override_settings
-from django.utils import timezone
 
 from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import RepositoryFactory

--- a/graphql_api/tests/test_plan.py
+++ b/graphql_api/tests/test_plan.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from codecov_auth.tests.factories import OwnerFactory
-from core.tests.factories import OwnerFactory
 from plan.constants import PlanName, TrialStatus
 
 from .helper import GraphQLTestHelper

--- a/graphql_api/tests/test_plan_representation.py
+++ b/graphql_api/tests/test_plan_representation.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from codecov_auth.tests.factories import OwnerFactory
-from core.tests.factories import OwnerFactory
 from plan.constants import PlanName, TrialStatus
 
 from .helper import GraphQLTestHelper

--- a/graphql_api/tests/test_repository_measurements.py
+++ b/graphql_api/tests/test_repository_measurements.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from django.test import TransactionTestCase, override_settings
-from django.utils import timezone
 
 from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import RepositoryFactory

--- a/graphql_api/types/__init__.py
+++ b/graphql_api/types/__init__.py
@@ -24,7 +24,7 @@ from .component import component, component_bindable
 from .component_comparison import component_comparison, component_comparison_bindable
 from .config import config, config_bindable
 from .coverage_totals import coverage_totals, coverage_totals_bindable
-from .enums import enum_types, enums
+from .enums import enum_types
 from .file import commit_file, file_bindable
 from .flag import flag, flag_bindable
 from .flag_comparison import flag_comparison, flag_comparison_bindable

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -31,7 +31,7 @@ from graphql_api.types.comparison.comparison import (
     MissingHeadReport,
 )
 from graphql_api.types.enums import OrderingDirection, PathContentDisplayType
-from graphql_api.types.errors import MissingCoverage, MissingHeadReport, UnknownPath
+from graphql_api.types.errors import MissingCoverage, UnknownPath
 from graphql_api.types.errors.errors import UnknownFlags
 from services.bundle_analysis import BundleAnalysisComparison, BundleAnalysisReport
 from services.comparison import Comparison, ComparisonReport

--- a/graphql_api/types/mutation/mutation.py
+++ b/graphql_api/types/mutation/mutation.py
@@ -1,7 +1,5 @@
 from ariadne import MutationType
 
-from graphql_api.types.mutation.start_trial.start_trial import resolve_start_trial
-
 from .activate_measurements import (
     error_activate_measurements,
     resolve_activate_measurements,

--- a/ruff.toml
+++ b/ruff.toml
@@ -37,8 +37,8 @@ target-version = "py312"
 
 [lint]
 # Currently only enabled for F541 and I: https://docs.astral.sh/ruff/rules/
-select = ["F541", "I"]
-ignore = []
+select = ["F", "I"]
+ignore = ["F841", "F401", "F405", "F403"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 # The preferred method (for now) w.r.t. fixable rules is to manually update the makefile

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -4,7 +4,6 @@ from typing import Dict, Optional
 
 from asgiref.sync import async_to_sync
 from shared.yaml import UserYaml, fetch_current_yaml_from_provider_via_reference
-from shared.yaml.user_yaml import UserYaml
 from shared.yaml.validation import validate_yaml
 from yaml import safe_load
 

--- a/timeseries/tests/test_helpers.py
+++ b/timeseries/tests/test_helpers.py
@@ -4,7 +4,6 @@ from unittest.mock import call, patch
 import pytest
 from django.conf import settings
 from django.test import TransactionTestCase
-from django.utils import timezone
 from freezegun import freeze_time
 from freezegun.api import FakeDatetime
 from shared.reports.resources import Report, ReportFile, ReportLine

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -1065,7 +1065,6 @@ class UploadHandlerRouteTest(APITestCase):
             "reportid": "dec1f00b-1883-40d0-afd6-6dcb876510be",
             "redis_key": "upload/b521e55/dec1f00b-1883-40d0-afd6-6dcb876510be/plain",
             "url": None,
-            "branch": None,
             "job": None,
         }
 
@@ -1143,7 +1142,6 @@ class UploadHandlerRouteTest(APITestCase):
             "reportid": "dec1f00b-1883-40d0-afd6-6dcb876510be",
             "redis_key": "upload/b521e55/dec1f00b-1883-40d0-afd6-6dcb876510be/plain",
             "url": None,
-            "branch": None,
             "job": None,
         }
 


### PR DESCRIPTION
### Purpose/Motivation

Part of the Ruff Enhancement epic, this adds all the "F" rules to our lint configuration for API, disabling a few super noisy ones that we can fix in individual PR's later. The benefit of doing it this way is we get ~40 rules "for free" that are on now checking our code :) At the cost of letting 4 of them be excluded til we have more bandwidth.

Rule list: https://docs.astral.sh/ruff/rules/#pyflakes-f
- The F Rules are all the "PyFlakes" rules that Ruff has configured


### Links to relevant tickets

https://github.com/codecov/engineering-team/issues/1716

### What does this PR do?

The rules we've mainly had to fix were around duplicate imports or duplicate keys in dicts. The rest we were already good on. Woohoo!

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
