### PR TITLE
gitlab oauth scope setting

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -451,7 +451,7 @@ GITLAB_CLIENT_SECRET = get_config("gitlab", "client_secret")
 GITLAB_REDIRECT_URI = get_config(
     "gitlab", "redirect_uri", default="https://codecov.io/login/gitlab"
 )
-
+GITLAB_SCOPE = get_config("gitlab", "scope", default="api")
 GITLAB_BOT_KEY = get_config("gitlab", "bot", "key")
 GITLAB_TOKENLESS_BOT_KEY = get_config(
     "gitlab", "bots", "tokenless", "key", default=GITLAB_BOT_KEY

--- a/codecov_auth/tests/unit/views/test_gitlab.py
+++ b/codecov_auth/tests/unit/views/test_gitlab.py
@@ -33,7 +33,7 @@ def test_get_gitlab_redirect(client, settings, mock_redis, mocker):
     assert res.status_code == 302
     assert (
         res.url
-        == f"https://gitlab.com/oauth/authorize?response_type=code&client_id=testfiuozujcfo5kxgigugr5x3xxx2ukgyandp16x6w566uits7f32crzl4yvmth&redirect_uri=http%3A%2F%2Flocalhost%2Flogin%2Fgitlab&state={state}"
+        == f"https://gitlab.com/oauth/authorize?response_type=code&client_id=testfiuozujcfo5kxgigugr5x3xxx2ukgyandp16x6w566uits7f32crzl4yvmth&redirect_uri=http%3A%2F%2Flocalhost%2Flogin%2Fgitlab&state={state}&scope=api"
     )
 
 

--- a/codecov_auth/tests/unit/views/test_gitlab_enterprise.py
+++ b/codecov_auth/tests/unit/views/test_gitlab_enterprise.py
@@ -37,7 +37,7 @@ def test_get_gle_redirect(client, settings, mock_redis, mocker):
     assert res.status_code == 302
     assert (
         res.url
-        == f"https://my.gitlabenterprise.com/oauth/authorize?response_type=code&client_id=testfiuozujcfo5kxgigugr5x3xxx2ukgyandp16x6w566uits7f32crzl4yvmth&redirect_uri=http%3A%2F%2Flocalhost%2Flogin%2Fgle&state={state}"
+        == f"https://my.gitlabenterprise.com/oauth/authorize?response_type=code&client_id=testfiuozujcfo5kxgigugr5x3xxx2ukgyandp16x6w566uits7f32crzl4yvmth&redirect_uri=http%3A%2F%2Flocalhost%2Flogin%2Fgle&state={state}&scope=api"
     )
     mock_get_config.assert_called_with("gitlab_enterprise", "url")
 

--- a/codecov_auth/views/gitlab.py
+++ b/codecov_auth/views/gitlab.py
@@ -42,8 +42,8 @@ class GitlabLoginView(LoginMixin, StateMixin, View):
         base_url = urljoin(redirect_info["repo_service"].service_url, "oauth/authorize")
         state = self.generate_state()
 
-        scope = get_config("gitlab_scopes", default="api")
-        log.info(f"Gitlab oauth with scopes: {scope}")
+        scope = " ".join(settings.GITLAB_SCOPES)
+        log.info(f"Gitlab oauth with scope: '{scope}'")
 
         query = dict(
             response_type="code",

--- a/codecov_auth/views/gitlab.py
+++ b/codecov_auth/views/gitlab.py
@@ -42,7 +42,7 @@ class GitlabLoginView(LoginMixin, StateMixin, View):
         base_url = urljoin(redirect_info["repo_service"].service_url, "oauth/authorize")
         state = self.generate_state()
 
-        scope = get_config("gitlab_scopes", "api")
+        scope = get_config("gitlab_scopes", default="api")
         log.info(f"Gitlab oauth with scopes: {scope}")
 
         query = dict(

--- a/codecov_auth/views/gitlab.py
+++ b/codecov_auth/views/gitlab.py
@@ -12,6 +12,7 @@ from shared.torngit import Gitlab
 from shared.torngit.exceptions import TorngitError
 
 from codecov_auth.views.base import LoginMixin, StateMixin
+from utils.config import get_config
 
 log = logging.getLogger(__name__)
 
@@ -40,11 +41,16 @@ class GitlabLoginView(LoginMixin, StateMixin, View):
         redirect_info = self.redirect_info
         base_url = urljoin(redirect_info["repo_service"].service_url, "oauth/authorize")
         state = self.generate_state()
+
+        scope = get_config("gitlab_scopes", "api")
+        log.info(f"Gitlab oauth with scopes: {scope}")
+
         query = dict(
             response_type="code",
             client_id=redirect_info["client_id"],
             redirect_uri=redirect_info["redirect_uri"],
             state=state,
+            scope=scope,
         )
         query_str = urlencode(query)
         return f"{base_url}?{query_str}"

--- a/codecov_auth/views/gitlab.py
+++ b/codecov_auth/views/gitlab.py
@@ -42,7 +42,7 @@ class GitlabLoginView(LoginMixin, StateMixin, View):
         base_url = urljoin(redirect_info["repo_service"].service_url, "oauth/authorize")
         state = self.generate_state()
 
-        scope = " ".join(settings.GITLAB_SCOPES)
+        scope = settings.GITLAB_SCOPE
         log.info(f"Gitlab oauth with scope: '{scope}'")
 
         query = dict(


### PR DESCRIPTION

Test locally with adding `gitlab_scopes` to the  `config/codecov.yml` file in umbrella-hat.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
