### PR TITLE
chore: Remove unused Invoice GQL fields

### DIFF
--- a/graphql_api/tests/test_invoice.py
+++ b/graphql_api/tests/test_invoice.py
@@ -29,17 +29,14 @@ class TestInvoiceType(GraphQLTestHelper, TransactionTestCase):
                 invoices {
                     amountDue
                     amountPaid
-                    amountRemaining
                     created
                     currency
                     customerAddress
                     customerEmail
                     customerName
-                    customerShipping
                     dueDate
                     footer
                     id
-                    invoicePdf
                     lineItems {
                         amount
                         currency
@@ -82,17 +79,14 @@ class TestInvoiceType(GraphQLTestHelper, TransactionTestCase):
         assert data["owner"]["invoices"][0] == {
             "amountDue": 999,
             "amountPaid": 999,
-            "amountRemaining": 0,
             "created": 1489789429,
             "currency": "usd",
             "customerAddress": "6639 Boulevard Dr, Westwood FL 34202 USA",
             "customerEmail": "olivia.williams.03@example.com",
             "customerName": "Peer Company",
-            "customerShipping": None,
             "dueDate": None,
             "footer": None,
             "id": "in_19yTU92eZvKYlo2C7uDjvu6v",
-            "invoicePdf": "https://pay.stripe.com/invoice/acct_1032D82eZvKYlo2C/invst_a7KV10HpLw2QxrihgVyuOkOjMZ/pdf",
             "lineItems": [
                 {
                     "description": "(10) users-pr-inappm",

--- a/graphql_api/types/invoice/invoice.graphql
+++ b/graphql_api/types/invoice/invoice.graphql
@@ -1,18 +1,15 @@
 type Invoice {
   amountDue: Float!
   amountPaid: Float!
-  amountRemaining: Float!
   created: Int!
   currency: String!
   customerAddress: String
   customerEmail: String
   customerName: String
-  customerShipping: String
   defaultPaymentMethod: PaymentMethod
   dueDate: Int
   footer: String
   id: String!
-  invoicePdf: String
   lineItems: [LineItem]!
   number: String
   periodEnd: Int!

--- a/graphql_api/types/invoice/invoice.py
+++ b/graphql_api/types/invoice/invoice.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from typing import List, Optional
 
 from ariadne import ObjectType
+from graphql import GraphQLResolveInfo
 from stripe import (
     Invoice,
     InvoiceLineItem,
@@ -13,96 +14,104 @@ invoice_bindable = ObjectType("Invoice")
 
 
 @invoice_bindable.field("id")
-def resolve_invoice_id(invoice: Invoice, info) -> str | None:
+def resolve_invoice_id(invoice: Invoice, info: GraphQLResolveInfo) -> str | None:
     return invoice["id"]
 
 
 @invoice_bindable.field("number")
-def resolve_invoice_number(invoice: Invoice, info) -> str | None:
+def resolve_invoice_number(invoice: Invoice, info: GraphQLResolveInfo) -> str | None:
     return invoice["number"]
 
 
 @invoice_bindable.field("status")
-def resolve_invoice_status(invoice: Invoice, info) -> str | None:
+def resolve_invoice_status(invoice: Invoice, info: GraphQLResolveInfo) -> str | None:
     return invoice["status"]
 
 
 @invoice_bindable.field("created")
-def resolve_invoice_created(invoice: Invoice, info) -> int:
+def resolve_invoice_created(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["created"]
 
 
 @invoice_bindable.field("periodStart")
-def resolve_invoice_period_start(invoice: Invoice, info) -> int:
+def resolve_invoice_period_start(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["period_start"]
 
 
 @invoice_bindable.field("periodEnd")
-def resolve_invoice_period_end(invoice: Invoice, info) -> int:
+def resolve_invoice_period_end(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["period_end"]
 
 
 @invoice_bindable.field("dueDate")
-def resolve_invoice_due_date(invoice: Invoice, info) -> int | None:
+def resolve_invoice_due_date(invoice: Invoice, info: GraphQLResolveInfo) -> int | None:
     return invoice["due_date"]
 
 
 @invoice_bindable.field("customerName")
-def resolve_invoice_customer_name(invoice: Invoice, info) -> str | None:
+def resolve_invoice_customer_name(
+    invoice: Invoice, info: GraphQLResolveInfo
+) -> str | None:
     return invoice["customer_name"]
 
 
-# NOTE: This doesn't currently look to be used in gazebo, maybe can remove?
+# NOTE: Not currently used in Gazebo, keep for address updates
 @invoice_bindable.field("customerAddress")
-def resolve_invoice_customer_address(invoice: Invoice, info) -> str | None:
+def resolve_invoice_customer_address(
+    invoice: Invoice, info: GraphQLResolveInfo
+) -> str | None:
     if invoice["customer_address"]:
         return str(invoice["customer_address"])
     return None
 
 
-# NOTE: This doesn't currently look to be used in gazebo, maybe can remove?
+# NOTE: Not currently used in Gazebo, keep for tax id updates
 @invoice_bindable.field("currency")
-def resolve_invoice_currency(invoice: Invoice, info) -> str:
+def resolve_invoice_currency(invoice: Invoice, info: GraphQLResolveInfo) -> str:
     return invoice["currency"]
 
 
 @invoice_bindable.field("amountPaid")
-def resolve_invoice_amount_paid(invoice: Invoice, info) -> int:
+def resolve_invoice_amount_paid(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["amount_paid"]
 
 
 @invoice_bindable.field("amountDue")
-def resolve_invoice_amount_due(invoice: Invoice, info) -> int:
+def resolve_invoice_amount_due(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["amount_due"]
 
 
 @invoice_bindable.field("total")
-def resolve_invoice_total(invoice: Invoice, info) -> int:
+def resolve_invoice_total(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["total"]
 
 
 @invoice_bindable.field("subtotal")
-def resolve_invoice_subtotal(invoice: Invoice, info) -> int:
+def resolve_invoice_subtotal(invoice: Invoice, info: GraphQLResolveInfo) -> int:
     return invoice["subtotal"]
 
 
 @invoice_bindable.field("lineItems")
-def resolve_invoice_line_items(invoice: Invoice, info) -> ListObject[InvoiceLineItem]:
+def resolve_invoice_line_items(
+    invoice: Invoice, info: GraphQLResolveInfo
+) -> ListObject[InvoiceLineItem]:
     return invoice["lines"]["data"]
 
 
 @invoice_bindable.field("footer")
-def resolve_invoice_footer(invoice: Invoice, info) -> str | None:
+def resolve_invoice_footer(invoice: Invoice, info: GraphQLResolveInfo) -> str | None:
     return invoice["footer"]
 
 
 @invoice_bindable.field("customerEmail")
-def resolve_invoice_customer_email(invoice: Invoice, info) -> str | None:
+def resolve_invoice_customer_email(
+    invoice: Invoice, info: GraphQLResolveInfo
+) -> str | None:
     return invoice["customer_email"]
 
 
 @invoice_bindable.field("defaultPaymentMethod")
 def resolve_invoice_default_payment_method(
-    invoice: Invoice, info
+    invoice: Invoice, info: GraphQLResolveInfo
 ) -> PaymentMethod | None:
     return invoice["default_payment_method"]

--- a/graphql_api/types/invoice/invoice.py
+++ b/graphql_api/types/invoice/invoice.py
@@ -76,26 +76,14 @@ def resolve_invoice_amount_due(invoice: Invoice, info) -> int:
     return invoice["amount_due"]
 
 
-@invoice_bindable.field("amountRemaining")
-def resolve_invoice_amount_remaining(invoice: Invoice, info) -> int:
-    return invoice["amount_remaining"]
-
-
 @invoice_bindable.field("total")
 def resolve_invoice_total(invoice: Invoice, info) -> int:
     return invoice["total"]
 
 
-# NOTE: This doesn't currently look to be used in gazebo, maybe can remove?
 @invoice_bindable.field("subtotal")
 def resolve_invoice_subtotal(invoice: Invoice, info) -> int:
     return invoice["subtotal"]
-
-
-# NOTE: This doesn't currently look to be used in gazebo, maybe can remove?
-@invoice_bindable.field("invoicePdf")
-def resolve_invoice_pdf(invoice: Invoice, info) -> str | None:
-    return invoice["invoice_pdf"]
 
 
 @invoice_bindable.field("lineItems")
@@ -113,15 +101,6 @@ def resolve_invoice_customer_email(invoice: Invoice, info) -> str | None:
     return invoice["customer_email"]
 
 
-# NOTE: This doesn't currently look to be used in gazebo, maybe can remove?
-@invoice_bindable.field("customerShipping")
-def resolve_invoice_customer_shipping(invoice: Invoice, info) -> str | None:
-    if invoice["customer_shipping"]:
-        return str(invoice["customer_shipping"])
-    return None
-
-
-# NOTE: May need to create a separate type for this; FWIW this doesn't currently work on local
 @invoice_bindable.field("defaultPaymentMethod")
 def resolve_invoice_default_payment_method(
     invoice: Invoice, info


### PR DESCRIPTION
### Purpose/Motivation

Removes the unused invoice fields that aren't being referenced anymore in gazebo. Since we're exposing all the fields in GQL now, it is increasingly important to only expose fields that we intend to use.



### Links to relevant tickets

closes https://github.com/codecov/engineering-team/issues/1847

### What does this PR do?

Went through gazebo and confirmed the fields that were being used when pulled off the invoice model. There were 6 unused fields:
- invoicePDF
- currency
- customerAddress
- amountRemaining
- periodStart
- customerShipping

Of these, I removed invoicePDF, amountRemaining and customerShipping. I decided it maybe worthwhile keeping both currency and customerAddress since we have some initiatives coming up that will need those fields shown on the UI

<img width="501" alt="Screenshot 2024-06-03 at 11 49 11 AM" src="https://github.com/codecov/codecov-api/assets/159853603/5c9805b7-2b98-4b65-aed6-dbcb3fdfc648">


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
