### PR TITLE
feat: Add Update Billing Address service function

### DIFF
--- a/api/internal/owner/views.py
+++ b/api/internal/owner/views.py
@@ -106,6 +106,17 @@ class AccountDetailsViewSet(
         billing.update_email_address(owner, new_email)
         return Response(self.get_serializer(owner).data)
 
+    @action(detail=False, methods=["patch"])
+    @stripe_safe
+    def update_billing_address(self, request, *args, **kwargs):
+        billing_address = request.data.get("billing_address")
+        if not billing_address:
+            raise ValidationError(detail="No billing_address sent")
+        owner = self.get_object()
+        billing = BillingService(requesting_user=request.current_owner)
+        billing.update_billing_address(owner, billing_address)
+        return Response(self.get_serializer(owner).data)
+
 
 class UsersOrderingFilter(filters.OrderingFilter):
     def get_valid_fields(self, queryset, view, context=None):

--- a/api/internal/tests/views/cassetes/test_account_viewset/AccountViewSetTests/test_update_billing_address.yaml
+++ b/api/internal/tests/views/cassetes/test_account_viewset/AccountViewSetTests/test_update_billing_address.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Stripe-Version:
+      - '2024-04-10'
+      User-Agent:
+      - Stripe/v1 PythonBindings/9.6.0
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version": "9.6.0", "lang": "python", "publisher": "stripe", "httplib":
+        "requests", "lang_version": "3.12.3", "platform": "Linux-6.6.31-linuxkit-aarch64-with-glibc2.36",
+        "uname": "Linux b0efe3849169 6.6.31-linuxkit #1 SMP Thu May 23 08:36:57 UTC
+        2024 aarch64 "}'
+    method: GET
+    uri: https://api.stripe.com/v1/subscriptions/djfos?expand%5B0%5D=latest_invoice&expand%5B1%5D=customer&expand%5B2%5D=customer.invoice_settings.default_payment_method
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": \"resource_missing\",\n    \"doc_url\":
+        \"https://stripe.com/docs/error-codes/resource-missing\",\n    \"message\":
+        \"No such subscription: 'djfos'\",\n    \"param\": \"id\",\n    \"request_log_url\":
+        \"https://dashboard.stripe.com/test/logs/req_4POjCjRMnbE5Wg?t=1718056644\",\n
+        \   \"type\": \"invalid_request_error\"\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '324'
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fsubscriptions%2F%3Asubscription_exposed_id;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Date:
+      - Mon, 10 Jun 2024 21:57:24 GMT
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=billing-api-srv"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report?s=billing-api-srv"
+      Request-Id:
+      - req_4POjCjRMnbE5Wg
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Stripe-Version:
+      - '2024-04-10'
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -1068,6 +1068,70 @@ class AccountViewSetTests(APITestCase):
             self.current_owner.stripe_customer_id, email=new_email
         )
 
+    def test_update_billing_address_without_body(self):
+        kwargs = {
+            "service": self.current_owner.service,
+            "owner_username": self.current_owner.username,
+        }
+        url = reverse("account_details-update-billing-address", kwargs=kwargs)
+        response = self.client.patch(url, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("services.billing.StripeService.update_billing_address")
+    def test_update_billing_address_handles_stripe_error(self, stripe_mock):
+        code, message = 402, "Oops, nope"
+        self.current_owner.stripe_customer_id = "flsoe"
+        self.current_owner.stripe_subscription_id = "djfos"
+        self.current_owner.save()
+
+        stripe_mock.side_effect = StripeError(message=message, http_status=code)
+
+        billing_address = {
+            "line_1": "45 Fremont St.",
+            "line_2": "",
+            "city": "San Francisco",
+            "state": "CA",
+            "country": "US",
+            "postal_code": "94105",
+        }
+        kwargs = {
+            "service": self.current_owner.service,
+            "owner_username": self.current_owner.username,
+        }
+        data = {"billing_address": billing_address}
+        url = reverse("account_details-update-billing-address", kwargs=kwargs)
+        response = self.client.patch(url, data=data, format="json")
+        assert response.status_code == code
+        assert response.data["detail"] == message
+
+    @patch("services.billing.stripe.Subscription.retrieve")
+    @patch("services.billing.stripe.Customer.modify")
+    def test_update_billing_address(self, modify_customer_mock, retrieve_mock):
+        self.current_owner.stripe_customer_id = "flsoe"
+        self.current_owner.stripe_subscription_id = "djfos"
+        self.current_owner.save()
+
+        billing_address = {
+            "line_1": "45 Fremont St.",
+            "line_2": "",
+            "city": "San Francisco",
+            "state": "CA",
+            "country": "US",
+            "postal_code": "94105",
+        }
+        kwargs = {
+            "service": self.current_owner.service,
+            "owner_username": self.current_owner.username,
+        }
+        data = {"billing_address": billing_address}
+        url = reverse("account_details-update-billing-address", kwargs=kwargs)
+        response = self.client.patch(url, data=data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+        modify_customer_mock.assert_called_once_with(
+            self.current_owner.stripe_customer_id, address=billing_address
+        )
+
     @patch("api.shared.permissions.get_provider")
     def test_update_without_admin_permissions_returns_404(self, get_provider_mock):
         get_provider_mock.return_value = GetAdminProviderAdapter()


### PR DESCRIPTION
### Purpose/Motivation

Part of the Q2 billing epic, particularly around updates for edit billing details, this PR aims to add a new service function around updating a user's billing address.

This function is very similar to the email address function, the main difference being the data payload being pulled from the API request and the payload being passed into the stripe customer modify function.

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/1863

### Notes to Reviewer

For now, this endpoint isn't being used anywhere, but it will be used in the useUpdateBillingAddress gazebo hook added in this PR: https://github.com/codecov/gazebo/pull/2940. That hook is currently hard coded to use sentry's company address.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
