### PR TITLE
Remove repository deprecated resolver 

### DIFF
--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -1334,11 +1334,13 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
         ) {
             owner(username: $name) {
                 repository: repository(name: $repo) {
-                    components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
-                        __typename
-                        ... on ComponentMeasurements {
-                            name
-                            componentId
+                    ... on Repository {
+                        components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
+                            __typename
+                            ... on ComponentMeasurements {
+                                name
+                                componentId
+                            }
                         }
                     }
                 }

--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -777,7 +777,7 @@ query ComponentMeasurements(
     $orderingDirection: OrderingDirection
 ) {
     owner(username: $name) {
-        repository: repositoryDeprecated(name: $repo) {
+        repository: repository(name: $repo) {
             components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
                 __typename
                 ... on ComponentMeasurements {
@@ -1331,7 +1331,7 @@ class TestComponentMeasurements(GraphQLTestHelper, TransactionTestCase):
             $orderingDirection: OrderingDirection
         ) {
             owner(username: $name) {
-                repository: repositoryDeprecated(name: $repo) {
+                repository: repository(name: $repo) {
                     components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
                         __typename
                         ... on ComponentMeasurements {

--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -777,20 +777,22 @@ query ComponentMeasurements(
     $orderingDirection: OrderingDirection
 ) {
     owner(username: $name) {
-        repository: repository(name: $repo) {
-            components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
-                __typename
-                ... on ComponentMeasurements {
-                    name
-                    percentCovered
-                    percentChange
-                    measurements {
-                        avg
-                        min
-                        max
-                        timestamp
+        repository(name: $repo) {
+            ... on Repository {
+                components(filters: $filters, orderingDirection: $orderingDirection, after: $after, before: $before, branch: $branch, interval: $interval) {
+                    __typename
+                    ... on ComponentMeasurements {
+                        name
+                        percentCovered
+                        percentChange
+                        measurements {
+                            avg
+                            min
+                            max
+                            timestamp
+                        }
+                        lastUploaded
                     }
-                    lastUploaded
                 }
             }
         }

--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -13,7 +13,6 @@ type Owner {
     before: String
   ): RepositoryConnection! @cost(complexity: 25, multipliers: ["first", "last"])
   repository(name: String!): RepositoryResult!
-  repositoryDeprecated(name: String!): Repository
   numberOfUploads: Int
   hasPrivateRepos: Boolean
   isAdmin: Boolean

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -129,6 +129,7 @@ async def resolve_repository(owner, info, name):
     info.context["profiling_summary"] = ProfilingSummary(repository)
     return repository
 
+
 @owner_bindable.field("numberOfUploads")
 @require_part_of_org
 async def resolve_number_of_uploads(owner, info, **kwargs):

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -129,22 +129,6 @@ async def resolve_repository(owner, info, name):
     info.context["profiling_summary"] = ProfilingSummary(repository)
     return repository
 
-
-@owner_bindable.field("repositoryDeprecated")
-async def resolve_repository_deprecated(owner, info, name):
-    command = info.context["executor"].get_command("repository")
-    repository: Optional[Repository] = await command.fetch_repository(owner, name)
-
-    if repository is not None:
-        current_owner = info.context["request"].current_owner
-        if repository.private:
-            await sync_to_async(activation.try_auto_activate)(owner, current_owner)
-
-        info.context["profiling_summary"] = ProfilingSummary(repository)
-
-    return repository
-
-
 @owner_bindable.field("numberOfUploads")
 @require_part_of_org
 async def resolve_number_of_uploads(owner, info, **kwargs):


### PR DESCRIPTION
With the completion of https://github.com/codecov/engineering-team/issues/355, we can safely remove the resolver from the API. This PR closes https://github.com/codecov/engineering-team/issues/356.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
