### PR TITLE
feat: trigger PR sync

### DIFF
--- a/core/commands/pull/interactors/fetch_pull_request.py
+++ b/core/commands/pull/interactors/fetch_pull_request.py
@@ -1,9 +1,24 @@
+from datetime import UTC, datetime, timedelta
+
+from shared.django_apps.core.models import Pull
+
 from codecov.commands.base import BaseInteractor
 from codecov.db import sync_to_async
-from core.models import Pull
+from services.task.task import TaskService
 
 
 class FetchPullRequestInteractor(BaseInteractor):
+    def _should_sync_pull(self, pull: Pull | None) -> bool:
+        return (
+            pull is not None
+            and pull.state == "open"
+            and (datetime.now(tz=None) - pull.updatestamp) > timedelta(hours=1)
+        )
+
     @sync_to_async
     def execute(self, repository, id):
-        return repository.pull_requests.filter(pullid=id).first()
+        pull = repository.pull_requests.filter(pullid=id).first()
+        if self._should_sync_pull(pull):
+            TaskService().pulls_sync(repository.repoid, id)
+
+        return pull

--- a/core/commands/pull/interactors/tests/test_fetch_pull_request.py
+++ b/core/commands/pull/interactors/tests/test_fetch_pull_request.py
@@ -1,7 +1,12 @@
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import patch
+
 import pytest
 from asgiref.sync import async_to_sync
 from django.contrib.auth.models import AnonymousUser
 from django.test import TransactionTestCase
+from freezegun import freeze_time
 
 from api.internal import pull
 from core.tests.factories import OwnerFactory, PullFactory, RepositoryFactory
@@ -28,3 +33,33 @@ class FetchPullRequestInteractorTest(TransactionTestCase):
     async def test_fetch_pull_request(self):
         pr = await self.execute(None, self.repo, self.pr.pullid)
         assert pr == self.pr
+
+
+# Not part of the class because TransactionTestCase cannot be parametrized
+@freeze_time("2024-07-01 12:00:00")
+@pytest.mark.parametrize(
+    "pr_state, updatestamp, expected",
+    [
+        pytest.param(
+            "open", "2024-07-01 11:50:00", False, id="pr_open_recently_updated"
+        ),
+        pytest.param("merged", "2024-07-01 01:00:00", False, id="pr_merged"),
+        pytest.param(
+            "closed", "2024-07-01 11:50:00", False, id="pr_closed_recently_updated"
+        ),
+        pytest.param(
+            "open", "2024-07-01 01:00:00", True, id="pr_open_not_recently_updated"
+        ),
+    ],
+)
+def test_fetch_pull_should_sync(pr_state, updatestamp, expected, db):
+    repo = RepositoryFactory(private=False)
+    pr = PullFactory(repository_id=repo.repoid, state=pr_state)
+    repo.save()
+    pr.save()  # This will change the updatestamp, so we need to set it again
+    pr.updatestamp = datetime.fromisoformat(updatestamp).replace(tzinfo=None)
+    should_sync = FetchPullRequestInteractor(
+        repo.author, repo.service
+    )._should_sync_pull(pr)
+    assert pr.updatestamp == datetime.fromisoformat(updatestamp).replace(tzinfo=None)
+    assert should_sync == expected


### PR DESCRIPTION
It's possible with a combination of not having webhooks and temporary errors when
fetching info from the git provider that a PR will be left forever open.

One solution is to make the PR view trigger a sync_pull task in the background.
Notice that for the person that is actually viewing the PR it will probably be out of date,
but if they refresh the page it will eventually be updated.

closes: https://github.com/codecov/internal-issues/issues/513
