### PR TITLE
bundle analysis: when no head commit fall back to report base report

### DIFF
--- a/graphql_api/types/pull/pull.py
+++ b/graphql_api/types/pull/pull.py
@@ -101,7 +101,7 @@ def resolve_bundle_analysis_compare_with_base(
             return MissingBaseCommit()
 
     # Handles a case where the PR was created without any uploads because all bundles
-    # from the build is cached. Instead of showing a "no commit error" we will instead
+    # from the build are cached. Instead of showing a "no commit error" we will instead
     # show the parent bundle report as it implies everything was cached and carried
     # over to the head commit
     head_commit_sha = pull.head if pull.head else pull.compared_to

--- a/graphql_api/types/pull/pull.py
+++ b/graphql_api/types/pull/pull.py
@@ -1,7 +1,12 @@
+from typing import Any, Optional, Union
+
 from ariadne import ObjectType
 from asgiref.sync import async_to_sync
+from graphql import GraphQLResolveInfo
 
 from codecov.db import sync_to_async
+from codecov_auth.models import Owner
+from compare.models import CommitComparison
 from core.models import Commit, Pull
 from graphql_api.actions.commits import pull_commits
 from graphql_api.actions.comparison import validate_commit_comparison
@@ -9,7 +14,7 @@ from graphql_api.dataloader.bundle_analysis import load_bundle_analysis_comparis
 from graphql_api.dataloader.commit import CommitLoader
 from graphql_api.dataloader.comparison import ComparisonLoader
 from graphql_api.dataloader.owner import OwnerLoader
-from graphql_api.helpers.connection import queryset_to_connection_sync
+from graphql_api.helpers.connection import Connection, queryset_to_connection_sync
 from graphql_api.types.comparison.comparison import (
     FirstPullRequest,
     MissingBaseCommit,
@@ -25,37 +30,39 @@ pull_bindable.set_alias("pullId", "pullid")
 
 
 @pull_bindable.field("state")
-def resolve_state(pull, info) -> PullRequestState:
+def resolve_state(pull: Pull, info: GraphQLResolveInfo) -> PullRequestState:
     return PullRequestState(pull.state)
 
 
 @pull_bindable.field("author")
-def resolve_author(pull, info):
+def resolve_author(pull: Pull, info: GraphQLResolveInfo) -> Optional[Owner]:
     if pull.author_id:
         return OwnerLoader.loader(info).load(pull.author_id)
 
 
 @pull_bindable.field("head")
-def resolve_head(pull, info):
+def resolve_head(pull: Pull, info: GraphQLResolveInfo) -> Optional[Commit]:
     if pull.head is None:
         return None
     return CommitLoader.loader(info, pull.repository_id).load(pull.head)
 
 
 @pull_bindable.field("comparedTo")
-def resolve_base(pull, info):
+def resolve_base(pull: Pull, info: GraphQLResolveInfo) -> Optional[Commit]:
     if pull.compared_to is None:
         return None
     return CommitLoader.loader(info, pull.repository_id).load(pull.compared_to)
 
 
 @sync_to_async
-def is_first_pull_request(pull: Pull):
+def is_first_pull_request(pull: Pull) -> bool:
     return pull.repository.pull_requests.order_by("id").first() == pull
 
 
 @pull_bindable.field("compareWithBase")
-async def resolve_compare_with_base(pull, info, **kwargs):
+async def resolve_compare_with_base(
+    pull: Pull, info: GraphQLResolveInfo, **kwargs: Any
+) -> Union[CommitComparison, Any]:
     if not pull.compared_to:
         if await is_first_pull_request(pull):
             return FirstPullRequest()
@@ -84,18 +91,24 @@ async def resolve_compare_with_base(pull, info, **kwargs):
 
 @pull_bindable.field("bundleAnalysisCompareWithBase")
 @sync_to_async
-def resolve_bundle_analysis_compare_with_base(pull, info, **kwargs):
+def resolve_bundle_analysis_compare_with_base(
+    pull: Pull, info: GraphQLResolveInfo, **kwargs: Any
+) -> Union[BundleAnalysisComparison, Any]:
     if not pull.compared_to:
         if pull.repository.pull_requests.order_by("id").first() == pull:
             return FirstPullRequest()
         else:
             return MissingBaseCommit()
-    if not pull.head:
-        return MissingHeadCommit()
+
+    # Handles a case where the PR was created without any uploads because all bundles
+    # from the build is cached. Instead of showing a "no commit error" we will instead
+    # show the parent bundle report as it implies everything was cached and carried
+    # over to the head commit
+    head_commit_sha = pull.head if pull.head else pull.compared_to
 
     bundle_analysis_comparison = load_bundle_analysis_comparison(
         Commit.objects.filter(commitid=pull.compared_to).first(),
-        Commit.objects.filter(commitid=pull.head).first(),
+        Commit.objects.filter(commitid=head_commit_sha).first(),
     )
 
     # Store the created SQLite DB path in info.context
@@ -117,7 +130,7 @@ def resolve_bundle_analysis_compare_with_base(pull, info, **kwargs):
 
 @pull_bindable.field("commits")
 @sync_to_async
-def resolve_commits(pull: Pull, info, **kwargs):
+def resolve_commits(pull: Pull, info: GraphQLResolveInfo, **kwargs: Any) -> Connection:
     queryset = pull_commits(pull)
 
     return queryset_to_connection_sync(
@@ -129,17 +142,19 @@ def resolve_commits(pull: Pull, info, **kwargs):
 
 
 @pull_bindable.field("behindBy")
-def resolve_behind_by(pull: Pull, info, **kwargs) -> int:
+def resolve_behind_by(pull: Pull, info: GraphQLResolveInfo, **kwargs: Any) -> int:
     return pull.behind_by
 
 
 @pull_bindable.field("behindByCommit")
-def resolve_behind_by_commit(pull: Pull, info, **kwargs) -> str:
+def resolve_behind_by_commit(
+    pull: Pull, info: GraphQLResolveInfo, **kwargs: Any
+) -> str:
     return pull.behind_by_commit
 
 
 @pull_bindable.field("firstPull")
 @sync_to_async
-def resolve_first_pull(pull: Pull, info) -> bool:
+def resolve_first_pull(pull: Pull, info: GraphQLResolveInfo) -> bool:
     # returns true if this pull is/was the 1st for a repo
     return pull.repository.pull_requests.order_by("id").first() == pull


### PR DESCRIPTION
closes: https://github.com/codecov/engineering-team/issues/2040

Handles a case where the PR was created without any uploads because all bundles from the build is cached. Instead of showing a "no commit error" we will instead show the parent bundle report as it implies everything was cached and carried over to the head commit.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
