### PR TITLE
build(deps): Bump sentry-sdk to 2.13.0

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -395,11 +395,9 @@ if SENTRY_DSN is not None:
         ],
         environment=SENTRY_ENV,
         traces_sample_rate=SENTRY_SAMPLE_RATE,
-        _experiments={
-            "profiles_sample_rate": float(
-                os.environ.get("SERVICES__SENTRY__PROFILE_SAMPLE_RATE", 0.01)
-            ),
-        },
+        profiles_sample_rate=float(
+            os.environ.get("SERVICES__SENTRY__PROFILE_SAMPLE_RATE", 0.01)
+        ),
     )
     if os.getenv("CLUSTER_ENV"):
         sentry_sdk.set_tag("cluster", os.getenv("CLUSTER_ENV"))

--- a/graphql_api/types/query/query.py
+++ b/graphql_api/types/query/query.py
@@ -3,7 +3,7 @@ from typing import Optional
 from ariadne import ObjectType
 from django.conf import settings
 from graphql import GraphQLResolveInfo
-from sentry_sdk import configure_scope
+from sentry_sdk import Scope
 
 from codecov.commands.exceptions import UnauthorizedGuestAccess
 from codecov.db import sync_to_async
@@ -26,9 +26,9 @@ def configure_sentry_scope(query_name: str):
     # we're configuring this here since it's the main entrypoint into GraphQL resolvers
 
     # https://docs.sentry.io/platforms/python/enriching-events/transaction-name/
-    with configure_scope() as scope:
-        if scope.transaction:
-            scope.transaction.name = f"GraphQL [{query_name}]"
+    scope = Scope.get_current_scope()
+    if scope.transaction:
+        scope.transaction.name = f"GraphQL [{query_name}]"
 
 
 @query_bindable.field("me")

--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,7 @@ pytz
 redis
 regex
 requests
-sentry-sdk>=1.40.0
+sentry-sdk>=2.13.0
 sentry-sdk[celery]
 setproctitle
 simplejson

--- a/requirements.txt
+++ b/requirements.txt
@@ -411,7 +411,7 @@ rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
     # via boto3
-sentry-sdk[celery]==1.44.1
+sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -2,7 +2,7 @@ import json
 from logging import Filter
 
 from pythonjsonlogger.jsonlogger import JsonFormatter
-from sentry_sdk import Hub
+from sentry_sdk import get_current_span
 
 
 class BaseLogger(JsonFormatter):
@@ -44,7 +44,7 @@ class CustomDatadogJsonFormatter(BaseLogger):
         else:
             log_record["level"] = record.levelname
 
-        span = Hub.current.scope.span
+        span = get_current_span()
         if span and span.trace_id:
             log_record["sentry_trace_id"] = span.trace_id
 


### PR DESCRIPTION
### Purpose/Motivation

The 2.x line of releases includes new features like support for the queue module.

Also, we've been seeing some disconnected spans in https://github.com/getsentry/sentry-python/issues/3169. Since there's a new major version of the SDK that includes significant changes, we first want to check whether the issue still exists in this new major version.

### Links to relevant tickets

- https://github.com/getsentry/sentry-python/issues/3169

### What does this PR do?

- Bumps `sentry-sdk` to `2.13.0`.
- Migrates `1.x` SDK API to `2.x`. (See also [migration guide](https://docs.sentry.io/platforms/python/migration/1.x-to-2.x).)

### Notes to Reviewer

