### PR TITLE
Fix call to `commit_components` to use the right type

### DIFF
--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -112,7 +112,9 @@ class TestCommitComponents(GraphQLTestHelper, TransactionTestCase):
             "repo": self.repo.name,
             "sha": self.commit.commitid,
         }
-        data = self.gql_request(query_commit_components, variables=variables)
+        data = self.gql_request(
+            query_commit_components, variables=variables, owner=OwnerFactory()
+        )
         assert data == {
             "owner": {
                 "repository": {
@@ -148,7 +150,11 @@ class TestCommitComponents(GraphQLTestHelper, TransactionTestCase):
             "repo": self.repo.name,
             "sha": self.commit.commitid,
         }
-        data = self.gql_request(query_commit_components, variables=variables)
+        data = self.gql_request(
+            query_commit_components,
+            variables=variables,
+            owner=OwnerFactory(),
+        )
         assert data == {
             "owner": {
                 "repository": {
@@ -229,7 +235,9 @@ class TestCommitComponents(GraphQLTestHelper, TransactionTestCase):
             "sha": self.commit.commitid,
             "filter": {"components": ["Python"]},
         }
-        data = self.gql_request(query_commit_components, variables=variables)
+        data = self.gql_request(
+            query_commit_components, variables=variables, owner=OwnerFactory()
+        )
         assert data == {
             "owner": {
                 "repository": {
@@ -289,7 +297,9 @@ class TestCommitComponents(GraphQLTestHelper, TransactionTestCase):
             "sha": self.commit.commitid,
             "filter": {"components": ["C", "Golang"]},
         }
-        data = self.gql_request(query_commit_components, variables=variables)
+        data = self.gql_request(
+            query_commit_components, variables=variables, owner=OwnerFactory()
+        )
         assert data == {
             "owner": {
                 "repository": {
@@ -349,7 +359,9 @@ class TestCommitComponents(GraphQLTestHelper, TransactionTestCase):
             "sha": self.commit.commitid,
             "filter": {"components": ["pYtHoN"]},
         }
-        data = self.gql_request(query_commit_components, variables=variables)
+        data = self.gql_request(
+            query_commit_components, variables=variables, owner=OwnerFactory()
+        )
         assert data == {
             "owner": {
                 "repository": {

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -1,8 +1,10 @@
+import logging
 from typing import List, Optional
 
 import sentry_sdk
 import yaml
 from ariadne import ObjectType, convert_kwargs_to_snake_case
+from shared.django_apps.codecov_auth.models import Owner
 from shared.reports.filtered import FilteredReportFile
 from shared.reports.resources import ReportFile
 
@@ -27,7 +29,6 @@ from graphql_api.helpers.connection import (
 )
 from graphql_api.types.comparison.comparison import (
     MissingBaseCommit,
-    MissingBaseReport,
     MissingHeadReport,
 )
 from graphql_api.types.enums import (
@@ -44,13 +45,18 @@ from services.components import Component
 from services.path import ReportPaths
 from services.profiling import CriticalFile, ProfilingSummary
 from services.report import ReadOnlyReport
-from services.yaml import YamlStates, get_yaml_state
+from services.yaml import (
+    YamlStates,
+    get_yaml_state,
+)
 
 commit_bindable = ObjectType("Commit")
 
 commit_bindable.set_alias("createdAt", "timestamp")
 commit_bindable.set_alias("pullId", "pullid")
 commit_bindable.set_alias("branchName", "branch")
+
+log = logging.getLogger(__name__)
 
 
 @commit_bindable.field("coverageFile")
@@ -325,9 +331,9 @@ async def resolve_total_uploads(commit, info):
 @commit_bindable.field("components")
 @sync_to_async
 def resolve_components(commit: Commit, info, filters=None) -> List[Component]:
-    request = info.context["request"]
     info.context["component_commit"] = commit
-    all_components = components_service.commit_components(commit, request.user)
+    current_owner = info.context["request"].current_owner
+    all_components = components_service.commit_components(commit, current_owner)
 
     if filters and filters.get("components"):
         return components_service.filter_components_by_name(

--- a/services/components.py
+++ b/services/components.py
@@ -15,7 +15,7 @@ from timeseries.helpers import fill_sparse_measurements
 from timeseries.models import Interval
 
 
-def commit_components(commit: Commit, owner: Owner) -> List[Component]:
+def commit_components(commit: Commit, owner: Owner | None) -> List[Component]:
     """
     Get the list of components for a commit.
     A request is made to the provider on behalf of the given `owner`

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -20,7 +20,7 @@ class YamlStates(enum.Enum):
 log = logging.getLogger(__name__)
 
 
-def fetch_commit_yaml(commit: Commit, owner: Owner) -> Optional[Dict]:
+def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
     """
     Fetches the codecov.yaml file for a particular commit from the service provider.
     Service provider API request is made on behalf of the given `owner`.
@@ -48,7 +48,7 @@ def fetch_commit_yaml(commit: Commit, owner: Owner) -> Optional[Dict]:
 
 @lru_cache()
 # TODO: make this use the Redis cache logic in 'shared' once it's there
-def final_commit_yaml(commit: Commit, owner: Owner) -> UserYaml:
+def final_commit_yaml(commit: Commit, owner: Owner | None) -> UserYaml:
     return UserYaml.get_final_yaml(
         owner_yaml=commit.repository.author.yaml,
         repo_yaml=commit.repository.yaml,

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 from functools import lru_cache
 from typing import Dict, Optional
 
@@ -14,6 +15,9 @@ from services.repo_providers import RepoProviderService
 
 class YamlStates(enum.Enum):
     DEFAULT = "default"
+
+
+log = logging.getLogger(__name__)
 
 
 def fetch_commit_yaml(commit: Commit, owner: Owner) -> Optional[Dict]:
@@ -35,6 +39,10 @@ def fetch_commit_yaml(commit: Commit, owner: Owner) -> Optional[Dict]:
         # have various exceptions, which we do not care about to get the final
         # yaml used for a commit, as any error here, the codecov.yaml would not
         # be used, so we return None here
+        log.warning(
+            "Was not able to fetch yaml file for commit. Ignoring error and returning None.",
+            extra={"commit_id": commit.commitid},
+        )
         return None
 
 


### PR DESCRIPTION
### Purpose/Motivation
Fix call to `commit_components` to use the `Owner` type 

### Links to relevant tickets
https://github.com/codecov/internal-issues/issues/452

### What does this PR do?
It was originally passing in a `User` object, but actually needed an `Owner` object. Getting the commit was (silently) failing on `service not found` because a service is not associated with a `User`.

I tested this locally and it seems to get the YAML components for the commit now. Previously, it would default to the repo YAML, which would be unstable based on whether the repo YAML is set (or updated during sync).

I also added a log so that this shouldn't silently fail.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
