### PR TITLE
add email to OwnerSerializer

### DIFF
--- a/api/public/v2/owner/serializers.py
+++ b/api/public/v2/owner/serializers.py
@@ -6,11 +6,7 @@ from codecov_auth.models import Owner
 class OwnerSerializer(serializers.ModelSerializer):
     class Meta:
         model = Owner
-        fields = (
-            "service",
-            "username",
-            "name",
-        )
+        fields = ("service", "username", "name", "email")
         read_only_fields = fields
 
 
@@ -20,4 +16,4 @@ class UserSerializer(OwnerSerializer):
 
     class Meta:
         model = Owner
-        fields = OwnerSerializer.Meta.fields + ("activated", "is_admin", "email")
+        fields = OwnerSerializer.Meta.fields + ("activated", "is_admin")

--- a/api/public/v2/tests/test_api_commit_viewset.py
+++ b/api/public/v2/tests/test_api_commit_viewset.py
@@ -138,6 +138,7 @@ class RepoCommitListTestCase(BaseRepoCommitTestCase):
                         "service": "github",
                         "username": "codecov",
                         "name": self.org.name,
+                        "email": self.org.email,
                     },
                     "branch": "master",
                     "totals": {
@@ -194,6 +195,7 @@ class RepoCommitListTestCase(BaseRepoCommitTestCase):
                         "service": "github",
                         "username": "codecov",
                         "name": self.org.name,
+                        "email": self.org.email,
                     },
                     "branch": "master",
                     "totals": {
@@ -274,6 +276,7 @@ class RepoCommitDetailTestCase(BaseRepoCommitTestCase):
                 "service": "github",
                 "username": "codecov",
                 "name": self.org.name,
+                "email": self.org.email,
             },
             "branch": "master",
             "totals": {

--- a/api/public/v2/tests/test_api_owner_viewset.py
+++ b/api/public/v2/tests/test_api_owner_viewset.py
@@ -20,6 +20,7 @@ class OwnerViewSetTests(APITestCase):
             "service": owner.service,
             "username": owner.username,
             "name": owner.name,
+            "email": owner.email,
         }
 
     def test_retrieve_returns_owner_with_period_username(self):
@@ -32,6 +33,7 @@ class OwnerViewSetTests(APITestCase):
             "service": owner.service,
             "username": owner.username,
             "name": owner.name,
+            "email": owner.email,
         }
 
     def test_retrieve_returns_404_if_no_matching_username(self):

--- a/api/public/v2/tests/test_api_repo_viewset.py
+++ b/api/public/v2/tests/test_api_repo_viewset.py
@@ -14,7 +14,7 @@ from utils.test_utils import APIClient
 @freeze_time("2022-01-01T00:00:00")
 class RepoViewsetTests(InternalAPITest):
     def setUp(self):
-        self.org = OwnerFactory()
+        self.org = OwnerFactory(email=None)
         self.repo = RepositoryFactory(author=self.org)
         self.commit = CommitFactory(
             repository=self.repo, timestamp=timezone.now() - timedelta(days=1)
@@ -55,6 +55,7 @@ class RepoViewsetTests(InternalAPITest):
                         "service": self.org.service,
                         "username": self.org.username,
                         "name": self.org.name,
+                        "email": self.org.email,
                     },
                     "language": self.repo.language,
                     "branch": "master",
@@ -108,6 +109,7 @@ class RepoViewsetTests(InternalAPITest):
                 "service": self.org.service,
                 "username": self.org.username,
                 "name": self.org.name,
+                "email": self.org.email,
             },
             "language": self.repo.language,
             "branch": "master",


### PR DESCRIPTION
### Purpose/Motivation
`author` field would include the `email` in addition to `name` and `username`
