### PR TITLE
Remove old REST repo endpoints and update new GQL mutations 

### DIFF
--- a/api/internal/repo/utils.py
+++ b/api/internal/repo/utils.py
@@ -1,9 +1,0 @@
-from django.conf import settings
-from shared.encryption.yaml_secret import yaml_secret_encryptor
-
-
-def encode_secret_string(value):
-    ## Reminder -- this should probably be rewritten to reuse the same code
-    ## as in the new worker, whenever the API starts using the new worker.
-    encryptor = yaml_secret_encryptor
-    return "secret:%s" % encryptor.encode(value).decode()

--- a/api/internal/repo/views.py
+++ b/api/internal/repo/views.py
@@ -79,4 +79,3 @@ class RepositoryViewSet(
             if owner.has_legacy_plan and owner.repo_credits <= 0:
                 raise PermissionDenied("Private repository limit reached.")
         return super().perform_update(serializer)
-

--- a/api/internal/repo/views.py
+++ b/api/internal/repo/views.py
@@ -1,25 +1,18 @@
 import logging
-import uuid
 
 from django.utils import timezone
 from django_filters import rest_framework as django_filters
-from rest_framework import filters, mixins, status
-from rest_framework.decorators import action
+from rest_framework import filters, mixins
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
 
 from api.internal.repo.filter import RepositoryOrderingFilter
 from api.shared.repo.filter import RepositoryFilters
 from api.shared.repo.mixins import RepositoryViewSetMixin
-from services.task import TaskService
 
 from .serializers import (
     RepoDetailsSerializer,
-    RepoSerializer,
     RepoWithMetricsSerializer,
-    SecretStringPayloadSerializer,
 )
-from .utils import encode_secret_string
 
 log = logging.getLogger(__name__)
 
@@ -87,40 +80,3 @@ class RepositoryViewSet(
                 raise PermissionDenied("Private repository limit reached.")
         return super().perform_update(serializer)
 
-    @action(detail=True, methods=["patch"], url_path="regenerate-upload-token")
-    def regenerate_upload_token(self, request, *args, **kwargs):
-        repo = self.get_object()
-        repo.upload_token = uuid.uuid4()
-        repo.save()
-        return Response(self.get_serializer(repo).data)
-
-    @action(detail=True, methods=["patch"])
-    def erase(self, request, *args, **kwargs):
-        self._assert_is_admin()
-        repo = self.get_object()
-        TaskService().delete_timeseries(repository_id=repo.repoid)
-        TaskService().flush_repo(repository_id=repo.repoid)
-        return Response(RepoSerializer(repo).data)
-
-    @action(detail=True, methods=["post"])
-    def encode(self, request, *args, **kwargs):
-        serializer = SecretStringPayloadSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-
-        owner, repo = self.owner, self.get_object()
-
-        to_encode = "/".join(
-            (
-                owner.service,
-                owner.service_id,
-                repo.service_id,
-                serializer.validated_data["value"],
-            )
-        )
-
-        return Response(
-            SecretStringPayloadSerializer(
-                {"value": encode_secret_string(to_encode)}
-            ).data,
-            status=status.HTTP_201_CREATED,
-        )

--- a/api/internal/tests/views/test_repo_view.py
+++ b/api/internal/tests/views/test_repo_view.py
@@ -57,6 +57,7 @@ class RepositoryViewSetTestSuite(InternalAPITest):
             }
         return self.client.delete(reverse("repos-detail", kwargs=kwargs))
 
+
 class TestRepositoryViewSetList(RepositoryViewSetTestSuite):
     def setUp(self):
         self.org = OwnerFactory(username="codecov", service="github")

--- a/api/internal/tests/views/test_repo_view.py
+++ b/api/internal/tests/views/test_repo_view.py
@@ -57,30 +57,6 @@ class RepositoryViewSetTestSuite(InternalAPITest):
             }
         return self.client.delete(reverse("repos-detail", kwargs=kwargs))
 
-    def _regenerate_upload_token(self, kwargs={}):
-        if kwargs == {}:
-            kwargs = {
-                "service": self.org.service,
-                "owner_username": self.org.username,
-                "repo_name": self.repo.name,
-            }
-        return self.client.patch(
-            reverse("repos-regenerate-upload-token", kwargs=kwargs)
-        )
-
-    def _erase(self, kwargs={}):
-        if kwargs == {}:
-            kwargs = {
-                "service": self.org.service,
-                "owner_username": self.org.username,
-                "repo_name": self.repo.name,
-            }
-        return self.client.patch(reverse("repos-erase", kwargs=kwargs))
-
-    def _encode(self, kwargs, data):
-        return self.client.post(reverse("repos-encode", kwargs=kwargs), data=data)
-
-
 class TestRepositoryViewSetList(RepositoryViewSetTestSuite):
     def setUp(self):
         self.org = OwnerFactory(username="codecov", service="github")
@@ -677,39 +653,6 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
         assert response.data["detail"] == "User not activated"
         assert Repository.objects.filter(name="repo1").exists()
 
-    def test_regenerate_upload_token_with_permissions_succeeds(
-        self, mocked_get_permissions
-    ):
-        mocked_get_permissions.return_value = True, True
-        old_upload_token = self.repo.upload_token
-
-        response = self._regenerate_upload_token()
-
-        assert response.status_code == 200
-        self.repo.refresh_from_db()
-        assert str(self.repo.upload_token) == response.data["upload_token"]
-        assert str(self.repo.upload_token) != old_upload_token
-
-    def test_regenerate_upload_token_without_permissions_returns_403(
-        self, mocked_get_permissions
-    ):
-        mocked_get_permissions.return_value = False, False
-        response = self._regenerate_upload_token()
-        self.assertEqual(response.status_code, 403)
-
-    def test_regenerate_upload_token_as_inactive_user_returns_403(
-        self, mocked_get_permissions
-    ):
-        mocked_get_permissions.return_value = True, True
-        self.org.plan = "users-inappy"
-        self.org.plan_auto_activate = False
-        self.org.save()
-
-        response = self._regenerate_upload_token()
-
-        assert response.status_code == 403
-        assert response.data["detail"] == "User not activated"
-
     def test_update_default_branch_with_permissions_succeeds(
         self, mocked_get_permissions
     ):
@@ -734,88 +677,6 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
 
         response = self._update(data={"branch": "dev"})
         self.assertEqual(response.status_code, 403)
-
-    @patch("services.task.TaskService.delete_timeseries")
-    @patch("services.task.TaskService.flush_repo")
-    def test_erase_triggers_task(
-        self, mocked_flush_repo, mocked_delete_timeseries, mocked_get_permissions
-    ):
-        mocked_get_permissions.return_value = True, True
-        self.org.admins = [self.current_owner.ownerid]
-        self.org.save()
-
-        response = self._erase()
-        assert response.status_code == 200
-
-        mocked_flush_repo.assert_called_once_with(repository_id=self.repo.pk)
-        mocked_delete_timeseries.assert_called_once_with(repository_id=self.repo.pk)
-
-    @patch("api.shared.permissions.get_provider")
-    def test_erase_without_admin_rights_returns_403(
-        self, mocked_get_provider, mocked_get_permissions
-    ):
-        mocked_get_provider.return_value = GetAdminProviderAdapter()
-        mocked_get_permissions.return_value = True, True
-
-        assert self.current_owner.ownerid not in self.org.admins
-
-        response = self._erase()
-        assert response.status_code == 403
-
-    def test_erase_as_inactive_user_returns_403(self, mocked_get_permissions):
-        mocked_get_permissions.return_value = True, True
-        self.org.plan = "users-inappy"
-        self.org.plan_auto_activate = False
-        self.org.admins = [self.current_owner.ownerid]
-        self.org.save()
-
-        response = self._erase()
-
-        assert response.status_code == 403
-        assert response.data["detail"] == "User not activated"
-
-    @override_settings(IS_ENTERPRISE=True)
-    @patch("api.shared.repo.mixins.RepositoryViewSetMixin.get_object")
-    @patch("services.self_hosted.get_config")
-    @patch("services.task.TaskService.delete_timeseries")
-    @patch("services.task.TaskService.flush_repo")
-    def test_erase_as_admin_self_hosted(
-        self,
-        mocked_flush_repo,
-        mocked_delete_timeseries,
-        mocked_get_config,
-        mocked_get_object,
-        mocked_get_permissions,
-    ):
-        mocked_get_permissions.return_value = True, True
-        self.org.admins = [self.current_owner.ownerid]
-        self.org.save()
-
-        mocked_get_config.return_value = [
-            {"service": "github", "username": "codecov-user"},
-        ]
-        mocked_get_object.return_value = self.repo
-
-        response = self._erase()
-        assert response.status_code == 200
-
-        mocked_flush_repo.assert_called_once_with(repository_id=self.repo.pk)
-        mocked_delete_timeseries.assert_called_once_with(repository_id=self.repo.pk)
-
-    @override_settings(IS_ENTERPRISE=True)
-    @patch("services.self_hosted.get_config")
-    @patch("api.shared.permissions.get_provider")
-    def test_erase_as_non_admin_self_hosted(
-        self, mocked_get_provider, mocked_get_config, mocked_get_permissions
-    ):
-        mocked_get_provider.return_value = GetAdminProviderAdapter()
-        mocked_get_config.return_value = [
-            {"service": "github", "username": "someone-else"},
-        ]
-        mocked_get_permissions.return_value = True, True
-
-        response = self._erase()
-        assert response.status_code == 403
 
     def test_retrieve_returns_yaml(self, mocked_get_permissions):
         mocked_get_permissions.return_value = True, False
@@ -847,64 +708,6 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
         response = self._update(data=activation_data)
 
         assert response.status_code == 403
-
-    def test_encode_returns_200_on_success(self, mocked_get_permissions):
-        mocked_get_permissions.return_value = True, True
-
-        to_encode = {"value": "hjrok"}
-        response = self._encode(
-            kwargs={
-                "service": self.org.service,
-                "owner_username": self.org.username,
-                "repo_name": self.repo.name,
-            },
-            data=to_encode,
-        )
-
-        assert response.status_code == 201
-
-    @patch("api.internal.repo.views.encode_secret_string")
-    def test_encode_returns_encoded_string_on_success(
-        self, encoder_mock, mocked_get_permissions
-    ):
-        mocked_get_permissions.return_value = True, True
-        encrypted_string = "string:encrypted string"
-        encoder_mock.return_value = encrypted_string
-
-        to_encode = {"value": "hjrok"}
-        response = self._encode(
-            kwargs={
-                "service": self.org.service,
-                "owner_username": self.org.username,
-                "repo_name": self.repo.name,
-            },
-            data=to_encode,
-        )
-
-        assert response.status_code == 201
-        assert response.data["value"] == encrypted_string
-
-    def test_encode_secret_string_encodes_with_right_key(self, _):
-        from api.internal.repo.utils import encode_secret_string
-
-        string_arg = "hi there"
-        to_encode = "/".join(
-            (  # this is the format expected by the key
-                self.org.service,
-                self.org.service_id,
-                self.repo.service_id,
-                string_arg,
-            )
-        )
-
-        from shared.encryption.yaml_secret import yaml_secret_encryptor
-
-        check_encryptor = yaml_secret_encryptor
-
-        encoded = encode_secret_string(to_encode)
-
-        # we slice to take off the word "secret" prepended by the util
-        assert check_encryptor.decode(encoded[7:]) == to_encode
 
     def test_repo_bot_returns_username_if_bot_not_null(self, mocked_get_permissions):
         mocked_get_permissions.return_value = True, True

--- a/core/commands/repository/interactors/encode_secret_string.py
+++ b/core/commands/repository/interactors/encode_secret_string.py
@@ -14,12 +14,9 @@ class EncodeSecretStringInteractor(BaseInteractor):
         if not self.current_user.is_authenticated:
             raise Unauthenticated()
 
-        author = Owner.objects.filter(
-            username=owner.username, service=self.service
-        ).first()
         repo = (
-            Repository.objects.viewable_repos(self.current_owner)
-            .filter(author=author, name=repo_name)
+            Repository.objects.viewable_repos(owner)
+            .filter(name=repo_name)
             .first()
         )
         if not repo:

--- a/core/commands/repository/interactors/encode_secret_string.py
+++ b/core/commands/repository/interactors/encode_secret_string.py
@@ -14,11 +14,7 @@ class EncodeSecretStringInteractor(BaseInteractor):
         if not self.current_user.is_authenticated:
             raise Unauthenticated()
 
-        repo = (
-            Repository.objects.viewable_repos(owner)
-            .filter(name=repo_name)
-            .first()
-        )
+        repo = Repository.objects.viewable_repos(owner).filter(name=repo_name).first()
         if not repo:
             raise ValidationError("Repo not found")
         to_encode = "/".join(

--- a/core/commands/repository/interactors/regenerate_repository_upload_token.py
+++ b/core/commands/repository/interactors/regenerate_repository_upload_token.py
@@ -10,12 +10,12 @@ from core.models import Repository
 class RegenerateRepositoryUploadTokenInteractor(BaseInteractor):
     @sync_to_async
     def execute(self, repo_name: str, owner_username: str) -> uuid.UUID:
-        author = Owner.objects.filter(
+        current_owner = Owner.objects.filter(
             username=owner_username, service=self.service
         ).first()
         repo = (
-            Repository.objects.viewable_repos(self.current_owner)
-            .filter(author=author, name=repo_name, active=True)
+            Repository.objects.viewable_repos(current_owner)
+            .filter(name=repo_name, active=True)
             .first()
         )
         if not repo:


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

This PR removes old REST endpoints for 
- EncodeSecretString
- Regenerate Repo Upload token 
- Erase Repo 

- [x] Test on staging

It also contains a fix to an edge case to update viewable repositories so the UI can see all repos in the org, not just those authored by the logged in user. 


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
