### PR TITLE
[Okta Login] Part 2: Add Okta Login API for Organizations/Account 

### DIFF
--- a/codecov_auth/tests/unit/views/test_okta_cloud.py
+++ b/codecov_auth/tests/unit/views/test_okta_cloud.py
@@ -1,0 +1,453 @@
+from logging import LogRecord
+from typing import Any
+from urllib.parse import unquote, urlencode, urlparse
+
+import pytest
+from django.test import override_settings
+from pytest import LogCaptureFixture
+from pytest_mock import MockerFixture
+from shared.django_apps.codecov_auth.models import Account, OktaSettings, Owner
+from shared.django_apps.codecov_auth.tests.factories import (
+    AccountFactory,
+    OktaSettingsFactory,
+)
+
+from codecov_auth.tests.factories import OwnerFactory
+from codecov_auth.views.okta_cloud import (
+    OKTA_CURRENT_SESSION,
+    OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY,
+)
+from codecov_auth.views.okta_mixin import OktaIdTokenPayload
+from utils.test_utils import Client as TestClient
+
+
+@pytest.fixture
+def signed_in_client() -> TestClient:
+    new_client = TestClient()
+    new_client.force_login_owner(OwnerFactory())
+    return new_client
+
+
+@pytest.fixture
+def okta_org_name() -> str:
+    return "foo-bar-organization"
+
+
+@pytest.fixture
+def okta_org(okta_org_name: str) -> Owner:
+    org: Owner = OwnerFactory.create(username=okta_org_name, service="github")
+    org.save()
+    return org
+
+
+@pytest.fixture
+def okta_account(okta_org: Owner):
+    account = AccountFactory()
+    okta_org.account = account
+    okta_org.save()
+
+    okta_settings: OktaSettings = OktaSettingsFactory(account=account)
+    okta_settings.url = "https://foo-bar.okta.com"
+    okta_settings.save()
+    return account
+
+
+@pytest.fixture
+def mocked_okta_token_request(mocker):
+    return mocker.patch(
+        "codecov_auth.views.okta_mixin.requests.post",
+        return_value=mocker.MagicMock(
+            status_code=200,
+            json=mocker.MagicMock(
+                return_value={
+                    "access_token": "test-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "id_token": "test-id-token",
+                    "state": "test-state",
+                },
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def mocked_validate_id_token(mocker):
+    return mocker.patch(
+        "codecov_auth.views.okta_cloud.validate_id_token",
+        return_value=OktaIdTokenPayload(
+            sub="test-id",
+            email="test@example.com",
+            name="Some User",
+            iss="https://example.com",
+            aud="test-client-id",
+        ),
+    )
+
+
+def log_message_exists(message: str, logs: list[LogRecord]) -> bool:
+    """Helper method to check that a particular log record was emitted"""
+    for log in logs:
+        if log.message == message:
+            return True
+    return False
+
+
+@pytest.mark.django_db
+def test_okta_login_unauthenticated_user(
+    client: TestClient,
+    caplog: LogCaptureFixture,
+):
+    res = client.get("/login/okta/github/some-unknown-service")
+    assert log_message_exists(
+        "User needs to be signed in before authenticating organization with Okta.",
+        caplog.records,
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.django_db
+def test_okta_login_invalid_organization(
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+):
+    res = signed_in_client.get("/login/okta/github/some-unknown-service")
+    assert log_message_exists("The organization doesn't exist.", caplog.records)
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_okta_login_no_account(signed_in_client: TestClient, caplog: LogCaptureFixture):
+    org: Owner = OwnerFactory.create(username="org-no-account", service="github")
+    org.save()
+    res = signed_in_client.get("/login/okta/github/org-no-account")
+    assert log_message_exists(
+        "Okta settings not found. Cannot sign into Okta", caplog.records
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_okta_login_no_okta_settings(
+    signed_in_client: TestClient, caplog: LogCaptureFixture
+):
+    org: Owner = OwnerFactory.create(username="account-no-okta", service="github")
+    org.account = AccountFactory()
+    org.save()
+    res = signed_in_client.get("/login/okta/github/account-no-okta")
+    assert log_message_exists(
+        "Okta settings not found. Cannot sign into Okta", caplog.records
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_okta_login_already_signed_into_okta(
+    signed_in_client: TestClient,
+    okta_org_name: str,
+    okta_account: Account,
+):
+    session = signed_in_client.session
+    session[OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY] = [okta_account.id]
+    session.save()
+    res = signed_in_client.get(f"/login/okta/gh/{okta_org_name}")
+    assert res.status_code == 302
+    assert res.url == f"http://localhost:3000/github/{okta_org_name}"
+
+
+@override_settings(
+    CODECOV_API_URL="http://localhost:8000",
+)
+@pytest.mark.django_db
+def test_okta_login_redirect_to_okta_issuer(
+    signed_in_client: TestClient, okta_org_name: str, okta_account: Account
+):
+    res = signed_in_client.get(f"/login/okta/gh/{okta_org_name}")
+    assert res.status_code == 302
+    parsed_url = urlparse(res.url)
+    assert parsed_url.hostname == "foo-bar.okta.com"
+    assert parsed_url.path == "/oauth2/v1/authorize"
+
+    parsed_query = parsed_url.query.split("&")
+    raw_redirect_url = next(x for x in parsed_query if x.startswith("redirect_uri="))
+    assert raw_redirect_url
+    assert (
+        unquote(raw_redirect_url.split("=")[1])
+        == "http://localhost:8000/login/okta/callback"
+    )
+
+
+@pytest.mark.django_db
+def test_okta_callback_login_success(
+    signed_in_client: TestClient,
+    okta_account: Account,
+    okta_org: Owner,
+    mocked_validate_id_token: Any,
+    mocked_okta_token_request: Any,
+):
+    state = "test-state"
+    session = signed_in_client.session
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+    session["okta_cloud_oauth_state"] = state
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+
+    session.save()
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+
+    assert res.status_code == 302
+    assert res.url == f"http://localhost:3000/github/{okta_org.username}"
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) == [okta_account.id]
+
+
+@pytest.mark.django_db
+def test_okta_callback_login_success_multiple_accounts(
+    signed_in_client: TestClient,
+    okta_account: Account,
+    okta_org: Owner,
+    mocked_validate_id_token: Any,
+    mocked_okta_token_request: Any,
+):
+    state = "test-state"
+    session = signed_in_client.session
+    # Put in a random account that's not current okta_account
+    session[OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY] = [okta_account.id + 1]
+
+    session["okta_cloud_oauth_state"] = state
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+
+    session.save()
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+
+    assert res.status_code == 302
+    assert res.url == f"http://localhost:3000/github/{okta_org.username}"
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) == [
+        okta_account.id + 1,
+        okta_account.id,
+    ]
+
+
+@pytest.mark.django_db
+def test_okta_callback_missing_session(
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+):
+    session = signed_in_client.session
+    state = "test-state"
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = state
+    session.save()
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+    assert res.status_code == 403
+
+    assert log_message_exists(
+        "Trying to sign into Okta with no existing sign-in session.", caplog.records
+    )
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+
+@pytest.mark.django_db
+def test_okta_callback_missing_user(
+    client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+):
+    session = client.session
+    state = "test-state"
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = state
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+    session.save()
+
+    res = client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+    assert res.status_code == 403
+
+    assert log_message_exists("User not logged in for Okta callback.", caplog.records)
+
+    updated_session = client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+
+@pytest.mark.django_db
+def test_okta_callback_missing_okta_settings(
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+):
+    session = signed_in_client.session
+    state = "test-state"
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = state
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": 12345,
+    }
+    session.save()
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+    assert res.status_code == 404
+
+    assert log_message_exists(
+        "Okta settings not found. Cannot sign into Okta", caplog.records
+    )
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+
+@pytest.mark.django_db
+def test_okta_callback_no_code(
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+):
+    session = signed_in_client.session
+    state = "test-state"
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = state
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+    session.save()
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "state": state,
+        },
+    )
+    assert res.status_code == 400
+
+    assert log_message_exists(
+        "No code is passed. Invalid callback. Cannot sign into Okta", caplog.records
+    )
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+
+@pytest.mark.django_db
+def test_okta_callback_perform_login_invalid_state(
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+):
+    session = signed_in_client.session
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = "random-state"
+
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+    session.save()
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": "different-state",
+        },
+    )
+    assert res.status_code == 302
+    assert res.url == f"http://localhost:3000/github/{okta_org.username}"
+
+    assert log_message_exists("Invalid state during Okta login", caplog.records)
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+
+@pytest.mark.django_db
+def test_okta_callback_perform_login_no_user_data(
+    mocker: MockerFixture,
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+    mocked_okta_token_request: Any,
+):
+    state = "test-state"
+    session = signed_in_client.session
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = state
+
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+    session.save()
+
+    mocked_okta_token_request.return_value = mocker.MagicMock(
+        status_code=400,
+    )
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+    assert res.status_code == 400
+
+    assert log_message_exists(
+        "Can't log in. Invalid Okta Token Response", caplog.records
+    )
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None

--- a/codecov_auth/urls.py
+++ b/codecov_auth/urls.py
@@ -9,6 +9,7 @@ from .views.gitlab import GitlabLoginView
 from .views.gitlab_enterprise import GitlabEnterpriseLoginView
 from .views.logout import logout_view
 from .views.okta import OktaLoginView
+from .views.okta_cloud import OktaCloudCallbackView, OktaCloudLoginView
 from .views.sentry import SentryLoginView
 
 urlpatterns = [
@@ -40,6 +41,16 @@ urlpatterns = [
     path("login/bbs", BitbucketServerLoginView.as_view(), name="bbs-login"),
     path("login/stash", BitbucketServerLoginView.as_view(), name="stash-login"),
     path("login/sentry", SentryLoginView.as_view(), name="sentry-login"),
+    path(
+        "login/okta/<str:service>/<str:org_username>",
+        OktaCloudLoginView.as_view(),
+        name="okta-cloud-login",
+    ),
+    path(
+        "login/okta/callback",
+        OktaCloudCallbackView.as_view(),
+        name="okta-cloud-callback",
+    ),
 ]
 if settings.OKTA_ISS is not None:
     urlpatterns += [path("login/okta", OktaLoginView.as_view(), name="okta-login")]

--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -1,0 +1,197 @@
+import logging
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+from django.views import View
+from requests.auth import HTTPBasicAuth
+from shared.django_apps.codecov_auth.models import Account, OktaSettings, Owner
+
+from codecov_auth.views.okta_mixin import (
+    OktaLoginMixin,
+    OktaTokenResponse,
+    validate_id_token,
+)
+
+# The key for accessing the Okta signed in accounts list in the session
+OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY = "okta_logged_in_accounts"
+
+# The key for the currently signing in session in Okta.
+# This is so that the callback can reference the orgs/accounts that we're
+# signing in for.
+OKTA_CURRENT_SESSION = "okta_current_session"
+
+log = logging.getLogger(__name__)
+
+
+def get_app_redirect_url(org_username: str, service: str) -> str:
+    """The Codecov app page we redirect users to."""
+    return f"{settings.CODECOV_DASHBOARD_URL}/{service}/{org_username}"
+
+
+def get_oauth_redirect_url(org_username: str, service: str) -> str:
+    """The Okta callback URL for us to finish the authentication."""
+    return f"{settings.CODECOV_API_URL}/login/okta/callback"
+
+
+def get_okta_settings(organization: Owner) -> OktaSettings | None:
+    account: Account | None = organization.account
+    if account:
+        okta_settings: OktaSettings | None = account.okta_settings.first()
+        if okta_settings:
+            return okta_settings
+    return None
+
+
+class OktaCloudLoginView(OktaLoginMixin, View):
+    service = "okta_cloud"
+
+    def get(
+        self, request: HttpRequest, service: str, org_username: str
+    ) -> HttpResponse:
+        log_context: dict = {"service": service, "username": org_username}
+        if not request.session.get("current_owner_id"):
+            log.warning(
+                "User needs to be signed in before authenticating organization with Okta.",
+                extra=log_context,
+            )
+            return HttpResponse(status=403)
+
+        try:
+            organization: Owner = Owner.objects.get(
+                service=service, username=org_username
+            )
+        except Owner.DoesNotExist:
+            log.warning("The organization doesn't exist.", extra=log_context)
+            return HttpResponse(status=404)
+
+        okta_settings = get_okta_settings(organization)
+        if not okta_settings:
+            log.warning(
+                "Okta settings not found. Cannot sign into Okta", extra=log_context
+            )
+            return HttpResponse(status=404)
+
+        app_redirect_url = get_app_redirect_url(org_username, service)
+        oauth_redirect_url = get_oauth_redirect_url(org_username, service)
+
+        # User is already logged in, redirect them to the org page
+        if organization.account.id in request.session.get(
+            OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY, []
+        ):
+            return redirect(app_redirect_url)
+
+        # Otherwise start the process redirect them to the Issuer page to authenticate
+        else:
+            consent = self._redirect_to_consent(
+                iss=okta_settings.url,
+                client_id=okta_settings.client_id,
+                oauth_redirect_url=oauth_redirect_url,
+            )
+            request.session[OKTA_CURRENT_SESSION] = {
+                "org_ownerid": organization.ownerid,
+                "okta_settings_id": okta_settings.id,
+            }
+            return consent
+
+
+class OktaCloudCallbackView(OktaLoginMixin, View):
+    service = "okta_cloud"
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        current_okta_session: dict[str, int] | None = request.session.get(
+            OKTA_CURRENT_SESSION
+        )
+        if not current_okta_session:
+            log.warning("Trying to sign into Okta with no existing sign-in session.")
+            return HttpResponse(status=403)
+
+        org_owner = Owner.objects.get(ownerid=current_okta_session["org_ownerid"])
+        log_context: dict = {
+            "service": org_owner.service,
+            "username": org_owner.username,
+        }
+
+        if not request.session.get("current_owner_id"):
+            log.warning(
+                "User not logged in for Okta callback.",
+                extra=log_context,
+            )
+            return HttpResponse(status=403)
+
+        try:
+            okta_settings = OktaSettings.objects.get(
+                id=current_okta_session["okta_settings_id"]
+            )
+        except OktaSettings.DoesNotExist:
+            log.warning(
+                "Okta settings not found. Cannot sign into Okta", extra=log_context
+            )
+            return HttpResponse(status=404)
+
+        app_redirect_url = get_app_redirect_url(org_owner.username, org_owner.service)
+        oauth_redirect_url = get_oauth_redirect_url(
+            org_owner.username, org_owner.service
+        )
+
+        # Redirect URL, need to validate and mark user as logged in
+        if request.GET.get("code"):
+            return self._perform_login(
+                request,
+                org_owner,
+                okta_settings,
+                app_redirect_url,
+                oauth_redirect_url,
+            )
+        else:
+            log.warning(
+                "No code is passed. Invalid callback. Cannot sign into Okta",
+                extra=log_context,
+            )
+
+        return HttpResponse(status=400)
+
+    def _perform_login(
+        self,
+        request: HttpRequest,
+        organization: Owner,
+        okta_settings: OktaSettings,
+        app_redirect_url: str,
+        oauth_redirect_url: str,
+    ) -> HttpResponse:
+        code = request.GET.get("code")
+        state = request.GET.get("state")
+
+        if not self.verify_state(state):
+            log.warning("Invalid state during Okta login")
+            return redirect(app_redirect_url)
+
+        issuer: str = okta_settings.url
+        user_data: OktaTokenResponse | None = self._fetch_user_data(
+            issuer,
+            code,
+            state,
+            oauth_redirect_url,
+            HTTPBasicAuth(okta_settings.client_id, okta_settings.client_secret),
+        )
+
+        if user_data is None:
+            log.warning("Can't log in. Invalid Okta Token Response", exc_info=True)
+            return HttpResponse(status=400)
+
+        _ = validate_id_token(issuer, user_data.id_token, okta_settings.client_id)
+
+        self._login_user(request, organization)
+
+        return redirect(app_redirect_url)
+
+    def _login_user(self, request: HttpRequest, organization: Owner) -> None:
+        """Logging in the user will just mean adding the account to the user's
+        okta_logged_in_accounts session.
+        """
+        okta_signed_in_accounts: list[int] = request.session.get(
+            OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY, []
+        )
+        okta_signed_in_accounts.append(organization.account.id)
+        request.session[OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY] = okta_signed_in_accounts
+        return


### PR DESCRIPTION
### Purpose/Motivation
This adds the login endpoint for uses to sign into Okta for specific orgs/account.
Depends on Part 1: https://github.com/codecov/codecov-api/pull/691

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1988

### What does this PR do?
Note that this is _not_ to authenticate the user. We check that the user has already authenticated via another mechanism (i.e. Github). This adds extra permissions for organizations that want extra level of security to see private repos.

The authentication flow looks something like this:

```mermaid 
sequenceDiagram
    User->>+Codecov: /login/okta/{service}/{org}
    Codecov->>+Okta: if not signed in, then redirect them to okta.com/oauth2/v1/authorized
    Okta->>+User: shows the user the Okta sign-in UI
    User->>+Okta: enters in credentials and signs in
    Okta->>+Codecov: sends back credentials info to Codecov via /login/okta/callback
    Codecov->>+Okta: queries auth token via okta.com/oauth2/v1/token
    Codecov->>+Okta: decrypts auth token with keys okta.com/oauth2/v1/keys
    Codecov->>+User: if auth is successful, stores the authenticated account in user session
```

This PR adds the 2 endpoints:
* `/login/okta/{service}/{org}` to send the user to Okta
* `/login/okta/callback` to finish authenticating the user on Codecov

### Notes to Reviewer

* I'm not sure about the naming of OktaCloudView. Feel free to suggest another name.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
