### PR TITLE
[fix] Pass extra param in resolver function 

### DIFF
--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -247,7 +247,7 @@ def resolve_is_github_rate_limited(owner: Owner, info) -> bool | None:
     if owner.service != SERVICE_GITHUB and owner.service != SERVICE_GITHUB_ENTERPRISE:
         return False
     redis_connection = get_redis_connection()
-    rate_limit_redis_key = rate_limits.determine_entity_redis_key(owner=owner)
+    rate_limit_redis_key = rate_limits.determine_entity_redis_key(owner=owner, repo=None)
     return rate_limits.determine_if_entity_is_rate_limited(
         redis_connection, rate_limit_redis_key
     )

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -248,7 +248,7 @@ def resolve_is_github_rate_limited(owner: Owner, info) -> bool | None:
         return False
     redis_connection = get_redis_connection()
     rate_limit_redis_key = rate_limits.determine_entity_redis_key(
-        owner=owner, repo=None
+        owner=owner, repository=None
     )
     return rate_limits.determine_if_entity_is_rate_limited(
         redis_connection, rate_limit_redis_key

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -247,7 +247,9 @@ def resolve_is_github_rate_limited(owner: Owner, info) -> bool | None:
     if owner.service != SERVICE_GITHUB and owner.service != SERVICE_GITHUB_ENTERPRISE:
         return False
     redis_connection = get_redis_connection()
-    rate_limit_redis_key = rate_limits.determine_entity_redis_key(owner=owner, repo=None)
+    rate_limit_redis_key = rate_limits.determine_entity_redis_key(
+        owner=owner, repo=None
+    )
     return rate_limits.determine_if_entity_is_rate_limited(
         redis_connection, rate_limit_redis_key
     )


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

The `determine_entity_redis_key` requires both args to be specified even if one of them is None. Updating function call to match the signature. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
