### PR TITLE
fix: Remove session expiry cookie

### DIFF
--- a/codecov_auth/tests/unit/views/test_github.py
+++ b/codecov_auth/tests/unit/views/test_github.py
@@ -313,10 +313,6 @@ def test_get_github_already_with_code_with_email(
     assert owner.email == "thiago@codecov.io"
     assert owner.private_access is True
     assert res.url == "http://localhost:3000/gh"
-    assert "session_expiry" in res.cookies
-    session_expiry_cookie = res.cookies["session_expiry"]
-    assert session_expiry_cookie.value == "2023-02-01T08:00:00Z"
-    assert session_expiry_cookie.get("domain") == ".simple.site"
 
 
 @freeze_time("2023-01-01T00:00:00")
@@ -382,10 +378,6 @@ def test_get_github_already_with_code_is_student(
     assert owner.private_access is True
     assert res.url == "http://localhost:3000/gh"
     assert owner.student is True
-    assert "session_expiry" in res.cookies
-    session_expiry_cookie = res.cookies["session_expiry"]
-    assert session_expiry_cookie.value == "2023-01-01T08:00:00Z"
-    assert session_expiry_cookie.get("domain") == ".simple.site"
 
 
 @freeze_time("2023-01-01T00:00:00")
@@ -448,10 +440,6 @@ def test_get_github_already_owner_already_exist(
     assert owner.service_id == "44376991"
     assert owner.private_access is True
     assert res.url == "http://localhost:3000/gh"
-    assert "session_expiry" in res.cookies
-    session_expiry_cookie = res.cookies["session_expiry"]
-    assert session_expiry_cookie.value == "2023-01-01T08:00:00Z"
-    assert session_expiry_cookie.get("domain") == ".simple.site"
 
 
 @pytest.mark.asyncio

--- a/codecov_auth/views/github.py
+++ b/codecov_auth/views/github.py
@@ -128,7 +128,6 @@ class GithubLoginView(LoginMixin, StateMixin, View):
         response = redirect(redirection_url)
         self.login_owner(owner, request, response)
         self.remove_state(state)
-        self.store_access_token_expiry_to_cookie(response)
         UserOnboardingMetricsService.create_user_onboarding_metric(
             org_id=owner.ownerid, event="INSTALLED_APP", payload={"login": "github"}
         )
@@ -166,13 +165,3 @@ class GithubLoginView(LoginMixin, StateMixin, View):
             response = redirect(url_to_redirect_to)
             self.store_to_cookie_utm_tags(response)
             return response
-
-    # Set a session expiry of 8 hours for github logins. GH access tokens expire after 8 hours by default
-    # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/token-expiration-and-revocation#user-token-revoked-due-to-github-app-configuration
-    def store_access_token_expiry_to_cookie(self, response):
-        domain_to_use = settings.COOKIES_DOMAIN
-        eight_hours_later = datetime.utcnow() + timedelta(hours=8)
-        eight_hours_later_iso = eight_hours_later.isoformat() + "Z"
-        response.set_cookie(
-            "session_expiry", eight_hours_later_iso, domain=domain_to_use, secure=True
-        )


### PR DESCRIPTION
Removes the code that sets the github session expiry cookie.

We are going to try a different approach to come in a future PR.

Closes https://github.com/codecov/engineering-team/issues/2025
