### PR TITLE
fix: Prevent org admins from being activated even without seat

### DIFF
--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -478,9 +478,9 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(query)
         assert data["owner"]["isCurrentUserActivated"] == False
 
-    def test_admin_is_current_user_activated_authorized(self):
+    def test_is_current_user_activated_admin_activated(self):
         owner = OwnerFactory(
-            username="sample-owner-authorized", admins=[self.owner.ownerid]
+            username="sample-owner-authorized", admins=[self.owner.ownerid], plan_activated_users=[self.owner.ownerid]
         )
         self.owner.organizations = [owner.ownerid]
         self.owner.save()
@@ -492,6 +492,21 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         """ % (owner.username)
         data = self.gql_request(query, owner=self.owner)
         assert data["owner"]["isCurrentUserActivated"] == True
+
+    def test_is_current_user_activated_admin_not_activated(self):
+        owner = OwnerFactory(
+            username="sample-owner-authorized", admins=[self.owner.ownerid], plan_activated_users=None
+        )
+        self.owner.organizations = [owner.ownerid]
+        self.owner.save()
+        query = """{
+            owner(username: "%s") {
+                isCurrentUserActivated
+            }
+        }
+        """ % (owner.username)
+        data = self.gql_request(query, owner=self.owner)
+        assert data["owner"]["isCurrentUserActivated"] == False
 
     def test_owner_is_current_user_activated(self):
         query = """{

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -480,7 +480,9 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
 
     def test_is_current_user_activated_admin_activated(self):
         owner = OwnerFactory(
-            username="sample-owner-authorized", admins=[self.owner.ownerid], plan_activated_users=[self.owner.ownerid]
+            username="sample-owner-authorized",
+            admins=[self.owner.ownerid],
+            plan_activated_users=[self.owner.ownerid],
         )
         self.owner.organizations = [owner.ownerid]
         self.owner.save()
@@ -495,7 +497,9 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
 
     def test_is_current_user_activated_admin_not_activated(self):
         owner = OwnerFactory(
-            username="sample-owner-authorized", admins=[self.owner.ownerid], plan_activated_users=None
+            username="sample-owner-authorized",
+            admins=[self.owner.ownerid],
+            plan_activated_users=None,
         )
         self.owner.organizations = [owner.ownerid]
         self.owner.save()

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -217,7 +217,7 @@ def resolve_is_current_user_activated(owner, info):
     if not current_owner:
         return False
 
-    if owner.ownerid == current_owner.ownerid or owner.is_admin(current_owner):
+    if owner.ownerid == current_owner.ownerid:
         return True
     if owner.plan_activated_users is None:
         return False


### PR DESCRIPTION
Updates `isCurrentUserActivated` resolver to no longer count admins as activated when they don't have a seat.

Closes https://github.com/codecov/internal-issues/issues/502

After this change, admins will see the following when trying to access a private repo when not activated:
![Screenshot 2024-06-10 at 09 53 57](https://github.com/codecov/codecov-api/assets/159931558/b7a79653-1fa6-4eb6-9482-69cf2b8ab905)

