### PR TITLE
feat: Update owner query with `isOktaAuthenticated` field

### DIFF
--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -34,4 +34,5 @@ type Owner {
   ): [Measurement!]
   invoices: [Invoice] @cost(complexity: 100)
   invoice(invoiceId: String!): Invoice
+  isUserOktaAuthenticated: Boolean!
 }

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -251,3 +251,12 @@ def resolve_owner_invoice(
 def resolve_owner_account(owner: Owner, info) -> dict:
     account_id = owner.account_id
     return Account.objects.filter(pk=account_id).first()
+
+
+@owner_bindable.field("isUserOktaAuthenticated")
+@sync_to_async
+def resolve_is_user_okta_authenticated(owner: Owner, info) -> bool:
+    current_user = info.context["request"].user
+    if not current_user.is_authenticated:
+        return False
+    return current_user.is_okta_authenticated_for_org(owner.ownerid)


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
We need this as a flag to tell if current user is OKTA authenticated to display okta banners 

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/2053

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
