### PR TITLE
be more flexible with responses coming through repo_auth_custom_exception_handler

### DIFF
--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -43,10 +43,17 @@ def repo_auth_custom_exception_handler(exc, context):
     give the user something better than "Invalid Token" or "Authentication credentials were not provided."
     """
     response = exception_handler(exc, context)
-    if response is not None:
+    # we were having issues with this block, I made it super cautions.
+    # Re-evaluate later whether this is overly cautious.
+    if (
+        response is not None
+        and hasattr(response, "status_code")
+        and response.status_code == 401
+        and hasattr(response, "data")
+    ):
         try:
-            exc_code = response.data["detail"].code
-        except TypeError:
+            exc_code = response.data.get("detail").code
+        except (TypeError, AttributeError):
             return response
         if exc_code == NotAuthenticated.default_code:
             response.data["detail"] = (


### PR DESCRIPTION
### Purpose/Motivation
This code introduced an issue when it was added, sentry entry [here](https://codecov.sentry.io/releases/production-release-252b887/?project=5215654). lots of responses were getting a `KeyError` because they didn't have the format that was expected. 

### What does this PR do?
Makes the logic in the function much more cautious, does several checks instead of making assumptions

