### PR TITLE
chore: Remove GET method handler for /logout endpoint

### DIFF
--- a/codecov_auth/tests/unit/views/test_logout.py
+++ b/codecov_auth/tests/unit/views/test_logout.py
@@ -39,37 +39,3 @@ class LogoutViewTest(TransactionTestCase):
 
         res = self._get("/graphql/gh/")
         self.assertEqual(self._is_authenticated(), False)
-
-    def test_get_logout_when_unauthenticated(self):
-        res = self._get("/logout/gh")
-        assert res.status_code == 302
-
-    def test_get_logout_when_authenticated(self):
-        owner = OwnerFactory()
-        self.client = Client()
-        self.client.force_login_owner(owner)
-
-        res = self._get("/graphql/gh/")
-        self.assertEqual(self._is_authenticated(), True)
-
-        res = self._get("/logout/gh")
-        assert res.url == "http://localhost:3000"
-        self.assertEqual(res.status_code, 302)
-
-        res = self._get("/graphql/gh/")
-        self.assertEqual(self._is_authenticated(), False)
-
-    def test_get_logout_when_authenticated_with_redirect(self):
-        owner = OwnerFactory()
-        self.client = Client()
-        self.client.force_login_owner(owner)
-
-        res = self._get("/graphql/gh/")
-        self.assertEqual(self._is_authenticated(), True)
-
-        res = self._get("/logout/gh?to=/test")
-        assert res.url == "http://localhost:3000"
-        self.assertEqual(res.status_code, 302)
-
-        res = self._get("/graphql/gh/")
-        self.assertEqual(self._is_authenticated(), False)

--- a/codecov_auth/views/logout.py
+++ b/codecov_auth/views/logout.py
@@ -1,21 +1,16 @@
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpRequest
-from django.shortcuts import HttpResponse, redirect
+from django.shortcuts import HttpResponse
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 
-@api_view(["GET", "POST"])
+@api_view(["POST"])
 def logout_view(request: HttpRequest, **kwargs: str) -> HttpResponse:
-    if request.method == "POST":
-        response = Response(status=205)
-    else:
-        # Preserving GET logouts until Gazebo is moved off of it.
-        redirect_url = settings.CODECOV_DASHBOARD_URL
-        response = redirect(redirect_url)
-
     logout(request)
+
+    response = Response(status=205)
     kwargs_cookie = dict(
         domain=settings.COOKIES_DOMAIN, samesite=settings.COOKIE_SAME_SITE
     )


### PR DESCRIPTION
Removes the logic to handle GET requests at `/logout`. This is the final part of the transition from GET to POST on the logout endpoint.

Closes https://github.com/codecov/internal-issues/issues/488
Closes https://github.com/codecov/internal-issues/issues/391
