### PR TITLE
feat: Allow logout by POST request

### DIFF
--- a/codecov_auth/tests/unit/views/test_logout.py
+++ b/codecov_auth/tests/unit/views/test_logout.py
@@ -11,6 +11,9 @@ class LogoutViewTest(TransactionTestCase):
     def _get(self, url):
         return self.client.get(url, content_type="application/json")
 
+    def _post(self, url):
+        return self.client.post(url, content_type="application/json")
+
     def _is_authenticated(self):
         response = self.client.post(
             "/graphql/gh",
@@ -20,10 +23,28 @@ class LogoutViewTest(TransactionTestCase):
         return response.json()["data"]["me"] is not None
 
     def test_logout_when_unauthenticated(self):
+        res = self._post("/logout")
+        assert res.status_code == 401
+
+    def test_logout_when_authenticated(self):
+        owner = OwnerFactory()
+        self.client = Client()
+        self.client.force_login_owner(owner)
+
+        res = self._post("/graphql/gh/")
+        self.assertEqual(self._is_authenticated(), True)
+
+        res = self._post("/logout")
+        self.assertEqual(res.status_code, 205)
+
+        res = self._get("/graphql/gh/")
+        self.assertEqual(self._is_authenticated(), False)
+
+    def test_get_logout_when_unauthenticated(self):
         res = self._get("/logout/gh")
         assert res.status_code == 302
 
-    def test_logout_when_authenticated(self):
+    def test_get_logout_when_authenticated(self):
         owner = OwnerFactory()
         self.client = Client()
         self.client.force_login_owner(owner)
@@ -38,7 +59,7 @@ class LogoutViewTest(TransactionTestCase):
         res = self._get("/graphql/gh/")
         self.assertEqual(self._is_authenticated(), False)
 
-    def test_logout_when_authenticated_with_redirect(self):
+    def test_get_logout_when_authenticated_with_redirect(self):
         owner = OwnerFactory()
         self.client = Client()
         self.client.force_login_owner(owner)

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -1,12 +1,13 @@
 from django.conf import settings
 from django.contrib.auth import logout
+from django.http import HttpRequest
 from django.shortcuts import HttpResponse, redirect
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 
 @api_view(["GET", "POST"])
-def logout_view(request, **kwargs) -> HttpResponse:
+def logout_view(request: HttpRequest, **kwargs) -> HttpResponse:
     if request.method == "POST":
         response = Response(status=205)
     else:

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -1,12 +1,12 @@
 from django.conf import settings
 from django.contrib.auth import logout
-from django.shortcuts import redirect
+from django.shortcuts import HttpResponse, redirect
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 
 @api_view(["GET", "POST"])
-def logout_view(request, **kwargs):
+def logout_view(request, **kwargs) -> HttpResponse:
     if request.method == "POST":
         response = Response(status=205)
     else:

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -1,11 +1,19 @@
 from django.conf import settings
 from django.contrib.auth import logout
 from django.shortcuts import redirect
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
 
 
+@api_view(['GET', 'POST'])
 def logout_view(request, **kwargs):
-    redirect_url = settings.CODECOV_DASHBOARD_URL
-    response = redirect(redirect_url)
+    if request.method == 'POST':
+        response = Response(status=205)
+    else:
+        # Preserving GET logouts until Gazebo is moved off of it.
+        redirect_url = settings.CODECOV_DASHBOARD_URL
+        response = redirect(redirect_url)
+
     logout(request)
     kwargs_cookie = dict(
         domain=settings.COOKIES_DOMAIN, samesite=settings.COOKIE_SAME_SITE
@@ -16,4 +24,5 @@ def logout_view(request, **kwargs):
     # So we need delete in both samesite Strict / Lax for a little while
     kwargs_cookie = dict(domain=settings.COOKIES_DOMAIN, samesite="Strict")
     response.delete_cookie("staff_user", **kwargs_cookie)
+
     return response

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -8,7 +8,6 @@ from rest_framework.response import Response
 
 @api_view(["GET", "POST"])
 def logout_view(request: HttpRequest, **kwargs: str) -> HttpResponse:
-    print(kwargs)
     if request.method == "POST":
         response = Response(status=205)
     else:

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -7,7 +7,8 @@ from rest_framework.response import Response
 
 
 @api_view(["GET", "POST"])
-def logout_view(request: HttpRequest, **kwargs) -> HttpResponse:
+def logout_view(request: HttpRequest, **kwargs: str) -> HttpResponse:
+    print(kwargs)
     if request.method == "POST":
         response = Response(status=205)
     else:

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 from django.contrib.auth import logout
 from django.shortcuts import redirect
-from rest_framework.response import Response
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 
-@api_view(['GET', 'POST'])
+@api_view(["GET", "POST"])
 def logout_view(request, **kwargs):
-    if request.method == 'POST':
+    if request.method == "POST":
         response = Response(status=205)
     else:
         # Preserving GET logouts until Gazebo is moved off of it.


### PR DESCRIPTION
Allows logout by POST request. Part one of a three-part CSRF vuln fix with our existing GET logout strategy.

Closes https://github.com/codecov/internal-issues/issues/486
