### PR TITLE
fix: set plan_auto_activate false when user cancels

### DIFF
--- a/plan/service.py
+++ b/plan/service.py
@@ -63,6 +63,7 @@ class PlanService:
         self.current_org.plan_activated_users = None
         self.current_org.plan_user_count = 1
         self.current_org.stripe_subscription_id = None
+        self.current_org.plan_auto_activate = False
         self.current_org.save()
 
     @property

--- a/plan/tests/test_plan.py
+++ b/plan/tests/test_plan.py
@@ -305,6 +305,7 @@ class PlanServiceTests(TestCase):
         assert current_org.plan_user_count == 1
         assert current_org.plan_activated_users is None
         assert current_org.stripe_subscription_id is None
+        assert current_org.plan_auto_activate is False
 
     def test_plan_service_returns_if_owner_has_trial_dates(self):
         current_org = OwnerFactory(


### PR DESCRIPTION
### Purpose/Motivation

Makes this wording correct when a user cancels

![Screenshot 2024-07-10 at 3 10 43 PM](https://github.com/codecov/codecov-api/assets/159853603/b106b726-260f-49d4-be6b-d1bbc41485b5)

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
