### PR TITLE
feat: Add VAT to checkout session

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -385,6 +385,10 @@ class StripeService(AbstractPaymentService):
             subscription_data={
                 "metadata": self._get_checkout_session_and_subscription_metadata(owner),
             },
+            tax_id_collection={"enabled": True},
+            customer_update={"name": "auto", "address": "auto"}
+            if owner.stripe_customer_id
+            else None,
         )
         log.info(
             f"Stripe Checkout Session created successfully for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1027,6 +1027,8 @@ class StripeServiceTests(TestCase):
                     "obo": self.user.ownerid,
                 },
             },
+            tax_id_collection={"enabled": True},
+            customer_update=None,
         )
 
     @patch("services.billing.stripe.checkout.Session.create")
@@ -1073,6 +1075,8 @@ class StripeServiceTests(TestCase):
                     "obo": self.user.ownerid,
                 },
             },
+            tax_id_collection={"enabled": True},
+            customer_update={"name": "auto", "address": "auto"},
         )
 
     def test_get_subscription_when_no_subscription(self):


### PR DESCRIPTION
### Purpose/Motivation

Adds the VAT information field to the stripe checkout session, this is to allow user's part of businesses to accurately represent their tax information, particularly for users outside of the US.

Related stripe docs: https://docs.stripe.com/tax/checkout/tax-ids

Closes https://github.com/codecov/engineering-team/issues/1868

**NOTE:** This doesn't affect anything outside of the stripe customer object, or anything outside of the stripe session.

### Screenshots


https://github.com/codecov/codecov-api/assets/159853603/084974c9-918f-4831-bb19-84b66df8462b

![Screenshot 2024-06-06 at 5 46 37 PM](https://github.com/codecov/codecov-api/assets/159853603/b056b84c-8799-4748-9204-34ce57e504e7)
![Screenshot 2024-06-06 at 5 47 31 PM](https://github.com/codecov/codecov-api/assets/159853603/4c52c83c-7ade-4870-aee4-5c47b998ee63)


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
