### PR TITLE
Update default branch logic from master to main

### DIFF
--- a/core/managers.py
+++ b/core/managers.py
@@ -276,7 +276,7 @@ class RepositoryQuerySet(QuerySet):
             author=owner,
             service_id=git_repo.get("service_id") or git_repo.get("id"),
             private=git_repo["private"],
-            branch=git_repo.get("branch") or git_repo.get("default_branch") or "master",
+            branch=git_repo.get("branch") or git_repo.get("default_branch") or "main",
             name=git_repo["name"],
         )
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

We are seeing some issues in the UI where the default branch of main cannot be fetched. Since the git community uses main as [default](https://github.com/github/renaming), we are updating our backend to reflect that. 
 
 ### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
