### PR TITLE
bundle analysis: measurements optional "after" data and fetch asset gzip size from DB

### DIFF
--- a/graphql_api/actions/measurements.py
+++ b/graphql_api/actions/measurements.py
@@ -13,8 +13,8 @@ def measurements_by_ids(
     measurable_name: str,
     measurable_ids: Iterable[str],
     interval: Interval,
-    after: datetime,
     before: datetime,
+    after: Optional[datetime] = None,
     branch: Optional[str] = None,
 ) -> Mapping[int, Iterable[dict]]:
     queryset = MeasurementSummary.agg_by(interval).filter(
@@ -22,9 +22,13 @@ def measurements_by_ids(
         owner_id=repository.author_id,
         repo_id=repository.pk,
         measurable_id__in=measurable_ids,
-        timestamp_bin__gte=aligned_start_date(interval, after),
         timestamp_bin__lte=before,
     )
+
+    if after is not None:
+        queryset = queryset.filter(
+            timestamp_bin__gte=aligned_start_date(interval, after)
+        )
 
     if branch:
         queryset = queryset.filter(branch=branch)

--- a/graphql_api/types/bundle_analysis/base.graphql
+++ b/graphql_api/types/bundle_analysis/base.graphql
@@ -51,7 +51,7 @@ type BundleAsset {
   measurements(
     interval: MeasurementInterval!
     before: DateTime!
-    after: DateTime!
+    after: DateTime
     branch: String
   ): BundleAnalysisMeasurements
 }
@@ -65,7 +65,7 @@ type BundleReport {
   measurements(
     interval: MeasurementInterval!
     before: DateTime!
-    after: DateTime!
+    after: DateTime
     branch: String
     orderingDirection: OrderingDirection
     filters: BundleAnalysisMeasurementsSetFilters

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -83,7 +83,7 @@ def resolve_extension(bundle_asset: AssetReport, info: GraphQLResolveInfo) -> st
 def resolve_bundle_asset_bundle_data(
     bundle_asset: AssetReport, info: GraphQLResolveInfo
 ) -> BundleData:
-    return BundleData(bundle_asset.size_total)
+    return BundleData(bundle_asset.size_total, bundle_asset.gzip_size_total)
 
 
 @bundle_asset_bindable.field("modules")

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -101,14 +101,14 @@ def resolve_asset_report_measurements(
     info: GraphQLResolveInfo,
     interval: Interval,
     before: datetime,
-    after: datetime,
+    after: Optional[datetime] = None,
     branch: Optional[str] = None,
 ) -> Optional[BundleAnalysisMeasurementData]:
     bundle_analysis_measurements = BundleAnalysisMeasurementsService(
         repository=info.context["commit"].repository,
         interval=interval,
-        after=after,
         before=before,
+        after=after,
         branch=branch,
     )
     return bundle_analysis_measurements.compute_asset(bundle_asset)
@@ -157,7 +157,7 @@ def resolve_bundle_report_measurements(
     info: GraphQLResolveInfo,
     interval: Interval,
     before: datetime,
-    after: datetime,
+    after: Optional[datetime] = None,
     branch: Optional[str] = None,
     filters: Mapping = {},
     ordering_direction: Optional[OrderingDirection] = OrderingDirection.ASC,
@@ -172,8 +172,8 @@ def resolve_bundle_report_measurements(
     bundle_analysis_measurements = BundleAnalysisMeasurementsService(
         repository=info.context["commit"].repository,
         interval=interval,
-        after=after,
         before=before,
+        after=after,
         branch=branch,
     )
 

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/b3927cc7765e207030b25d5370bab9e56bf3e21a.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/b679996ed9df69753d8dd24cd8e1fc3817cb6b59.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -412,7 +412,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/b3927cc7765e207030b25d5370bab9e56bf3e21a.tar.gz
+shared @ https://github.com/codecov/shared/archive/b679996ed9df69753d8dd24cd8e1fc3817cb6b59.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -361,8 +361,8 @@ class BundleAnalysisMeasurementsService(object):
         self,
         repository: Repository,
         interval: Interval,
-        after: datetime,
         before: datetime,
+        after: Optional[datetime] = None,
         branch: Optional[str] = None,
     ) -> None:
         self.repository = repository
@@ -386,7 +386,7 @@ class BundleAnalysisMeasurementsService(object):
 
         # Carry over previous available value for start date if its value is null
         for measurable_id, measurements in all_measurements.items():
-            if measurements[0]["timestamp_bin"] > self.after:
+            if self.after is not None and measurements[0]["timestamp_bin"] > self.after:
                 carryover_measurement = measurements_last_uploaded_before_start_date(
                     repo_id=self.repository.repoid,
                     measurable_name=measurable_name,

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -157,14 +157,20 @@ class BundleSize:
 
 @dataclass
 class BundleData:
-    def __init__(self, size_in_bytes: int):
+    def __init__(self, size_in_bytes: int, gzip_size_in_bytes: Optional[int] = None):
         self.size_in_bytes = size_in_bytes
         self.size_in_bits = size_in_bytes * 8
+        self.gzip_size_in_bytes = gzip_size_in_bytes
 
     @cached_property
     def size(self) -> BundleSize:
+        gzip_size = (
+            self.gzip_size_in_bytes
+            if self.gzip_size_in_bytes is not None
+            else int(float(self.size_in_bytes) * BundleSize.GZIP)
+        )
         return BundleSize(
-            gzip=int(float(self.size_in_bytes) * BundleSize.GZIP),
+            gzip=gzip_size,
             uncompress=int(float(self.size_in_bytes) * BundleSize.UNCOMPRESS),
         )
 
@@ -215,6 +221,10 @@ class AssetReport(object):
     @cached_property
     def size_total(self) -> int:
         return self.asset.size
+
+    @cached_property
+    def gzip_size_total(self) -> int:
+        return self.asset.gzip_size
 
     @cached_property
     def modules(self) -> List[ModuleReport]:


### PR DESCRIPTION
- Make the `after` arg as optional, if not present will fetch from the first commit measurement datapoint.
- `BundleAsset.bundleData.size.gzip` now returns true gzip size if available (via version 2 of bundle stats file) or fallbacks to old calculation (ie size/1000)

closes https://github.com/codecov/engineering-team/issues/1928

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
