### PR TITLE
fix: Update name in update_billing_address view

### DIFF
--- a/api/internal/owner/views.py
+++ b/api/internal/owner/views.py
@@ -109,6 +109,9 @@ class AccountDetailsViewSet(
     @action(detail=False, methods=["patch"])
     @stripe_safe
     def update_billing_address(self, request, *args, **kwargs):
+        name = request.data.get("name")
+        if not name:
+            raise ValidationError(detail="No name sent")
         billing_address = request.data.get("billing_address")
         if not billing_address:
             raise ValidationError(detail="No billing_address sent")
@@ -124,7 +127,7 @@ class AccountDetailsViewSet(
         }
 
         billing = BillingService(requesting_user=request.current_owner)
-        billing.update_billing_address(owner, billing_address=formatted_address)
+        billing.update_billing_address(owner, name, billing_address=formatted_address)
         return Response(self.get_serializer(owner).data)
 
 

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -1097,6 +1097,34 @@ class AccountViewSetTests(APITestCase):
         response = self.client.patch(url, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_update_billing_address_without_name(self):
+        kwargs = {
+            "service": self.current_owner.service,
+            "owner_username": self.current_owner.username,
+        }
+        billing_address = {
+            "line_1": "45 Fremont St.",
+            "line_2": "",
+            "city": "San Francisco",
+            "state": "CA",
+            "country": "US",
+            "postal_code": "94105",
+        }
+        data = {"billing_address": billing_address}
+        url = reverse("account_details-update-billing-address", kwargs=kwargs)
+        response = self.client.patch(url, data=data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_billing_address_without_address(self):
+        kwargs = {
+            "service": self.current_owner.service,
+            "owner_username": self.current_owner.username,
+        }
+        data = {"name": "John Doe"}
+        url = reverse("account_details-update-billing-address", kwargs=kwargs)
+        response = self.client.patch(url, data=data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     @patch("services.billing.StripeService.update_billing_address")
     def test_update_billing_address_handles_stripe_error(self, stripe_mock):
         code, message = 402, "Oops, nope"

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -1118,7 +1118,7 @@ class AccountViewSetTests(APITestCase):
             "service": self.current_owner.service,
             "owner_username": self.current_owner.username,
         }
-        data = {"billing_address": billing_address}
+        data = {"name": "John Doe", "billing_address": billing_address}
         url = reverse("account_details-update-billing-address", kwargs=kwargs)
         response = self.client.patch(url, data=data, format="json")
         assert response.status_code == code
@@ -1184,7 +1184,7 @@ class AccountViewSetTests(APITestCase):
             "service": self.current_owner.service,
             "owner_username": self.current_owner.username,
         }
-        data = {"billing_address": billing_address}
+        data = {"name": "John Doe", "billing_address": billing_address}
         url = reverse("account_details-update-billing-address", kwargs=kwargs)
         response = self.client.patch(url, data=data, format="json")
         assert response.status_code == status.HTTP_200_OK

--- a/services/billing.py
+++ b/services/billing.py
@@ -70,6 +70,10 @@ class AbstractPaymentService(ABC):
         pass
 
     @abstractmethod
+    def update_billing_address(self, owner, name, billing_address):
+        pass
+
+    @abstractmethod
     def get_schedule(self, owner):
         pass
 
@@ -453,7 +457,7 @@ class StripeService(AbstractPaymentService):
         )
 
     @_log_stripe_error
-    def update_billing_address(self, owner: Owner, billing_address):
+    def update_billing_address(self, owner: Owner, name, billing_address):
         log.info(f"Stripe update billing address for owner {owner.ownerid}")
         if owner.stripe_customer_id is None:
             log.info(
@@ -467,7 +471,8 @@ class StripeService(AbstractPaymentService):
             ).invoice_settings.default_payment_method
 
             stripe.PaymentMethod.modify(
-                default_payment_method, billing_details={"address": billing_address}
+                default_payment_method,
+                billing_details={"name": name, "address": billing_address},
             )
 
             stripe.Customer.modify(owner.stripe_customer_id, address=billing_address)
@@ -548,7 +553,7 @@ class EnterprisePaymentService(AbstractPaymentService):
     def update_email_address(self, owner, email_address):
         pass
 
-    def update_billing_address(self, owner, billing_address):
+    def update_billing_address(self, owner, name, billing_address):
         pass
 
     def get_schedule(self, owner):
@@ -627,13 +632,13 @@ class BillingService:
         """
         return self.payment_service.update_email_address(owner, email_address)
 
-    def update_billing_address(self, owner: Owner, billing_address):
+    def update_billing_address(self, owner: Owner, name: str, billing_address):
         """
         Takes an owner and a billing address. Try to update the owner's billing address
         to the address passed in. Address should be validated via stripe component prior
         to hitting this service method. Return None if invalid.
         """
-        return self.payment_service.update_billing_address(owner, billing_address)
+        return self.payment_service.update_billing_address(owner, name, billing_address)
 
     def apply_cancellation_discount(self, owner: Owner):
         return self.payment_service.apply_cancellation_discount(owner)

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1150,7 +1150,7 @@ class StripeServiceTests(TestCase):
     @patch("logging.Logger.error")
     def test_update_billing_address_with_invalid_address(self, log_error_mock):
         owner = OwnerFactory(stripe_customer_id="123", stripe_subscription_id="123")
-        assert self.stripe.update_billing_address(owner, "gabagool") is None
+        assert self.stripe.update_billing_address(owner, "John Doe", "gabagool") is None
         log_error_mock.assert_called_with(
             "Unable to update billing address for customer",
             extra={
@@ -1164,6 +1164,7 @@ class StripeServiceTests(TestCase):
         assert (
             self.stripe.update_billing_address(
                 owner,
+                name="John Doe",
                 billing_address={
                     "line1": "45 Fremont St.",
                     "line2": "",
@@ -1197,6 +1198,7 @@ class StripeServiceTests(TestCase):
         }
         self.stripe.update_billing_address(
             owner,
+            name="John Doe",
             billing_address=billing_address,
         )
 
@@ -1339,6 +1341,9 @@ class MockPaymentService(AbstractPaymentService):
         pass
 
     def update_email_address(self, owner, email_address):
+        pass
+
+    def update_billing_address(self, owner, name, billing_address):
         pass
 
     def get_schedule(self, owner):


### PR DESCRIPTION
Fixes [bug](https://github.com/codecov/engineering-team/issues/2013) where updating name in UI doesn't work by modifying the update_billing_address view to accept a name parameter. Corresponding change in Gazebo to be merged first. Arguably this could be done better, but we're just trying to fix the bug right now. Will bring up with Ajay when he's back.

Tested on staging with the Gazebo change, all is working as expected!
