### PR TITLE
[Okta Login] Part 1: Refactoring existing Okta code

### DIFF
--- a/codecov_auth/tests/unit/views/test_okta.py
+++ b/codecov_auth/tests/unit/views/test_okta.py
@@ -1,7 +1,3 @@
-from http.cookies import SimpleCookie
-from unittest.mock import MagicMock, patch
-
-import jwt
 import pytest
 from django.conf import settings
 from django.contrib import auth
@@ -10,14 +6,13 @@ from django.urls import reverse
 
 from codecov_auth.models import OktaUser
 from codecov_auth.tests.factories import OktaUserFactory, OwnerFactory, UserFactory
-from codecov_auth.views.okta import OktaLoginView, validate_id_token
-from codecov_auth.views.okta import auth as okta_basic_auth
+from codecov_auth.views.okta import OKTA_BASIC_AUTH
 
 
 @pytest.fixture
 def mocked_okta_token_request(mocker):
     return mocker.patch(
-        "codecov_auth.views.okta.requests.post",
+        "codecov_auth.views.okta_mixin.requests.post",
         return_value=mocker.MagicMock(
             status_code=200,
             json=mocker.MagicMock(
@@ -55,91 +50,6 @@ cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
 mwIDAQAB
 -----END PUBLIC KEY-----
 """
-private_key = """-----BEGIN PRIVATE KEY-----
-MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC7VJTUt9Us8cKj
-MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
-NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
-qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg
-p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
-ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi
-VuNd9tybAgMBAAECggEBAKTmjaS6tkK8BlPXClTQ2vpz/N6uxDeS35mXpqasqskV
-laAidgg/sWqpjXDbXr93otIMLlWsM+X0CqMDgSXKejLS2jx4GDjI1ZTXg++0AMJ8
-sJ74pWzVDOfmCEQ/7wXs3+cbnXhKriO8Z036q92Qc1+N87SI38nkGa0ABH9CN83H
-mQqt4fB7UdHzuIRe/me2PGhIq5ZBzj6h3BpoPGzEP+x3l9YmK8t/1cN0pqI+dQwY
-dgfGjackLu/2qH80MCF7IyQaseZUOJyKrCLtSD/Iixv/hzDEUPfOCjFDgTpzf3cw
-ta8+oE4wHCo1iI1/4TlPkwmXx4qSXtmw4aQPz7IDQvECgYEA8KNThCO2gsC2I9PQ
-DM/8Cw0O983WCDY+oi+7JPiNAJwv5DYBqEZB1QYdj06YD16XlC/HAZMsMku1na2T
-N0driwenQQWzoev3g2S7gRDoS/FCJSI3jJ+kjgtaA7Qmzlgk1TxODN+G1H91HW7t
-0l7VnL27IWyYo2qRRK3jzxqUiPUCgYEAx0oQs2reBQGMVZnApD1jeq7n4MvNLcPv
-t8b/eU9iUv6Y4Mj0Suo/AU8lYZXm8ubbqAlwz2VSVunD2tOplHyMUrtCtObAfVDU
-AhCndKaA9gApgfb3xw1IKbuQ1u4IF1FJl3VtumfQn//LiH1B3rXhcdyo3/vIttEk
-48RakUKClU8CgYEAzV7W3COOlDDcQd935DdtKBFRAPRPAlspQUnzMi5eSHMD/ISL
-DY5IiQHbIH83D4bvXq0X7qQoSBSNP7Dvv3HYuqMhf0DaegrlBuJllFVVq9qPVRnK
-xt1Il2HgxOBvbhOT+9in1BzA+YJ99UzC85O0Qz06A+CmtHEy4aZ2kj5hHjECgYEA
-mNS4+A8Fkss8Js1RieK2LniBxMgmYml3pfVLKGnzmng7H2+cwPLhPIzIuwytXywh
-2bzbsYEfYx3EoEVgMEpPhoarQnYPukrJO4gwE2o5Te6T5mJSZGlQJQj9q4ZB2Dfz
-et6INsK0oG8XVGXSpQvQh3RUYekCZQkBBFcpqWpbIEsCgYAnM3DQf3FJoSnXaMhr
-VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD
-TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc
-dn/RsYEONbwQSjIfMPkvxF+8HQ==
------END PRIVATE KEY-----
-"""
-
-
-@override_settings(
-    OKTA_OAUTH_CLIENT_ID="test-client-id",
-)
-def test_validate_id_token(mocker):
-    data = {
-        "sub": "test-okta-id",
-        "name": "Some User",
-        "email": "test@example.com",
-        "iss": "https://example.okta.com",
-        "aud": "test-client-id",
-    }
-    id_token = jwt.encode(
-        data, private_key, algorithm="RS256", headers={"kid": "test-kid"}
-    )
-
-    # did this offline so as not to need an additional dependency - here's the code
-    # if we ever need to regenerate this:
-    #
-    # from Crypto.PublicKey import RSA
-    # import base64
-    # pub = RSA.importKey(public_key)
-    # modulus = base64.b64encode(pub.n.to_bytes(256, "big")).decode("ascii")
-    # exponent = base64.b64encode(pub.e.to_bytes(3, "big")).decode("ascii")
-
-    exponent = "AQAB"
-    modulus = "u1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmw=="
-
-    get_keys = mocker.patch(
-        "codecov_auth.views.okta.requests.get",
-        return_value=mocker.MagicMock(
-            status_code=200,
-            json=mocker.MagicMock(
-                return_value={
-                    "keys": [
-                        {
-                            "kty": "RSA",
-                            "alg": "RS256",
-                            "kid": "test-kid",
-                            "use": "sig",
-                            "e": exponent,
-                            "n": modulus,
-                        }
-                    ]
-                }
-            ),
-        ),
-    )
-
-    id_payload = validate_id_token(iss="https://example.okta.com", id_token=id_token)
-    assert id_payload["sub"] == "test-okta-id"
-    assert id_payload["name"] == "Some User"
-    assert id_payload["email"] == "test@example.com"
-
-    get_keys.assert_called_once_with("https://example.okta.com/oauth2/v1/keys")
 
 
 @override_settings(
@@ -188,7 +98,7 @@ def test_okta_redirect_to_authorize_invalid_iss(client):
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
 def test_okta_perform_login(
@@ -209,7 +119,7 @@ def test_okta_perform_login(
 
     mocked_okta_token_request.assert_called_once_with(
         "https://example.okta.com/oauth2/v1/token",
-        auth=okta_basic_auth,
+        auth=OKTA_BASIC_AUTH,
         data={
             "grant_type": "authorization_code",
             "code": "test-code",
@@ -219,8 +129,7 @@ def test_okta_perform_login(
     )
 
     mocked_validate_id_token.assert_called_once_with(
-        "https://example.okta.com",
-        "test-id-token",
+        "https://example.okta.com", "test-id-token", "test-client-id"
     )
 
     assert res.status_code == 302
@@ -243,7 +152,7 @@ def test_okta_perform_login(
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
 def test_okta_perform_login_authenticated(
@@ -282,7 +191,7 @@ def test_okta_perform_login_authenticated(
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
 def test_okta_perform_login_existing_okta_user(
@@ -313,7 +222,7 @@ def test_okta_perform_login_existing_okta_user(
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
 def test_okta_perform_login_authenticated_existing_okta_user(
@@ -347,11 +256,12 @@ def test_okta_perform_login_authenticated_existing_okta_user(
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
+@pytest.mark.django_db
 def test_okta_perform_login_existing_okta_user_existing_owner(
-    client, mocked_okta_token_request, mocked_validate_id_token, db
+    client, mocked_okta_token_request, mocked_validate_id_token
 ):
     okta_user = OktaUserFactory(okta_id="test-id")
     OwnerFactory(service="github", user=okta_user.user)
@@ -380,12 +290,12 @@ def test_okta_perform_login_existing_okta_user_existing_owner(
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
 def test_okta_perform_login_error(client, mocker, db):
     mocker.patch(
-        "codecov_auth.views.okta.requests.post",
+        "codecov_auth.views.okta_mixin.requests.post",
         return_value=mocker.MagicMock(
             status_code=401,
         ),
@@ -409,7 +319,7 @@ def test_okta_perform_login_error(client, mocker, db):
 
 @override_settings(
     OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
+    OKTA_OAUTH_CLIENT_SECRET="test-client-secret",
     OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
 )
 def test_okta_perform_login_state_mismatch(client, mocker, db):
@@ -427,25 +337,3 @@ def test_okta_perform_login_state_mismatch(client, mocker, db):
     # does not login user
     current_user = auth.get_user(client)
     assert current_user.is_anonymous
-
-
-@override_settings(
-    OKTA_OAUTH_CLIENT_ID="test-client-id",
-    OKTA_OAUTH_CLIENT_SECRE="test-client-secret",
-    OKTA_OAUTH_REDIRECT_URL="https://localhost:8000/login/okta",
-)
-def test_okta_fetch_user_data_invalid_state(client, db):
-    with patch("codecov_auth.views.okta.requests.post") as mock_post:
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_post.return_value = mock_response
-
-        with patch.object(OktaLoginView, "verify_state", return_value=False):
-            view = OktaLoginView()
-            res = view._fetch_user_data(
-                "https://example.okta.com",
-                "test-code",
-                "invalid-state",
-            )
-
-    assert res is None

--- a/codecov_auth/tests/unit/views/test_okta.py
+++ b/codecov_auth/tests/unit/views/test_okta.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from codecov_auth.models import OktaUser
 from codecov_auth.tests.factories import OktaUserFactory, OwnerFactory, UserFactory
 from codecov_auth.views.okta import OKTA_BASIC_AUTH
+from codecov_auth.views.okta_mixin import OktaIdTokenPayload
 
 
 @pytest.fixture
@@ -21,7 +22,7 @@ def mocked_okta_token_request(mocker):
                     "refresh_token": "test-refresh-token",
                     "id_token": "test-id-token",
                     "state": "test-state",
-                }
+                },
             ),
         ),
     )
@@ -31,11 +32,13 @@ def mocked_okta_token_request(mocker):
 def mocked_validate_id_token(mocker):
     return mocker.patch(
         "codecov_auth.views.okta.validate_id_token",
-        return_value={
-            "sub": "test-id",
-            "email": "test@example.com",
-            "name": "Some User",
-        },
+        return_value=OktaIdTokenPayload(
+            sub="test-id",
+            email="test@example.com",
+            name="Some User",
+            iss="https://example.com",
+            aud="test-client-id",
+        ),
     )
 
 

--- a/codecov_auth/tests/unit/views/test_okta_mixin.py
+++ b/codecov_auth/tests/unit/views/test_okta_mixin.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock, patch
+
+import jwt
+
+from codecov_auth.views.okta import OKTA_BASIC_AUTH, OktaEnterpriseLoginView
+from codecov_auth.views.okta_mixin import validate_id_token
+
+private_key = """-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC7VJTUt9Us8cKj
+MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
+NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
+qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg
+p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
+ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi
+VuNd9tybAgMBAAECggEBAKTmjaS6tkK8BlPXClTQ2vpz/N6uxDeS35mXpqasqskV
+laAidgg/sWqpjXDbXr93otIMLlWsM+X0CqMDgSXKejLS2jx4GDjI1ZTXg++0AMJ8
+sJ74pWzVDOfmCEQ/7wXs3+cbnXhKriO8Z036q92Qc1+N87SI38nkGa0ABH9CN83H
+mQqt4fB7UdHzuIRe/me2PGhIq5ZBzj6h3BpoPGzEP+x3l9YmK8t/1cN0pqI+dQwY
+dgfGjackLu/2qH80MCF7IyQaseZUOJyKrCLtSD/Iixv/hzDEUPfOCjFDgTpzf3cw
+ta8+oE4wHCo1iI1/4TlPkwmXx4qSXtmw4aQPz7IDQvECgYEA8KNThCO2gsC2I9PQ
+DM/8Cw0O983WCDY+oi+7JPiNAJwv5DYBqEZB1QYdj06YD16XlC/HAZMsMku1na2T
+N0driwenQQWzoev3g2S7gRDoS/FCJSI3jJ+kjgtaA7Qmzlgk1TxODN+G1H91HW7t
+0l7VnL27IWyYo2qRRK3jzxqUiPUCgYEAx0oQs2reBQGMVZnApD1jeq7n4MvNLcPv
+t8b/eU9iUv6Y4Mj0Suo/AU8lYZXm8ubbqAlwz2VSVunD2tOplHyMUrtCtObAfVDU
+AhCndKaA9gApgfb3xw1IKbuQ1u4IF1FJl3VtumfQn//LiH1B3rXhcdyo3/vIttEk
+48RakUKClU8CgYEAzV7W3COOlDDcQd935DdtKBFRAPRPAlspQUnzMi5eSHMD/ISL
+DY5IiQHbIH83D4bvXq0X7qQoSBSNP7Dvv3HYuqMhf0DaegrlBuJllFVVq9qPVRnK
+xt1Il2HgxOBvbhOT+9in1BzA+YJ99UzC85O0Qz06A+CmtHEy4aZ2kj5hHjECgYEA
+mNS4+A8Fkss8Js1RieK2LniBxMgmYml3pfVLKGnzmng7H2+cwPLhPIzIuwytXywh
+2bzbsYEfYx3EoEVgMEpPhoarQnYPukrJO4gwE2o5Te6T5mJSZGlQJQj9q4ZB2Dfz
+et6INsK0oG8XVGXSpQvQh3RUYekCZQkBBFcpqWpbIEsCgYAnM3DQf3FJoSnXaMhr
+VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD
+TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc
+dn/RsYEONbwQSjIfMPkvxF+8HQ==
+-----END PRIVATE KEY-----
+"""
+
+
+def test_validate_id_token(mocker):
+    data = {
+        "sub": "test-okta-id",
+        "name": "Some User",
+        "email": "test@example.com",
+        "iss": "https://example.okta.com",
+        "aud": "test-client-id",
+    }
+    id_token = jwt.encode(
+        data, private_key, algorithm="RS256", headers={"kid": "test-kid"}
+    )
+
+    # did this offline so as not to need an additional dependency - here's the code
+    # if we ever need to regenerate this:
+    #
+    # from Crypto.PublicKey import RSA
+    # import base64
+    # pub = RSA.importKey(public_key)
+    # modulus = base64.b64encode(pub.n.to_bytes(256, "big")).decode("ascii")
+    # exponent = base64.b64encode(pub.e.to_bytes(3, "big")).decode("ascii")
+
+    exponent = "AQAB"
+    modulus = "u1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmw=="
+
+    get_keys = mocker.patch(
+        "codecov_auth.views.okta_mixin.requests.get",
+        return_value=mocker.MagicMock(
+            status_code=200,
+            json=mocker.MagicMock(
+                return_value={
+                    "keys": [
+                        {
+                            "kty": "RSA",
+                            "alg": "RS256",
+                            "kid": "test-kid",
+                            "use": "sig",
+                            "e": exponent,
+                            "n": modulus,
+                        }
+                    ]
+                }
+            ),
+        ),
+    )
+
+    id_payload = validate_id_token(
+        iss="https://example.okta.com", id_token=id_token, client_id="test-client-id"
+    )
+    assert id_payload.sub == "test-okta-id"
+    assert id_payload.name == "Some User"
+    assert id_payload.email == "test@example.com"
+
+    get_keys.assert_called_once_with("https://example.okta.com/oauth2/v1/keys")
+
+
+def test_okta_fetch_user_data_invalid_state(client, db):
+    with patch("codecov_auth.views.okta_mixin.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        with patch.object(OktaEnterpriseLoginView, "verify_state", return_value=False):
+            view = OktaEnterpriseLoginView()
+            res = view._fetch_user_data(
+                "https://example.okta.com",
+                "test-code",
+                "invalid-state",
+                "https://localhost:8000/login/okta",
+                OKTA_BASIC_AUTH,
+            )
+
+    assert res is None

--- a/codecov_auth/tests/unit/views/test_okta_mixin.py
+++ b/codecov_auth/tests/unit/views/test_okta_mixin.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import jwt
 
-from codecov_auth.views.okta import OKTA_BASIC_AUTH, OktaEnterpriseLoginView
+from codecov_auth.views.okta import OKTA_BASIC_AUTH, OktaLoginView
 from codecov_auth.views.okta_mixin import validate_id_token
 
 private_key = """-----BEGIN PRIVATE KEY-----
@@ -97,8 +97,8 @@ def test_okta_fetch_user_data_invalid_state(client, db):
         mock_response.status_code = 200
         mock_post.return_value = mock_response
 
-        with patch.object(OktaEnterpriseLoginView, "verify_state", return_value=False):
-            view = OktaEnterpriseLoginView()
+        with patch.object(OktaLoginView, "verify_state", return_value=False):
+            view = OktaLoginView()
             res = view._fetch_user_data(
                 "https://example.okta.com",
                 "test-code",

--- a/codecov_auth/views/okta_mixin.py
+++ b/codecov_auth/views/okta_mixin.py
@@ -4,6 +4,7 @@ import re
 from urllib.parse import urlencode
 
 import jwt
+import pydantic
 import requests
 from django.http import HttpResponse
 from django.shortcuts import redirect
@@ -16,7 +17,30 @@ log = logging.getLogger(__name__)
 ISS_REGEX = re.compile(r"https://[\w\d\-\_]+.okta.com/?")
 
 
-def validate_id_token(iss: str, id_token: str, client_id: str) -> dict[str, str]:
+class OktaTokenResponse(pydantic.BaseModel):
+    """This model serializes the response from Okta's oauth/v1/token endpoint.
+    ref: https://developer.okta.com/docs/reference/api/oidc/#token
+
+    Keeping reference to only the fields that are used.
+    """
+
+    access_token: str
+    id_token: str  # this will be present since we requested the `oidc` scope
+
+
+class OktaIdTokenPayload(pydantic.BaseModel):
+    """Serializes the ID Payload from Okta's id_token deserialization.
+    ref: https://developer.okta.com/docs/reference/api/oidc/#id-token
+    """
+
+    aud: str
+    iss: str
+    sub: str
+    email: str
+    name: str
+
+
+def validate_id_token(iss: str, id_token: str, client_id: str) -> OktaIdTokenPayload:
     res = requests.get(f"{iss}/oauth2/v1/keys")
     jwks = res.json()
 
@@ -34,10 +58,11 @@ def validate_id_token(iss: str, id_token: str, client_id: str) -> dict[str, str]
         algorithms=["RS256"],
         audience=client_id,
     )
-    assert id_payload["iss"] == iss
-    assert id_payload["aud"] == client_id
+    id_token_payload = OktaIdTokenPayload(**id_payload)
+    assert id_token_payload.iss == iss
+    assert id_token_payload.aud == client_id
 
-    return id_payload
+    return id_token_payload
 
 
 class OktaLoginMixin(StateMixin):
@@ -48,7 +73,7 @@ class OktaLoginMixin(StateMixin):
         state: str,
         redirect_url: str,
         auth: HTTPBasicAuth,
-    ) -> dict | None:
+    ) -> OktaTokenResponse | None:
         res = requests.post(
             f"{iss}/oauth2/v1/token",
             auth=auth,
@@ -66,7 +91,8 @@ class OktaLoginMixin(StateMixin):
 
         if res.status_code >= 400:
             return None
-        return res.json()
+
+        return OktaTokenResponse(**res.json())
 
     def _redirect_to_consent(
         self, iss: str, client_id: str, oauth_redirect_url: str
@@ -83,6 +109,4 @@ class OktaLoginMixin(StateMixin):
         )
         redirect_url = f"{iss}/oauth2/v1/authorize?{qs}"
         response = redirect(redirect_url)
-        self.store_to_cookie_utm_tags(response)
-
         return response

--- a/codecov_auth/views/okta_mixin.py
+++ b/codecov_auth/views/okta_mixin.py
@@ -1,0 +1,88 @@
+import json
+import logging
+import re
+from urllib.parse import urlencode
+
+import jwt
+import requests
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from requests.auth import HTTPBasicAuth
+
+from codecov_auth.views.base import StateMixin
+
+log = logging.getLogger(__name__)
+
+ISS_REGEX = re.compile(r"https://[\w\d\-\_]+.okta.com/?")
+
+
+def validate_id_token(iss: str, id_token: str, client_id: str) -> dict[str, str]:
+    res = requests.get(f"{iss}/oauth2/v1/keys")
+    jwks = res.json()
+
+    public_keys = {}
+    for jwk in jwks["keys"]:
+        kid = jwk["kid"]
+        public_keys[kid] = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+
+    kid = jwt.get_unverified_header(id_token)["kid"]
+    key = public_keys[kid]
+
+    id_payload = jwt.decode(
+        id_token,
+        key=key,
+        algorithms=["RS256"],
+        audience=client_id,
+    )
+    assert id_payload["iss"] == iss
+    assert id_payload["aud"] == client_id
+
+    return id_payload
+
+
+class OktaLoginMixin(StateMixin):
+    def _fetch_user_data(
+        self,
+        iss: str,
+        code: str,
+        state: str,
+        redirect_url: str,
+        auth: HTTPBasicAuth,
+    ) -> dict | None:
+        res = requests.post(
+            f"{iss}/oauth2/v1/token",
+            auth=auth,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_url,
+                "state": state,
+            },
+        )
+
+        if not self.verify_state(state):
+            log.warning("Invalid state during Okta OAuth")
+            return None
+
+        if res.status_code >= 400:
+            return None
+        return res.json()
+
+    def _redirect_to_consent(
+        self, iss: str, client_id: str, oauth_redirect_url: str
+    ) -> HttpResponse:
+        state = self.generate_state()
+        qs = urlencode(
+            dict(
+                response_type="code",
+                client_id=client_id,
+                scope="openid email profile",
+                redirect_uri=oauth_redirect_url,
+                state=state,
+            )
+        )
+        redirect_url = f"{iss}/oauth2/v1/authorize?{qs}"
+        response = redirect(redirect_url)
+        self.store_to_cookie_utm_tags(response)
+
+        return response

--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,7 @@ opentracing
 pre-commit
 psycopg2
 PyJWT
+pydantic
 pytest>=7.2.0
 pytest-cov
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ amqp==5.2.0
     # via kombu
 analytics-python==1.3.0b1
     # via shared
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.6.1
     # via
     #   httpcore
@@ -175,7 +177,6 @@ freezegun==1.1.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-storage
@@ -334,6 +335,10 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.20
     # via cffi
+pydantic==2.8.2
+    # via -r requirements.in
+pydantic-core==2.20.1
+    # via pydantic
 pyjwt==2.8.0
     # via
     #   -r requirements.in
@@ -402,9 +407,7 @@ requests==2.32.3
     #   shared
     #   stripe
 rfc3986[idna2008]==1.4.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -463,6 +466,8 @@ typing-extensions==4.6.2
     #   ariadne
     #   ddtrace
     #   opentelemetry-sdk
+    #   pydantic
+    #   pydantic-core
     #   shared
     #   stripe
 tzdata==2024.1


### PR DESCRIPTION
### Purpose/Motivation
Refactoring this so that it is more easily shared. Split this from [part 2](https://github.com/codecov/codecov-api/pull/685) to make reviewing both parts easier. See Part 2 for more context in how this refactor will be used.

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1988

### What does this PR do?
This moves some of the shared code that will be common in all Okta implementations to a new `mixin` that can be shared across both Views. 

### Notes to Reviewer
* I added Pydantic to better type check the responses coming from Okta (and better document what is in the responses).

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
