### PR TITLE
fix: Prevent infinite loop in update_payment_method logic

### DIFF
--- a/billing/views.py
+++ b/billing/views.py
@@ -228,10 +228,12 @@ class StripeWebhookHandler(APIView):
         # with it
         default_payment_method = subscription.default_payment_method
         if default_payment_method and owner.stripe_customer_id is not None:
-            stripe.PaymentMethod.attach(payment_method, customer=owner.stripe_customer_id)
+            stripe.PaymentMethod.attach(
+                default_payment_method, customer=owner.stripe_customer_id
+            )
             stripe.Customer.modify(
                 owner.stripe_customer_id,
-                invoice_settings={"default_payment_method": default_payment_method }
+                invoice_settings={"default_payment_method": default_payment_method},
             )
 
         subscription_schedule_id = subscription.schedule


### PR DESCRIPTION
Fixes infinite loop introduced in https://github.com/codecov/codecov-api/pull/630 which has meant us spamming the Stripe API constantly.
