### PR TITLE
feat: Create mutation endpoint for OKTA config

### DIFF
--- a/codecov_auth/commands/owner/interactors/save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/save_okta_config.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from codecov.commands.base import BaseInteractor
+from codecov.commands.exceptions import Unauthenticated, Unauthorized, ValidationError
+from codecov.db import sync_to_async
+from codecov_auth.models import Account, OktaSettings, Owner
+
+
+@dataclass
+class SaveOktaConfigInput:
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    url: Optional[str] = None
+    enabled: bool = False
+    enforced: bool = False
+    org_username: str = None
+
+class SaveOktaConfigInteractor(BaseInteractor):
+    def validate(self, owner: Owner):
+        if not self.current_user.is_authenticated:
+            raise Unauthenticated()
+        if not owner:
+            raise ValidationError("Cannot find owner record in the database")
+        if not owner.is_admin(self.current_owner):
+            raise Unauthorized()
+
+    @sync_to_async
+    def execute(self, input: dict):
+        typed_input = SaveOktaConfigInput(
+            client_id=input.get("client_id"),
+            client_secret=input.get("client_secret"),
+            url=input.get("url"),
+            enabled=input.get("enabled"),
+            enforced=input.get("enforced"),
+            org_username=input.get("org_username"),
+        )
+
+        owner = Owner.objects.filter(
+            username=typed_input.org_username, service=self.service
+        ).first()
+        self.validate(owner=owner)
+
+        account_id = owner.account_id
+        if not account_id:
+            account = Account.objects.create()
+            account_id = account.id
+            owner.account_id = account_id
+            owner.save()
+
+        okta_config, created = OktaSettings.objects.get_or_create(account_id=account_id)
+
+        for field in ["client_id", "client_secret", "url", "enabled", "enforced"]:
+            value = getattr(typed_input, field)
+            if value is not None:
+                setattr(okta_config, field, value)
+
+        okta_config.save()

--- a/codecov_auth/commands/owner/interactors/tests/test_save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_save_okta_config.py
@@ -1,0 +1,176 @@
+import pytest
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import AnonymousUser
+from django.test import TransactionTestCase
+from freezegun import freeze_time
+from freezegun.api import FakeDatetime
+
+from codecov.commands.exceptions import Unauthenticated, Unauthorized, ValidationError
+from codecov_auth.models import Account, OktaSettings
+from codecov_auth.tests.factories import (
+    AccountFactory,
+    OktaSettingsFactory,
+    OwnerFactory,
+)
+
+from ..save_okta_config import SaveOktaConfigInput, SaveOktaConfigInteractor
+
+
+class SaveOktaConfigInteractorTest(TransactionTestCase):
+    def setUp(self):
+        self.current_user = OwnerFactory(username="codecov-user")
+        self.service = "github"
+        self.owner = OwnerFactory(username=self.current_user.username, service=self.service)
+        self.owner_with_admins = OwnerFactory(username=self.current_user.username, service=self.service, admins=[self.current_user.ownerid])
+
+        self.interactor = SaveOktaConfigInteractor(current_owner=self.owner, service=self.service, current_user=self.current_user)
+
+    @async_to_sync
+    def execute(self, interactor =None, input: dict=None):
+        if not interactor:
+            interactor = self.interactor
+
+        return interactor.execute(input)
+
+    def test_user_is_not_authenticated(self):
+        with pytest.raises(Unauthenticated):
+            self.execute(
+                interactor=SaveOktaConfigInteractor(current_owner=None, service=self.service, current_user=AnonymousUser()),
+                input={
+                    "client_id": "some-client-id",
+                    "client_secret": "some-client-secret",
+                    "url": "https://okta.example.com",
+                    "enabled": True,
+                    "enforced": True,
+                    "org_username": self.owner.username,
+                },
+            )
+
+    def test_validation_error_when_owner_not_found(self):
+        with pytest.raises(ValidationError):
+            self.execute(
+                input={
+                    "client_id": "some-client-id",
+                    "client_secret": "some-client-secret",
+                    "url": "https://okta.example.com",
+                    "enabled": True,
+                    "enforced": True,
+                    "org_username": "non-existent-user",
+                },
+            )
+
+    def test_unauthorized_error_when_user_is_not_admin(self):
+        with pytest.raises(Unauthorized):
+            self.execute(
+                input={
+                    "client_id": "some-client-id",
+                    "client_secret": "some-client-secret",
+                    "url": "https://okta.example.com",
+                    "enabled": True,
+                    "enforced": True,
+                    "org_username": self.owner.username,
+                },
+            )
+
+    def test_create_okta_settings_when_account_does_not_exist(self):
+        input_data = {
+            "client_id": "some-client-id",
+            "client_secret": "some-client-secret",
+            "url": "https://okta.example.com",
+            "enabled": True,
+            "enforced": True,
+            "org_username": self.owner_with_admins.username,
+        }
+
+        interactor = SaveOktaConfigInteractor(current_owner=self.current_user, service=self.service)
+        self.execute(interactor=interactor, input=input_data)
+
+        okta_config = OktaSettings.objects.get(account=self.owner_with_admins.account)
+
+        assert okta_config.client_id == input_data["client_id"]
+        assert okta_config.client_secret == input_data["client_secret"]
+        assert okta_config.url == input_data["url"]
+        assert okta_config.enabled == input_data["enabled"]
+        assert okta_config.enforced == input_data["enforced"]
+
+
+    def test_update_okta_settings_when_account_exists(self):
+        input_data = {
+            "client_id": "some-client-id",
+            "client_secret": "some-client-secret",
+            "url": "https://okta.example.com",
+            "enabled": True,
+            "enforced": True,
+            "org_username": self.owner_with_admins.username,
+        }
+
+        account = AccountFactory()
+        self.owner_with_admins.account = account
+        self.owner_with_admins.save()
+
+        interactor = SaveOktaConfigInteractor(current_owner=self.current_user, service=self.service)
+        self.execute(interactor=interactor, input=input_data)
+
+        okta_config = OktaSettings.objects.get(account=self.owner_with_admins.account)
+
+        assert okta_config.client_id == input_data["client_id"]
+        assert okta_config.client_secret == input_data["client_secret"]
+        assert okta_config.url == input_data["url"]
+        assert okta_config.enabled == input_data["enabled"]
+        assert okta_config.enforced == input_data["enforced"]
+
+    def test_update_okta_settings_when_okta_settings_exists(self):
+        input_data = {
+            "client_id": "some-client-id",
+            "client_secret": "some-client-secret",
+            "url": "https://okta.example.com",
+            "enabled": True,
+            "enforced": True,
+            "org_username": self.owner_with_admins.username,
+        }
+
+        account = AccountFactory()
+        OktaSettingsFactory(account=account)
+        self.owner_with_admins.account = account
+        self.owner_with_admins.save()
+
+        interactor = SaveOktaConfigInteractor(current_owner=self.current_user, service=self.service)
+        self.execute(interactor=interactor, input=input_data)
+
+        okta_config = OktaSettings.objects.get(account=self.owner_with_admins.account)
+
+        assert okta_config.client_id == input_data["client_id"]
+        assert okta_config.client_secret == input_data["client_secret"]
+        assert okta_config.url == input_data["url"]
+        assert okta_config.enabled == input_data["enabled"]
+        assert okta_config.enforced == input_data["enforced"]
+
+    def test_update_okta_settings_when_some_fields_are_none(self):
+        input_data = {
+            "client_id": "some-client-id",
+            "client_secret": None,
+            "url": None,
+            "enabled": True,
+            "enforced": True,
+            "org_username": self.owner_with_admins.username,
+        }
+
+        account = AccountFactory()
+        OktaSettingsFactory(account=account)
+        self.owner_with_admins.account = account
+        self.owner_with_admins.save()
+
+        interactor = SaveOktaConfigInteractor(current_owner=self.current_user, service=self.service)
+        self.execute(interactor=interactor, input=input_data)
+
+        okta_config = OktaSettings.objects.get(account=self.owner_with_admins.account)
+
+        assert okta_config.client_id == input_data["client_id"]
+        assert okta_config.client_secret is not None
+        assert okta_config.url is not None
+        assert okta_config.enabled == input_data["enabled"]
+        assert okta_config.enforced == input_data["enforced"]
+
+
+
+

--- a/codecov_auth/commands/owner/owner.py
+++ b/codecov_auth/commands/owner/owner.py
@@ -12,6 +12,7 @@ from .interactors.is_syncing import IsSyncingInteractor
 from .interactors.onboard_user import OnboardUserInteractor
 from .interactors.regenerate_org_upload_token import RegenerateOrgUploadTokenInteractor
 from .interactors.revoke_user_token import RevokeUserTokenInteractor
+from .interactors.save_okta_config import SaveOktaConfigInteractor
 from .interactors.save_terms_agreement import SaveTermsAgreementInteractor
 from .interactors.set_yaml_on_owner import SetYamlOnOwnerInteractor
 from .interactors.start_trial import StartTrialInteractor
@@ -94,3 +95,6 @@ class OwnerCommands(BaseCommand):
         return self.get_interactor(StoreCodecovMetricInteractor).execute(
             org_username, event, json_string
         )
+
+    def save_okta_config(self, input) -> None:
+        return self.get_interactor(SaveOktaConfigInteractor).execute(input)

--- a/codecov_auth/commands/owner/tests/test_owner.py
+++ b/codecov_auth/commands/owner/tests/test_owner.py
@@ -121,3 +121,11 @@ class OwnerCommandsTest(TransactionTestCase):
         owner = {}
         self.command.regenerate_org_upload_token(owner)
         interactor_mock.assert_called_once_with(owner)
+
+    @patch(
+        "codecov_auth.commands.owner.owner.SaveOktaConfigInteractor.execute"
+    )
+    def test_save_okta_config_delegate_to_interactor(self, interactor_mock):
+        input_dict = {"client_id": "123", "client_secret": "123", "url": "http://example.com", "enabled": True, "enforced": False, "org_username": "codecov-user"}
+        self.command.save_okta_config(input_dict)
+        interactor_mock.assert_called_once_with(input_dict)

--- a/codecov_auth/tests/factories.py
+++ b/codecov_auth/tests/factories.py
@@ -5,7 +5,9 @@ from django.utils import timezone
 from factory.django import DjangoModelFactory
 
 from codecov_auth.models import (
+    Account,
     DjangoSession,
+    OktaSettings,
     OktaUser,
     OrganizationLevelToken,
     Owner,
@@ -33,6 +35,25 @@ class UserFactory(DjangoModelFactory):
     customer_intent = "Business"
 
 
+class AccountFactory(DjangoModelFactory):
+    class Meta:
+        model = Account
+
+    name = factory.Faker("name")
+
+
+class OktaSettingsFactory(DjangoModelFactory):
+    class Meta:
+        model = OktaSettings
+
+    account = factory.SubFactory(AccountFactory)
+    client_id = factory.Faker("uuid4")
+    client_secret = factory.Faker("uuid4")
+    url = factory.Faker("url")
+    enabled = True
+    enforced = False
+
+
 class OwnerFactory(DjangoModelFactory):
     class Meta:
         model = Owner
@@ -56,6 +77,7 @@ class OwnerFactory(DjangoModelFactory):
     )
     user = factory.SubFactory(UserFactory)
     trial_status = TrialStatus.NOT_STARTED.value
+    account = factory.SubFactory(AccountFactory)
 
 
 class SentryUserFactory(DjangoModelFactory):

--- a/graphql_api/tests/mutation/test_save_okta_config.py
+++ b/graphql_api/tests/mutation/test_save_okta_config.py
@@ -1,0 +1,31 @@
+from django.test import TransactionTestCase
+
+from codecov_auth.models import OktaSettings
+from codecov_auth.tests.factories import OwnerFactory
+from graphql_api.tests.helper import GraphQLTestHelper
+
+query = """
+mutation($input: SaveOktaConfigInput!) {
+  saveOktaConfig(input: $input) {
+    error {
+      __typename
+    }
+  }
+}
+"""
+
+class SaveOktaConfigTestCase(GraphQLTestHelper, TransactionTestCase):
+    def setUp(self):
+        self.current_user = OwnerFactory(username="codecov-user")
+        self.owner = OwnerFactory(username="codecov-owner", admins=[self.current_user.ownerid])
+
+    def test_when_unauthenticated(self):
+        data = self.gql_request(query, variables={"input": {"clientId": "some-client-id", "clientSecret": "some-client-secret", "url": "https://okta.example.com", "enabled": True, "enforced": True, "orgUsername": self.owner.username}})
+        assert data["saveOktaConfig"]["error"]["__typename"] == "UnauthenticatedError"
+
+    def test_when_authenticated(self):
+        data = self.gql_request(
+            query, owner=self.owner, variables={"input": {"clientId": "some-client-id", "clientSecret": "some-client-secret", "url": "https://okta.example.com", "enabled": True, "enforced": True, "orgUsername": self.owner.username}}
+        )
+        assert OktaSettings.objects.filter(account=self.owner.account).exists()
+        assert data["saveOktaConfig"] is None

--- a/graphql_api/types/mutation/__init__.py
+++ b/graphql_api/types/mutation/__init__.py
@@ -15,6 +15,7 @@ from .regenerate_org_upload_token import gql_regenerate_org_upload_token
 from .regenerate_repository_token import gql_regenerate_repository_token
 from .regenerate_repository_upload_token import gql_regenerate_repository_upload_token
 from .revoke_user_token import gql_revoke_user_token
+from .save_okta_config import gql_save_okta_config
 from .save_sentry_state import gql_save_sentry_state
 from .save_terms_agreement import gql_save_terms_agreement
 from .set_yaml_on_owner import gql_set_yaml_on_owner
@@ -51,3 +52,4 @@ mutation = mutation + gql_update_self_hosted_settings
 mutation = mutation + gql_regenerate_repository_upload_token
 mutation = mutation + gql_encode_secret_string
 mutation = mutation + gql_store_event_metrics
+mutation = mutation + gql_save_okta_config

--- a/graphql_api/types/mutation/mutation.graphql
+++ b/graphql_api/types/mutation/mutation.graphql
@@ -24,11 +24,18 @@ type Mutation {
   deleteFlag(input: DeleteFlagInput!): DeleteFlagPayload
   saveSentryState(input: SaveSentryStateInput!): SaveSentryStatePayload
   saveTermsAgreement(input: SaveTermsAgreementInput!): SaveTermsAgreementPayload
-  deleteComponentMeasurements(input: DeleteComponentMeasurementsInput!): DeleteComponentMeasurementsPayload
+  deleteComponentMeasurements(
+    input: DeleteComponentMeasurementsInput!
+  ): DeleteComponentMeasurementsPayload
   eraseRepository(input: EraseRepositoryInput!): EraseRepositoryPayload
   updateRepository(input: UpdateRepositoryInput!): UpdateRepositoryPayload
-  updateSelfHostedSettings(input: UpdateSelfHostedSettingsInput!): UpdateSelfHostedSettingsPayload
-  regenerateRepositoryUploadToken(input: RegenerateRepositoryUploadTokenInput!): RegenerateRepositoryUploadTokenPayload
+  updateSelfHostedSettings(
+    input: UpdateSelfHostedSettingsInput!
+  ): UpdateSelfHostedSettingsPayload
+  regenerateRepositoryUploadToken(
+    input: RegenerateRepositoryUploadTokenInput!
+  ): RegenerateRepositoryUploadTokenPayload
   encodeSecretString(input: EncodeSecretStringInput!): EncodeSecretStringPayload
   storeEventMetric(input: StoreEventMetricsInput!): StoreEventMetricsPayload
+  saveOktaConfig(input: SaveOktaConfigInput!): SaveOktaConfigPayload
 }

--- a/graphql_api/types/mutation/mutation.py
+++ b/graphql_api/types/mutation/mutation.py
@@ -32,6 +32,7 @@ from .regenerate_repository_upload_token import (
     resolve_regenerate_repository_upload_token,
 )
 from .revoke_user_token import error_revoke_user_token, resolve_revoke_user_token
+from .save_okta_config import error_save_okta_config, resolve_save_okta_config
 from .save_sentry_state import error_save_sentry_state, resolve_save_sentry_state
 from .save_terms_agreement import (
     error_save_terms_agreement,
@@ -92,6 +93,8 @@ mutation_bindable.field("encodeSecretString")(resolve_encode_secret_string)
 
 mutation_bindable.field("storeEventMetric")(resolve_store_event_metrics)
 
+mutation_bindable.field("saveOktaConfig")(resolve_save_okta_config)
+
 mutation_resolvers = [
     mutation_bindable,
     error_create_api_token,
@@ -118,4 +121,5 @@ mutation_resolvers = [
     error_regenerate_repository_upload_token,
     error_encode_secret_string,
     error_store_event_metrics,
+    error_save_okta_config,
 ]

--- a/graphql_api/types/mutation/save_okta_config/__init__.py
+++ b/graphql_api/types/mutation/save_okta_config/__init__.py
@@ -1,0 +1,5 @@
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+
+from .save_okta_config import error_save_okta_config, resolve_save_okta_config
+
+gql_save_okta_config = ariadne_load_local_graphql(__file__, "save_okta_config.graphql")

--- a/graphql_api/types/mutation/save_okta_config/save_okta_config.graphql
+++ b/graphql_api/types/mutation/save_okta_config/save_okta_config.graphql
@@ -1,0 +1,17 @@
+union SaveOktaConfigError =
+    UnauthenticatedError
+  | UnauthorizedError
+  | ValidationError
+
+type SaveOktaConfigPayload {
+  error: SaveOktaConfigError
+}
+
+input SaveOktaConfigInput {
+  clientId: String
+  clientSecret: String
+  url: String
+  enabled: Boolean
+  enforced: Boolean
+  orgUsername: String
+}

--- a/graphql_api/types/mutation/save_okta_config/save_okta_config.py
+++ b/graphql_api/types/mutation/save_okta_config/save_okta_config.py
@@ -1,0 +1,19 @@
+from ariadne import UnionType, convert_kwargs_to_snake_case
+
+from codecov.db import sync_to_async
+from graphql_api.helpers.mutation import (
+    require_authenticated,
+    resolve_union_error_type,
+    wrap_error_handling_mutation,
+)
+
+
+@wrap_error_handling_mutation
+@require_authenticated
+@convert_kwargs_to_snake_case
+async def resolve_save_okta_config(_, info, input):
+    command = info.context["executor"].get_command("owner")
+    return await command.save_okta_config(input)
+
+error_save_okta_config = UnionType("SaveOktaConfigError")
+error_save_okta_config.type_resolver(resolve_union_error_type)


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
We need to be able to send requests to update / create okta config in the DB 

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1981

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.
- New mutation 
- Tests

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
