### PR TITLE
chore(ci): bump gha workflows to 1.2.20

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
-          
+
           REPO=${{ github.repository }}
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ permissions:
 jobs:
   lint:
     name: Run Lint
-    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.20
 
   build:
     name: Build API
-    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.20
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -31,14 +31,14 @@ jobs:
   codecovstartup:
     name: Codecov Startup
     needs: build
-    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.20
     secrets: inherit
 
   # ats:
   #   name: ATS
   #   needs: [build]
   #   if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-  #   uses: codecov/gha-workflows/.github/workflows/run-ats.yml@v1.2.19
+  #   uses: codecov/gha-workflows/.github/workflows/run-ats.yml@v1.2.20
   #   secrets: inherit
   #   with:
   #     repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -47,7 +47,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.20
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -55,7 +55,7 @@ jobs:
   build-self-hosted:
     name: Build Self Hosted API
     needs: [build, test]
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.20
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -64,7 +64,7 @@ jobs:
     name: Push Staging Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/staging' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.20
     secrets: inherit
     with:
       environment: staging
@@ -74,7 +74,7 @@ jobs:
     name: Push Production Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.20
     secrets: inherit
     with:
       environment: production
@@ -85,7 +85,7 @@ jobs:
     needs: [build-self-hosted, test]
     secrets: inherit
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.20
     with:
       push_rolling: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   patch-typing-check:
     name: Run Patch Type Check
-    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.20

--- a/.github/workflows/self-hosted-release-pr.yml
+++ b/.github/workflows/self-hosted-release-pr.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   create-release-pr:
     name: Create PR for Release ${{ github.event.inputs.versionName }}
-    uses: codecov/gha-workflows/.github/workflows/create-release-pr.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/create-release-pr.yml@v1.2.20
     secrets: inherit

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -14,7 +14,7 @@ jobs:
   create-release:
     name: Tag Release ${{ github.head_ref }} and Push Docker image to Docker Hub
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/create-release.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/create-release.yml@v1.2.20
     with:
       tag_to_prepend: self-hosted-
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
   push-image:
     needs: [create-release]
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.20
     secrets: inherit
     with:
       push_release: true


### PR DESCRIPTION
### Purpose/Motivation
Bumps the GHA Action workflows to 1.2.20

### Links to relevant tickets
https://github.com/codecov/infrastructure-team/issues/375

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
