### PR TITLE
bundle analysis: update trend measurement compute

### DIFF
--- a/graphql_api/actions/measurements.py
+++ b/graphql_api/actions/measurements.py
@@ -44,7 +44,7 @@ def measurements_by_ids(
     return measurements
 
 
-def measurements_last_uploaded_by_before_date(
+def measurements_last_uploaded_before_start_date(
     repo_id: int,
     measurable_name: str,
     measurable_ids: Iterable[str],

--- a/graphql_api/tests/test_bundle_analysis_measurements.py
+++ b/graphql_api/tests/test_bundle_analysis_measurements.py
@@ -1371,3 +1371,845 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TransactionTestCase):
                 "name": "super",
             },
         }
+
+    @patch("graphql_api.dataloader.bundle_analysis.get_appropriate_storage_service")
+    def test_bundle_report_no_carryovers(self, get_storage_service):
+        storage = MemoryStorageService({})
+        get_storage_service.return_value = storage
+
+        with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
+            storage_path = StoragePaths.bundle_report.path(
+                repo_key=ArchiveService.get_archive_hash(self.repo),
+                report_key=self.head_commit_report.external_id,
+            )
+            storage.write_file(get_bucket_name(), storage_path, f)
+
+        query = """
+            query FetchMeasurements(
+                $org: String!,
+                $repo: String!,
+                $commit: String!
+                $filters: BundleAnalysisMeasurementsSetFilters
+                $orderingDirection: OrderingDirection!
+                $interval: MeasurementInterval!
+                $before: DateTime!
+                $after: DateTime!
+            ) {
+                owner(username: $org) {
+                    repository(name: $repo) {
+                        ... on Repository {
+                            commit(id: $commit) {
+                                bundleAnalysisReport {
+                                    __typename
+                                    ... on BundleAnalysisReport {
+                                        bundle(name: "super") {
+                                            name
+                                            measurements(
+                                                filters: $filters
+                                                orderingDirection: $orderingDirection
+                                                after: $after
+                                                interval: $interval
+                                                before: $before
+                                            ){
+                                                assetType
+                                                name
+                                                size {
+                                                    loadTime {
+                                                        threeG
+                                                        highSpeed
+                                                    }
+                                                    size {
+                                                        gzip
+                                                        uncompress
+                                                    }
+                                                }
+                                                change {
+                                                    loadTime {
+                                                        threeG
+                                                        highSpeed
+                                                    }
+                                                    size {
+                                                        gzip
+                                                        uncompress
+                                                    }
+                                                }
+                                                measurements {
+                                                    avg
+                                                    min
+                                                    max
+                                                    timestamp
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        # Test without using asset type filters
+        variables = {
+            "org": self.org.username,
+            "repo": self.repo.name,
+            "commit": self.commit.commitid,
+            "orderingDirection": "ASC",
+            "interval": "INTERVAL_1_DAY",
+            "after": "2024-06-05",
+            "before": "2024-06-10",
+            "filters": {},
+        }
+        data = self.gql_request(query, variables=variables)
+        commit = data["owner"]["repository"]["commit"]
+
+        assert commit["bundleAnalysisReport"] == {
+            "__typename": "BundleAnalysisReport",
+            "bundle": {
+                "measurements": [
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 2,
+                                "threeG": 106,
+                            },
+                            "size": {
+                                "gzip": 10,
+                                "uncompress": 10000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 4126.0,
+                                "max": 4126.0,
+                                "min": 4126.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 14126.0,
+                                "max": 14126.0,
+                                "min": 14126.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": "asset-*.js",
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 3,
+                                "threeG": 150,
+                            },
+                            "size": {
+                                "gzip": 14,
+                                "uncompress": 14126,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 2,
+                                "threeG": 106,
+                            },
+                            "size": {
+                                "gzip": 10,
+                                "uncompress": 10000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 1421.0,
+                                "max": 1421.0,
+                                "min": 1421.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 11421.0,
+                                "max": 11421.0,
+                                "min": 11421.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": "asset-*.js",
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 3,
+                                "threeG": 121,
+                            },
+                            "size": {
+                                "gzip": 11,
+                                "uncompress": 11421,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "change": None,
+                        "measurements": [],
+                        "name": "asset-*.js",
+                        "size": None,
+                    },
+                    {
+                        "assetType": "FONT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 2,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 240,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 50.0,
+                                "max": 50.0,
+                                "min": 50.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 290.0,
+                                "max": 290.0,
+                                "min": 290.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 3,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 290,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "IMAGE_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 25,
+                            },
+                            "size": {
+                                "gzip": 2,
+                                "uncompress": 2400,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 500.0,
+                                "max": 500.0,
+                                "min": 500.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 2900.0,
+                                "max": 2900.0,
+                                "min": 2900.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 30,
+                            },
+                            "size": {
+                                "gzip": 2,
+                                "uncompress": 2900,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "JAVASCRIPT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 5,
+                                "threeG": 224,
+                            },
+                            "size": {
+                                "gzip": 21,
+                                "uncompress": 21000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 5708.0,
+                                "max": 5708.0,
+                                "min": 5708.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 26708.0,
+                                "max": 26708.0,
+                                "min": 26708.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 7,
+                                "threeG": 284,
+                            },
+                            "size": {
+                                "gzip": 26,
+                                "uncompress": 26708,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "REPORT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 6,
+                                "threeG": 252,
+                            },
+                            "size": {
+                                "gzip": 23,
+                                "uncompress": 23664,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 6263.0,
+                                "max": 6263.0,
+                                "min": 6263.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 29927.0,
+                                "max": 29927.0,
+                                "min": 29927.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 7,
+                                "threeG": 319,
+                            },
+                            "size": {
+                                "gzip": 29,
+                                "uncompress": 29927,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "STYLESHEET_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 0,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 24,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 5.0,
+                                "max": 5.0,
+                                "min": 5.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 29.0,
+                                "max": 29.0,
+                                "min": 29.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 0,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 29,
+                            },
+                        },
+                    },
+                ],
+                "name": "super",
+            },
+        }
+
+        # Test with using asset type filters
+        variables = {
+            "org": self.org.username,
+            "repo": self.repo.name,
+            "commit": self.commit.commitid,
+            "orderingDirection": "ASC",
+            "interval": "INTERVAL_1_DAY",
+            "after": "2024-06-05",
+            "before": "2024-06-10",
+            "filters": {"assetTypes": "JAVASCRIPT_SIZE"},
+        }
+        data = self.gql_request(query, variables=variables)
+        commit = data["owner"]["repository"]["commit"]
+
+        assert commit["bundleAnalysisReport"] == {
+            "__typename": "BundleAnalysisReport",
+            "bundle": {
+                "measurements": [
+                    {
+                        "assetType": "JAVASCRIPT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 5,
+                                "threeG": 224,
+                            },
+                            "size": {
+                                "gzip": 21,
+                                "uncompress": 21000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-05T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 5708.0,
+                                "max": 5708.0,
+                                "min": 5708.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 26708.0,
+                                "max": 26708.0,
+                                "min": 26708.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 7,
+                                "threeG": 284,
+                            },
+                            "size": {
+                                "gzip": 26,
+                                "uncompress": 26708,
+                            },
+                        },
+                    },
+                ],
+                "name": "super",
+            },
+        }
+
+    @patch("graphql_api.dataloader.bundle_analysis.get_appropriate_storage_service")
+    def test_bundle_report_branch(self, get_storage_service):
+        measurements_data = [
+            # 2024-06-10
+            ["bundle_analysis_report_size", "super", "2024-06-10T19:07:23", 123],
+            # 2024-06-06
+            ["bundle_analysis_report_size", "super", "2024-06-06T19:07:23", 456],
+        ]
+
+        for item in measurements_data:
+            MeasurementFactory(
+                name=item[0],
+                owner_id=self.org.pk,
+                repo_id=self.repo.pk,
+                branch="feat",
+                measurable_id=item[1],
+                commit_sha=self.commit.pk,
+                timestamp=item[2],
+                value=item[3],
+            )
+
+        storage = MemoryStorageService({})
+        get_storage_service.return_value = storage
+
+        with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
+            storage_path = StoragePaths.bundle_report.path(
+                repo_key=ArchiveService.get_archive_hash(self.repo),
+                report_key=self.head_commit_report.external_id,
+            )
+            storage.write_file(get_bucket_name(), storage_path, f)
+
+        query = """
+            query FetchMeasurements(
+                $org: String!,
+                $repo: String!,
+                $commit: String!
+                $filters: BundleAnalysisMeasurementsSetFilters
+                $orderingDirection: OrderingDirection!
+                $interval: MeasurementInterval!
+                $before: DateTime!
+                $after: DateTime!
+                $branch: String!
+            ) {
+                owner(username: $org) {
+                    repository(name: $repo) {
+                        ... on Repository {
+                            commit(id: $commit) {
+                                bundleAnalysisReport {
+                                    __typename
+                                    ... on BundleAnalysisReport {
+                                        bundle(name: "super") {
+                                            name
+                                            measurements(
+                                                filters: $filters
+                                                orderingDirection: $orderingDirection
+                                                after: $after
+                                                interval: $interval
+                                                before: $before
+                                                branch: $branch
+                                            ){
+                                                assetType
+                                                name
+                                                size {
+                                                    loadTime {
+                                                        threeG
+                                                        highSpeed
+                                                    }
+                                                    size {
+                                                        gzip
+                                                        uncompress
+                                                    }
+                                                }
+                                                change {
+                                                    loadTime {
+                                                        threeG
+                                                        highSpeed
+                                                    }
+                                                    size {
+                                                        gzip
+                                                        uncompress
+                                                    }
+                                                }
+                                                measurements {
+                                                    avg
+                                                    min
+                                                    max
+                                                    timestamp
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        variables = {
+            "org": self.org.username,
+            "repo": self.repo.name,
+            "commit": self.commit.commitid,
+            "orderingDirection": "ASC",
+            "interval": "INTERVAL_1_DAY",
+            "after": "2024-06-06",
+            "before": "2024-06-10",
+            "branch": "feat",
+            "filters": {},
+        }
+        data = self.gql_request(query, variables=variables)
+        commit = data["owner"]["repository"]["commit"]
+
+        assert commit["bundleAnalysisReport"] == {
+            "__typename": "BundleAnalysisReport",
+            "bundle": {
+                "name": "super",
+                "measurements": [
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "name": "asset-*.js",
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "name": "asset-*.js",
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "name": "asset-*.js",
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                    {
+                        "assetType": "FONT_SIZE",
+                        "name": None,
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                    {
+                        "assetType": "IMAGE_SIZE",
+                        "name": None,
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                    {
+                        "assetType": "JAVASCRIPT_SIZE",
+                        "name": None,
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                    {
+                        "assetType": "REPORT_SIZE",
+                        "name": None,
+                        "size": {
+                            "loadTime": {"threeG": 1, "highSpeed": 0},
+                            "size": {"gzip": 0, "uncompress": 123},
+                        },
+                        "change": {
+                            "loadTime": {"threeG": -3, "highSpeed": 0},
+                            "size": {"gzip": 0, "uncompress": -333},
+                        },
+                        "measurements": [
+                            {
+                                "avg": 456.0,
+                                "min": 456.0,
+                                "max": 456.0,
+                                "timestamp": "2024-06-06T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "min": None,
+                                "max": None,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "min": None,
+                                "max": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "min": None,
+                                "max": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 123.0,
+                                "min": 123.0,
+                                "max": 123.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                    },
+                    {
+                        "assetType": "STYLESHEET_SIZE",
+                        "name": None,
+                        "size": None,
+                        "change": None,
+                        "measurements": [],
+                    },
+                ],
+            },
+        }

--- a/graphql_api/tests/test_bundle_analysis_measurements.py
+++ b/graphql_api/tests/test_bundle_analysis_measurements.py
@@ -840,3 +840,534 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TransactionTestCase):
                 },
             },
         }
+
+    @patch("graphql_api.dataloader.bundle_analysis.get_appropriate_storage_service")
+    def test_bundle_report_measurements_carryovers(self, get_storage_service):
+        storage = MemoryStorageService({})
+        get_storage_service.return_value = storage
+
+        with open("./services/tests/samples/bundle_with_uuid.sqlite", "rb") as f:
+            storage_path = StoragePaths.bundle_report.path(
+                repo_key=ArchiveService.get_archive_hash(self.repo),
+                report_key=self.head_commit_report.external_id,
+            )
+            storage.write_file(get_bucket_name(), storage_path, f)
+
+        query = """
+            query FetchMeasurements(
+                $org: String!,
+                $repo: String!,
+                $commit: String!
+                $filters: BundleAnalysisMeasurementsSetFilters
+                $orderingDirection: OrderingDirection!
+                $interval: MeasurementInterval!
+                $before: DateTime!
+                $after: DateTime!
+            ) {
+                owner(username: $org) {
+                    repository(name: $repo) {
+                        ... on Repository {
+                            commit(id: $commit) {
+                                bundleAnalysisReport {
+                                    __typename
+                                    ... on BundleAnalysisReport {
+                                        bundle(name: "super") {
+                                            name
+                                            measurements(
+                                                filters: $filters
+                                                orderingDirection: $orderingDirection
+                                                after: $after
+                                                interval: $interval
+                                                before: $before
+                                            ){
+                                                assetType
+                                                name
+                                                size {
+                                                    loadTime {
+                                                        threeG
+                                                        highSpeed
+                                                    }
+                                                    size {
+                                                        gzip
+                                                        uncompress
+                                                    }
+                                                }
+                                                change {
+                                                    loadTime {
+                                                        threeG
+                                                        highSpeed
+                                                    }
+                                                    size {
+                                                        gzip
+                                                        uncompress
+                                                    }
+                                                }
+                                                measurements {
+                                                    avg
+                                                    min
+                                                    max
+                                                    timestamp
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        # Test without using asset type filters
+        variables = {
+            "org": self.org.username,
+            "repo": self.repo.name,
+            "commit": self.commit.commitid,
+            "orderingDirection": "ASC",
+            "interval": "INTERVAL_1_DAY",
+            "after": "2024-06-07",
+            "before": "2024-06-10",
+            "filters": {},
+        }
+        data = self.gql_request(query, variables=variables)
+        commit = data["owner"]["repository"]["commit"]
+
+        assert commit["bundleAnalysisReport"] == {
+            "__typename": "BundleAnalysisReport",
+            "bundle": {
+                "measurements": [
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 2,
+                                "threeG": 106,
+                            },
+                            "size": {
+                                "gzip": 10,
+                                "uncompress": 10000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 4126.0,
+                                "max": 4126.0,
+                                "min": 4126.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 14126.0,
+                                "max": 14126.0,
+                                "min": 14126.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": "asset-*.js",
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 3,
+                                "threeG": 150,
+                            },
+                            "size": {
+                                "gzip": 14,
+                                "uncompress": 14126,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 2,
+                                "threeG": 106,
+                            },
+                            "size": {
+                                "gzip": 10,
+                                "uncompress": 10000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 1421.0,
+                                "max": 1421.0,
+                                "min": 1421.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 11421.0,
+                                "max": 11421.0,
+                                "min": 11421.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": "asset-*.js",
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 3,
+                                "threeG": 121,
+                            },
+                            "size": {
+                                "gzip": 11,
+                                "uncompress": 11421,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "ASSET_SIZE",
+                        "change": None,
+                        "measurements": [],
+                        "name": "asset-*.js",
+                        "size": None,
+                    },
+                    {
+                        "assetType": "FONT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 2,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 240,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 50.0,
+                                "max": 50.0,
+                                "min": 50.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 290.0,
+                                "max": 290.0,
+                                "min": 290.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 3,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 290,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "IMAGE_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 25,
+                            },
+                            "size": {
+                                "gzip": 2,
+                                "uncompress": 2400,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 500.0,
+                                "max": 500.0,
+                                "min": 500.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 2900.0,
+                                "max": 2900.0,
+                                "min": 2900.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 30,
+                            },
+                            "size": {
+                                "gzip": 2,
+                                "uncompress": 2900,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "JAVASCRIPT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 5,
+                                "threeG": 224,
+                            },
+                            "size": {
+                                "gzip": 21,
+                                "uncompress": 21000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 5708.0,
+                                "max": 5708.0,
+                                "min": 5708.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 26708.0,
+                                "max": 26708.0,
+                                "min": 26708.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 7,
+                                "threeG": 284,
+                            },
+                            "size": {
+                                "gzip": 26,
+                                "uncompress": 26708,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "REPORT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 6,
+                                "threeG": 252,
+                            },
+                            "size": {
+                                "gzip": 23,
+                                "uncompress": 23664,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 6263.0,
+                                "max": 6263.0,
+                                "min": 6263.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 29927.0,
+                                "max": 29927.0,
+                                "min": 29927.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 7,
+                                "threeG": 319,
+                            },
+                            "size": {
+                                "gzip": 29,
+                                "uncompress": 29927,
+                            },
+                        },
+                    },
+                    {
+                        "assetType": "STYLESHEET_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 0,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 24,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 5.0,
+                                "max": 5.0,
+                                "min": 5.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 29.0,
+                                "max": 29.0,
+                                "min": 29.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 0,
+                                "threeG": 0,
+                            },
+                            "size": {
+                                "gzip": 0,
+                                "uncompress": 29,
+                            },
+                        },
+                    },
+                ],
+                "name": "super",
+            },
+        }
+
+        # Test with using asset type filters
+        variables = {
+            "org": self.org.username,
+            "repo": self.repo.name,
+            "commit": self.commit.commitid,
+            "orderingDirection": "ASC",
+            "interval": "INTERVAL_1_DAY",
+            "after": "2024-06-07",
+            "before": "2024-06-10",
+            "filters": {"assetTypes": "JAVASCRIPT_SIZE"},
+        }
+        data = self.gql_request(query, variables=variables)
+        commit = data["owner"]["repository"]["commit"]
+
+        assert commit["bundleAnalysisReport"] == {
+            "__typename": "BundleAnalysisReport",
+            "bundle": {
+                "measurements": [
+                    {
+                        "assetType": "JAVASCRIPT_SIZE",
+                        "change": {
+                            "loadTime": {
+                                "highSpeed": 5,
+                                "threeG": 224,
+                            },
+                            "size": {
+                                "gzip": 21,
+                                "uncompress": 21000,
+                            },
+                        },
+                        "measurements": [
+                            {
+                                "avg": 5708.0,
+                                "max": 5708.0,
+                                "min": 5708.0,
+                                "timestamp": "2024-06-07T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-08T00:00:00+00:00",
+                            },
+                            {
+                                "avg": None,
+                                "max": None,
+                                "min": None,
+                                "timestamp": "2024-06-09T00:00:00+00:00",
+                            },
+                            {
+                                "avg": 26708.0,
+                                "max": 26708.0,
+                                "min": 26708.0,
+                                "timestamp": "2024-06-10T00:00:00+00:00",
+                            },
+                        ],
+                        "name": None,
+                        "size": {
+                            "loadTime": {
+                                "highSpeed": 7,
+                                "threeG": 284,
+                            },
+                            "size": {
+                                "gzip": 26,
+                                "uncompress": 26708,
+                            },
+                        },
+                    },
+                ],
+                "name": "super",
+            },
+        }

--- a/graphql_api/tests/test_bundle_analysis_measurements.py
+++ b/graphql_api/tests/test_bundle_analysis_measurements.py
@@ -2104,7 +2104,7 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TransactionTestCase):
             "commit": self.commit.commitid,
             "orderingDirection": "ASC",
             "interval": "INTERVAL_1_DAY",
-            "after": "2024-06-06",
+            "after": "2024-06-07",
             "before": "2024-06-10",
             "branch": "feat",
             "filters": {},
@@ -2175,12 +2175,6 @@ class TestBundleAnalysisMeasurements(GraphQLTestHelper, TransactionTestCase):
                                 "avg": 456.0,
                                 "min": 456.0,
                                 "max": 456.0,
-                                "timestamp": "2024-06-06T00:00:00+00:00",
-                            },
-                            {
-                                "avg": None,
-                                "min": None,
-                                "max": None,
                                 "timestamp": "2024-06-07T00:00:00+00:00",
                             },
                             {

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -399,11 +399,7 @@ class BundleAnalysisMeasurementsService(object):
                 # Create a new datapoint in the measurements and prepend it to the existing list
                 # If there isn't any measurements before the start date range, measurements will be untouched
                 if carryover_measurement:
-                    value = (
-                        Decimal(carryover_measurement[0]["value"])
-                        if carryover_measurement
-                        else None
-                    )
+                    value = Decimal(carryover_measurement[0]["value"])
                     carryover = dict(measurements[0])
                     carryover["timestamp_bin"] = self.after
                     carryover["min"] = value

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -21,7 +21,7 @@ from shared.storage import get_appropriate_storage_service
 from core.models import Commit, Repository
 from graphql_api.actions.measurements import (
     measurements_by_ids,
-    measurements_last_uploaded_by_before_date,
+    measurements_last_uploaded_before_start_date,
 )
 from reports.models import CommitReport
 from services.archive import ArchiveService
@@ -385,12 +385,10 @@ class BundleAnalysisMeasurementsService(object):
             branch=self.branch,
         )
 
-        print("what on earth", all_measurements)
-
         # Carry over previous available value for start date if its value is null
         for measurable_id, measurements in all_measurements.items():
             if measurements[0]["timestamp_bin"] > self.after:
-                carryover_measurement = measurements_last_uploaded_by_before_date(
+                carryover_measurement = measurements_last_uploaded_before_start_date(
                     repo_id=self.repository.repoid,
                     measurable_name=measurable_name,
                     measurable_ids=[measurable_id],

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -396,24 +396,22 @@ class BundleAnalysisMeasurementsService(object):
                     branch=self.branch,
                 )
 
-                # There isn't any measurements before the start date range, it will just be null
-                if not carryover_measurement:
-                    continue
-
                 # Create a new datapoint in the measurements and prepend it to the existing list
-                value = (
-                    Decimal(carryover_measurement[0]["value"])
-                    if carryover_measurement
-                    else None
-                )
-                carryover = dict(measurements[0])
-                carryover["timestamp_bin"] = self.after
-                carryover["min"] = value
-                carryover["max"] = value
-                carryover["avg"] = value
-                all_measurements[measurable_id] = [carryover] + all_measurements[
-                    measurable_id
-                ]
+                # If there isn't any measurements before the start date range, measurements will be untouched
+                if carryover_measurement:
+                    value = (
+                        Decimal(carryover_measurement[0]["value"])
+                        if carryover_measurement
+                        else None
+                    )
+                    carryover = dict(measurements[0])
+                    carryover["timestamp_bin"] = self.after
+                    carryover["min"] = value
+                    carryover["max"] = value
+                    carryover["avg"] = value
+                    all_measurements[measurable_id] = [carryover] + all_measurements[
+                        measurable_id
+                    ]
 
         return all_measurements
 


### PR DESCRIPTION
closes: https://github.com/codecov/engineering-team/issues/1976

Make it so that when fetching measurements for trends, if the start date range doesn't have any value, then we look back further until we find the first instance of a measurement point. Then we use that point's value as the value of the start date range. Otherwise it becomes ambiguous if the measurement ID has no measurement at all in history or that the start date has no measurement.

With this if the start date range is still null it means there was never any measurements before the start date. If the start date range is not null there were measurements carried over from the further past.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
