### PR TITLE
fix: Remove prefilled email for customer if exists

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -366,12 +366,9 @@ class StripeService(AbstractPaymentService):
             extra=dict(owner_id=owner.ownerid),
         )
 
-        if not owner.stripe_customer_id:
-            customer_email = owner.email
-            customer = None
-        else:
+        customer = None
+        if owner.stripe_customer_id:
             customer = owner.stripe_customer_id
-            customer_email = None
 
         session = stripe.checkout.Session.create(
             billing_address_collection="required",
@@ -381,7 +378,6 @@ class StripeService(AbstractPaymentService):
             success_url=success_url,
             cancel_url=cancel_url,
             customer=customer,
-            customer_email=customer_email,
             mode="subscription",
             line_items=[
                 {

--- a/services/billing.py
+++ b/services/billing.py
@@ -366,10 +366,6 @@ class StripeService(AbstractPaymentService):
             extra=dict(owner_id=owner.ownerid),
         )
 
-        customer = None
-        if owner.stripe_customer_id:
-            customer = owner.stripe_customer_id
-
         session = stripe.checkout.Session.create(
             billing_address_collection="required",
             payment_method_types=["card"],
@@ -377,7 +373,7 @@ class StripeService(AbstractPaymentService):
             client_reference_id=str(owner.ownerid),
             success_url=success_url,
             cancel_url=cancel_url,
-            customer=customer,
+            customer=owner.stripe_customer_id,
             mode="subscription",
             line_items=[
                 {

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -984,14 +984,12 @@ class StripeServiceTests(TestCase):
         assert self.stripe._get_proration_params(owner, desired_plan) == "none"
 
     @patch("services.billing.stripe.checkout.Session.create")
-    def test_create_checkout_session_with_email_and_no_stripe_customer_id(
+    def test_create_checkout_session_with_no_stripe_customer_id(
         self, create_checkout_session_mock
     ):
-        email = "test-email@gmail.com"
         stripe_customer_id = None
         owner = OwnerFactory(
             service=Service.GITHUB.value,
-            email=email,
             stripe_customer_id=stripe_customer_id,
         )
         expected_id = "fkkgosd"
@@ -1009,7 +1007,6 @@ class StripeServiceTests(TestCase):
             payment_method_types=["card"],
             payment_method_collection="if_required",
             client_reference_id=str(owner.ownerid),
-            customer_email=owner.email,
             customer=None,
             success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
             cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
@@ -1033,63 +1030,12 @@ class StripeServiceTests(TestCase):
         )
 
     @patch("services.billing.stripe.checkout.Session.create")
-    def test_create_checkout_session_with_no_email_and_no_stripe_customer_id(
+    def test_create_checkout_session_with_stripe_customer_id(
         self, create_checkout_session_mock
     ):
-        email = None
-        stripe_customer_id = None
-        owner = OwnerFactory(
-            service=Service.GITHUB.value,
-            email=email,
-            stripe_customer_id=stripe_customer_id,
-        )
-        expected_id = "fkkgosd"
-        create_checkout_session_mock.return_value = {"id": expected_id}
-        desired_quantity = 25
-        desired_plan = {
-            "value": PlanName.CODECOV_PRO_MONTHLY.value,
-            "quantity": desired_quantity,
-        }
-
-        assert self.stripe.create_checkout_session(owner, desired_plan) == expected_id
-
-        create_checkout_session_mock.assert_called_once_with(
-            billing_address_collection="required",
-            payment_method_types=["card"],
-            payment_method_collection="if_required",
-            client_reference_id=str(owner.ownerid),
-            customer_email=owner.email,
-            customer=None,
-            success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
-            cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
-            mode="subscription",
-            line_items=[
-                {
-                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                    "quantity": desired_quantity,
-                }
-            ],
-            subscription_data={
-                "metadata": {
-                    "service": owner.service,
-                    "obo_organization": owner.ownerid,
-                    "username": owner.username,
-                    "obo_name": self.user.name,
-                    "obo_email": self.user.email,
-                    "obo": self.user.ownerid,
-                },
-            },
-        )
-
-    @patch("services.billing.stripe.checkout.Session.create")
-    def test_create_checkout_session_with_stripe_customer_id_and_no_email(
-        self, create_checkout_session_mock
-    ):
-        email = None
         stripe_customer_id = "test-cusa78723hb4@"
         owner = OwnerFactory(
             service=Service.GITHUB.value,
-            email=email,
             stripe_customer_id=stripe_customer_id,
         )
         expected_id = "fkkgosd"
@@ -1108,56 +1054,6 @@ class StripeServiceTests(TestCase):
             payment_method_collection="if_required",
             client_reference_id=str(owner.ownerid),
             customer=owner.stripe_customer_id,
-            customer_email=None,
-            success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
-            cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
-            mode="subscription",
-            line_items=[
-                {
-                    "price": settings.STRIPE_PLAN_IDS[desired_plan["value"]],
-                    "quantity": desired_quantity,
-                }
-            ],
-            subscription_data={
-                "metadata": {
-                    "service": owner.service,
-                    "obo_organization": owner.ownerid,
-                    "username": owner.username,
-                    "obo_name": self.user.name,
-                    "obo_email": self.user.email,
-                    "obo": self.user.ownerid,
-                },
-            },
-        )
-
-    @patch("services.billing.stripe.checkout.Session.create")
-    def test_create_checkout_session_with_stripe_customer_id_and_email(
-        self, create_checkout_session_mock
-    ):
-        email = "test-email@gmail.com"
-        stripe_customer_id = "test-cusa78723hb4@"
-        owner = OwnerFactory(
-            service=Service.GITHUB.value,
-            email=email,
-            stripe_customer_id=stripe_customer_id,
-        )
-        expected_id = "fkkgosd"
-        create_checkout_session_mock.return_value = {"id": expected_id}
-        desired_quantity = 25
-        desired_plan = {
-            "value": PlanName.CODECOV_PRO_MONTHLY.value,
-            "quantity": desired_quantity,
-        }
-
-        assert self.stripe.create_checkout_session(owner, desired_plan) == expected_id
-
-        create_checkout_session_mock.assert_called_once_with(
-            billing_address_collection="required",
-            payment_method_types=["card"],
-            payment_method_collection="if_required",
-            client_reference_id=str(owner.ownerid),
-            customer=owner.stripe_customer_id,
-            customer_email=None,
             success_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?success",
             cancel_url=f"{settings.CODECOV_DASHBOARD_URL}/plan/gh/{owner.username}?cancel",
             mode="subscription",


### PR DESCRIPTION
### Purpose/Motivation

Customer issue around prefilled email being prefilled but incorrect, stripe docs don't seem to allow changing of prefilled email when creating stripe session so we're looking to remove the prefill altogether.

Related Docs: https://docs.stripe.com/api/checkout/sessions/create

### Links to relevant tickets

N/A

### What does this PR do?

This PR simply removes email from being passed into the stripe checkout session, but still defaulting the customer value if it exists.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
