### PR TITLE
[Vuln] Bump urllib3 to >= 1.26.19

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -49,7 +49,7 @@ sentry-sdk[celery]
 setproctitle
 simplejson
 stripe>=9.6.0
-urllib3>=1.26.17
+urllib3>=1.26.19,<2.0.0
 vcrpy
 whitenoise
 django-autocomplete-light

--- a/requirements.in
+++ b/requirements.in
@@ -49,7 +49,7 @@ sentry-sdk[celery]
 setproctitle
 simplejson
 stripe>=9.6.0
-urllib3>=1.26.19,<2.0.0
+urllib3>=1.26.19
 vcrpy
 whitenoise
 django-autocomplete-light

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,6 +174,7 @@ freezegun==1.1.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
+    #   google-api-core
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-storage
@@ -400,7 +401,9 @@ requests==2.32.3
     #   shared
     #   stripe
 rfc3986[idna2008]==1.4.0
-    # via httpx
+    # via
+    #   httpx
+    #   rfc3986
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -465,7 +468,7 @@ tzdata==2024.1
     # via celery
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
Patch urllib3 

This closes https://github.com/codecov/internal-issues/issues/550
<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
