### PR TITLE
Lower log severity level to remove Sentry noise

### DIFF
--- a/core/commands/commit/interactors/get_file_content.py
+++ b/core/commands/commit/interactors/get_file_content.py
@@ -21,7 +21,7 @@ class GetFileContentInteractor(BaseInteractor):
             return content.get("content").decode("utf-8")
         # TODO raise this to the API so we can handle it.
         except Exception:
-            log.exception(
+            log.info(
                 "GetFileContentInteractor - exception raised",
                 extra=dict(commitid=commit.commitid),
             )


### PR DESCRIPTION
### Purpose/Motivation

fixes: https://github.com/codecov/internal-issues/issues/463

Change the severity level from `log.exception` to `log.info`, showing on exception level doesn't offer much as there's no actionable things for when fetching a non existent path on GH (we always return null when that happens), instead it would only spawn a Sentry error. Downgrading the severity level removes the Sentry noise.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
