### PR TITLE
Update GQL to return whether bundles are cached

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     "shared.django_apps.rollouts",
     "shared.django_apps.user_measurements",
     "shared.django_apps.codecov_metrics",
+    "shared.django_apps.bundle_analysis",
 ]
 
 MIDDLEWARE = [

--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -1079,6 +1079,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                                                     uncompress
                                                 }
                                             }
+                                            isCached
                                         }
                                         bundleData {
                                             loadTime {
@@ -1092,7 +1093,9 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                                         }
                                         bundle(name: "not_exist") {
                                             name
+                                            isCached
                                         }
+                                        isCached
                                     }
                                     ... on MissingHeadReport {
                                         message
@@ -1136,6 +1139,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                             "uncompress": 20,
                         },
                     },
+                    "isCached": False,
                 },
                 {
                     "name": "b2",
@@ -1157,6 +1161,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                             "uncompress": 200,
                         },
                     },
+                    "isCached": False,
                 },
                 {
                     "name": "b3",
@@ -1178,6 +1183,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                             "uncompress": 1500,
                         },
                     },
+                    "isCached": False,
                 },
                 {
                     "name": "b5",
@@ -1199,6 +1205,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                             "uncompress": 200000,
                         },
                     },
+                    "isCached": False,
                 },
             ],
             "bundleData": {
@@ -1212,6 +1219,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                 },
             },
             "bundle": None,
+            "isCached": False,
         }
 
     @patch("graphql_api.dataloader.bundle_analysis.get_appropriate_storage_service")

--- a/graphql_api/types/bundle_analysis/base.graphql
+++ b/graphql_api/types/bundle_analysis/base.graphql
@@ -70,6 +70,7 @@ type BundleReport {
     orderingDirection: OrderingDirection
     filters: BundleAnalysisMeasurementsSetFilters
   ): [BundleAnalysisMeasurements!]
+  isCached: Boolean!
 }
 
 type BundleAnalysisMeasurements{

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -188,3 +188,10 @@ def resolve_bundle_report_measurements(
         key=lambda c: c.asset_type,
         reverse=ordering_direction == OrderingDirection.DESC,
     )
+
+
+@bundle_report_bindable.field("isCached")
+def resolve_bundle_report_is_cached(
+    bundle_report: BundleReport, info: GraphQLResolveInfo
+) -> bool:
+    return bundle_report.is_cached

--- a/graphql_api/types/bundle_analysis/report.graphql
+++ b/graphql_api/types/bundle_analysis/report.graphql
@@ -6,4 +6,5 @@ type BundleAnalysisReport {
   bundles: [BundleReport]!
   bundleData: BundleData!
   bundle(name: String!, filters: BundleAnalysisReportFilters): BundleReport
+  isCached: Boolean!
 }

--- a/graphql_api/types/bundle_analysis/report.py
+++ b/graphql_api/types/bundle_analysis/report.py
@@ -78,3 +78,8 @@ def resolve_bundle_data(
     bundles_analysis_report: BundleAnalysisReport, info: GraphQLResolveInfo
 ) -> BundleData:
     return BundleData(bundles_analysis_report.size_total)
+
+
+@bundle_analysis_report_bindable.field("isCached")
+def resolve_is_cached(bundle_report: BundleReport, info: GraphQLResolveInfo) -> bool:
+    return bundle_report.is_cached

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/b679996ed9df69753d8dd24cd8e1fc3817cb6b59.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/b2cdf8166e904138eb7ad48daf5694333f3f952d.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -415,7 +415,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/b679996ed9df69753d8dd24cd8e1fc3817cb6b59.tar.gz
+shared @ https://github.com/codecov/shared/archive/b2cdf8166e904138eb7ad48daf5694333f3f952d.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -274,6 +274,10 @@ class BundleReport(object):
     def module_count(self) -> int:
         return len(self.module_extensions)
 
+    @cached_property
+    def is_cached(self) -> bool:
+        return self.report.is_cached()
+
 
 @dataclass
 class BundleAnalysisReport(object):
@@ -299,6 +303,10 @@ class BundleAnalysisReport(object):
     @cached_property
     def size_total(self) -> int:
         return sum([bundle.size_total for bundle in self.bundles])
+
+    @cached_property
+    def is_cached(self) -> bool:
+        return self.report.is_cached()
 
 
 @dataclass


### PR DESCRIPTION
closes https://github.com/codecov/engineering-team/issues/2035

Fetches whether a bundle report is cached or not (`BundleReport.isCached`) and whether if there are any reports in the bundle analysis report that is cached (`BundleAnalysisReport.isCached`)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
