### PR TITLE
fix: Update default payment method on subscription for user

### DIFF
--- a/api/internal/tests/views/cassetes/test_account_viewset/AccountViewSetTests/test_update_payment_method.yaml
+++ b/api/internal/tests/views/cassetes/test_account_viewset/AccountViewSetTests/test_update_payment_method.yaml
@@ -1,0 +1,91 @@
+interactions:
+- request:
+    body: default_payment_method=pm_123
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 7c40f9e9-3a01-4109-87bf-3218dfbcf27f
+      Stripe-Version:
+      - '2024-04-10'
+      User-Agent:
+      - Stripe/v1 PythonBindings/9.6.0
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version": "9.6.0", "lang": "python", "publisher": "stripe", "httplib":
+        "requests", "lang_version": "3.12.4", "platform": "Linux-6.6.31-linuxkit-aarch64-with-glibc2.36",
+        "uname": "Linux 2b87f96d1995 6.6.31-linuxkit #1 SMP Thu May 23 08:36:57 UTC
+        2024 aarch64 "}'
+    method: POST
+    uri: https://api.stripe.com/v1/subscriptions/djfos
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": \"resource_missing\",\n    \"doc_url\":
+        \"https://stripe.com/docs/error-codes/resource-missing\",\n    \"message\":
+        \"No such PaymentMethod: 'pm_123'\",\n    \"param\": \"default_payment_method\",\n
+        \   \"request_log_url\": \"https://dashboard.stripe.com/test/logs/req_xT5h1VWY7P75Lu?t=1719007484\",\n
+        \   \"type\": \"invalid_request_error\"\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '346'
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fsubscriptions%2F%3Asubscription_exposed_id;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Date:
+      - Fri, 21 Jun 2024 22:04:44 GMT
+      Idempotency-Key:
+      - 7c40f9e9-3a01-4109-87bf-3218dfbcf27f
+      Original-Request:
+      - req_xT5h1VWY7P75Lu
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=billing-api-srv"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report?s=billing-api-srv"
+      Request-Id:
+      - req_xT5h1VWY7P75Lu
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Stripe-Version:
+      - '2024-04-10'
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -961,8 +961,13 @@ class AccountViewSetTests(APITestCase):
     @patch("services.billing.stripe.Subscription.retrieve")
     @patch("services.billing.stripe.PaymentMethod.attach")
     @patch("services.billing.stripe.Customer.modify")
+    @patch("services.billing.stripe.Subscription.modify")
     def test_update_payment_method(
-        self, modify_customer_mock, attach_payment_mock, retrieve_subscription_mock
+        self,
+        modify_subscription_mock,
+        modify_customer_mock,
+        attach_payment_mock,
+        retrieve_subscription_mock,
     ):
         self.current_owner.stripe_customer_id = "flsoe"
         self.current_owner.stripe_subscription_id = "djfos"
@@ -1006,6 +1011,11 @@ class AccountViewSetTests(APITestCase):
         modify_customer_mock.assert_called_once_with(
             self.current_owner.stripe_customer_id,
             invoice_settings={"default_payment_method": payment_method_id},
+        )
+
+        modify_subscription_mock.assert_called_once_with(
+            self.current_owner.stripe_subscription_id,
+            default_payment_method=payment_method_id,
         )
 
     @patch("services.billing.StripeService.update_payment_method")

--- a/services/billing.py
+++ b/services/billing.py
@@ -397,11 +397,24 @@ class StripeService(AbstractPaymentService):
         return session["id"]
 
     @_log_stripe_error
-    def update_payment_method(self, owner, payment_method):
-        log.info(f"Stripe update payment method for owner {owner.ownerid}")
-        if owner.stripe_subscription_id is None:
-            log.info(
-                f"stripe_subscription_id is None, no updating card for owner {owner.ownerid}"
+    def update_payment_method(self, owner: Owner, payment_method):
+        log.info(
+            "Stripe update payment method for owner",
+            extra=dict(
+                owner_id=owner.ownerid,
+                user_id=self.requesting_user.ownerid,
+                subscription_id=owner.stripe_subscription_id,
+                customer_id=owner.stripe_customer_id,
+            ),
+        )
+        if owner.stripe_subscription_id is None or owner.stripe_customer_id is None:
+            log.warn(
+                "Missing subscription or customer id, returning early",
+                extra=dict(
+                    owner_id=owner.ownerid,
+                    subscription_id=owner.stripe_subscription_id,
+                    customer_id=owner.stripe_customer_id,
+                ),
             )
             return None
         # attach the payment method + set as default on the invoice and subscription
@@ -410,8 +423,17 @@ class StripeService(AbstractPaymentService):
             owner.stripe_customer_id,
             invoice_settings={"default_payment_method": payment_method},
         )
+        stripe.Subscription.modify(
+            owner.stripe_subscription_id, default_payment_method=payment_method
+        )
         log.info(
-            f"Stripe success update payment method for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"
+            "Successfully updated payment method for owner {owner.ownerid} by user #{self.requesting_user.ownerid}",
+            extra=dict(
+                owner_id=owner.ownerid,
+                user_id=self.requesting_user.ownerid,
+                subscription_id=owner.stripe_subscription_id,
+                customer_id=owner.stripe_customer_id,
+            ),
         )
 
     @_log_stripe_error

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1106,7 +1106,10 @@ class StripeServiceTests(TestCase):
 
     @patch("services.billing.stripe.PaymentMethod.attach")
     @patch("services.billing.stripe.Customer.modify")
-    def test_update_payment_method(self, modify_customer_mock, attach_payment_mock):
+    @patch("services.billing.stripe.Subscription.modify")
+    def test_update_payment_method(
+        self, modify_sub_mock, modify_customer_mock, attach_payment_mock
+    ):
         payment_method_id = "pm_1234567"
         subscription_id = "sub_abc"
         customer_id = "cus_abc"
@@ -1119,6 +1122,10 @@ class StripeServiceTests(TestCase):
         )
         modify_customer_mock.assert_called_once_with(
             customer_id, invoice_settings={"default_payment_method": payment_method_id}
+        )
+
+        modify_sub_mock.assert_called_once_with(
+            subscription_id, default_payment_method=payment_method_id
         )
 
     def test_update_email_address_with_invalid_email(self):


### PR DESCRIPTION
### Purpose/Motivation

Stemmed from this sentry feedback that came in: https://sentry.slack.com/archives/C04LZKE8RMJ/p1718994052609629

Long story short, a stripe subscription will use it's default payment method if exists, before using a customer's default payment method. Because we give the default payment method to a subscription at the time of creation, when a user goes to update their default payment method it doesn't update on the subscription, leading to some weird behavior

The fix then is to also update the default payment method on the subscription to the updated payment method, which is also the payment method shown on the portal for the user.

Relevant stripe doc:
https://docs.stripe.com/api/subscriptions/update#update_subscription-default_payment_method
- Calls out when this payment method is used vs. the default on the customer

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/1996

### What does this PR do?

Adds a stripe subscription modify call to the payment method

Also adds a guard where if the customer_id doesn't exist we return early (and changes that log to a warning as well)

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
