### PR TITLE
dev: Enable most "E" rules for Ruff

### DIFF
--- a/codecov_auth/helpers.py
+++ b/codecov_auth/helpers.py
@@ -52,7 +52,7 @@ class History:
         if action_flag is None:
             action_flag = CHANGE
 
-        if type(objects) is not list:
+        if not isinstance(objects, list):
             objects = [objects]
 
         if add_traceback:

--- a/core/commands/commit/interactors/get_file_content.py
+++ b/core/commands/commit/interactors/get_file_content.py
@@ -16,7 +16,7 @@ class GetFileContentInteractor(BaseInteractor):
 
             # When a file received from GH that is larger than 1MB the result will be
             # pre-decoded and of string type; no need to decode again in that case
-            if type(content.get("content")) == str:
+            if isinstance(content.get("content"), str):
                 return content.get("content")
             return content.get("content").decode("utf-8")
         # TODO raise this to the API so we can handle it.

--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -210,7 +210,7 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
         query = query_branches % (self.org.username, self.repo.name)
         data = self.gql_request(query, variables=variables)
         branches = data["owner"]["repository"]["branches"]["edges"]
-        assert type(branches) == list
+        assert isinstance(branches, list)
         assert len(branches) == 3
         assert branches == [
             {"node": {"name": "test2"}},
@@ -239,7 +239,7 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
         query = query_branches % (self.org.username, self.repo.name, "test2")
         data = self.gql_request(query, variables=variables)
         branches = data["owner"]["repository"]["branches"]["edges"]
-        assert type(branches) == list
+        assert isinstance(branches, list)
         assert len(branches) == 1
         assert branches == [
             {"node": {"name": "test2"}},

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -9,11 +9,14 @@ from codecov.db import sync_to_async
 from graphql_api.types.errors import ProviderError, UnknownPath
 from graphql_api.types.errors.errors import UnknownFlags
 from graphql_api.types.segment_comparison.segment_comparison import SegmentComparisons
-from services.comparison import Comparison, MissingComparisonReport, Segment
+from services.comparison import (
+    Comparison,
+    ImpactedFile,
+    MissingComparisonReport,
+)
 from services.profiling import ProfilingSummary
 
 impacted_file_bindable = ObjectType("ImpactedFile")
-from services.comparison import ImpactedFile
 
 
 @impacted_file_bindable.field("fileName")

--- a/graphql_api/views.py
+++ b/graphql_api/views.py
@@ -142,7 +142,7 @@ class AsyncGraphqlView(GraphQLAsyncView):
                         return HttpResponseBadRequest(
                             JsonResponse("Your query is too costly.")
                         )
-                except:
+                except Exception:
                     pass
             return response
 

--- a/graphs/mixins.py
+++ b/graphs/mixins.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 class GraphBadgeAPIMixin(object):
     def get(self, request, *args, **kwargs):
         ext = self.kwargs.get("ext")
-        if not ext in self.extensions:
+        if ext not in self.extensions:
             return Response(
                 {
                     "detail": f"File extension should be one of [ {' || '.join(self.extensions)} ]"

--- a/graphs/views.py
+++ b/graphs/views.py
@@ -54,7 +54,7 @@ class BadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
     def get_object(self, request, *args, **kwargs):
         # Validate coverage precision
         precision = self.request.query_params.get("precision", "0")
-        if not precision in self.precisions:
+        if precision not in self.precisions:
             raise NotFound("Coverage precision should be one of [ 0 || 1 || 2 ]")
 
         coverage, coverage_range = self.get_coverage()

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,9 +36,9 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled for F541 and I: https://docs.astral.sh/ruff/rules/
-select = ["F", "I"]
-ignore = ["F841", "F401", "F405", "F403"]
+# Currently only enabled for F, I, and E rules, with a few exclusions: https://docs.astral.sh/ruff/rules/
+select = ["F", "I", "E"]
+ignore = ["F841", "F401", "F405", "F403", "E501", "E712", "E711"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 # The preferred method (for now) w.r.t. fixable rules is to manually update the makefile

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -226,7 +226,7 @@ class FileComparisonVisitor:
 
         # copied from ReportFile._line, minus dataclass instantiation
         if line:
-            if type(line) is list:
+            if isinstance(line, list):
                 return line
             else:
                 # these are old versions
@@ -675,7 +675,7 @@ class Comparison(object):
                 file_name, self.head_commit.commitid
             )["content"]
             # make sure the file is str utf-8
-            if type(file_content) is not str:
+            if not isinstance(file_content, str):
                 file_content = str(file_content, "utf-8")
             src = file_content.splitlines()
         else:
@@ -1009,7 +1009,7 @@ class ComparisonReport(object):
         try:
             data = archive_service.read_file(self.commit_comparison.report_storage_path)
             return json.loads(data)
-        except:
+        except Exception:
             log.error(
                 "ComparisonReport - couldn't fetch data from storage", exc_info=True
             )

--- a/services/profiling.py
+++ b/services/profiling.py
@@ -53,7 +53,7 @@ class ProfilingSummary:
         try:
             data = archive_service.read_file(profiling_commit.summarized_location)
             return ProfilingSummaryDataAnalyzer(json.loads(data))
-        except:
+        except Exception:
             log.error(
                 "failed to read summarized profiling data from storage", exc_info=True
             )

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -30,7 +30,7 @@ def fetch_commit_yaml(commit: Commit, owner: Owner) -> Optional[Dict]:
         )
         yaml_dict = safe_load(yaml_str)
         return validate_yaml(yaml_dict, show_secrets_for=None)
-    except:
+    except Exception:
         # fetching, parsing, validating the yaml inside the commit can
         # have various exceptions, which we do not care about to get the final
         # yaml used for a commit, as any error here, the codecov.yaml would not

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -72,7 +72,7 @@ class GithubWebhookHandler(APIView):
             "webhook_secret",
             default=b"testixik8qdauiab1yiffydimvi72ekq",
         )
-        if type(key) is str:
+        if isinstance(key, str):
             # If "key" comes from k8s secret, it is of type str, so
             # must convert to bytearray for use with hmac
             key = bytes(key, "utf-8")


### PR DESCRIPTION
### Purpose/Motivation

Part of the Lint Enhancement epic, https://github.com/codecov/engineering-team/issues/1716, this PR aims to add a majority of the E rules to our ruff setup.

The ruff "E" rules are the "error" rules for the pycodestyle package. A majority of the fixes in this PR were for rules E721 and E722, around using type == instead of instanceof() and using bare excepts vs. explicit excepts.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
