### PR TITLE
bundle analysis: fix module count computation

### DIFF
--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -1301,7 +1301,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
         asset_report = bundle_report["asset"]
 
         assert bundle_report is not None
-        assert bundle_report["moduleCount"] == 7
+        assert bundle_report["moduleCount"] == 33
 
         assert asset_report is not None
         assert asset_report["name"] == "assets/LazyComponent-fcbb0922.js"

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -272,7 +272,7 @@ class BundleReport(object):
 
     @cached_property
     def module_count(self) -> int:
-        return len(self.module_extensions)
+        return sum([len(asset.modules) for asset in self.assets()])
 
     @cached_property
     def is_cached(self) -> bool:


### PR DESCRIPTION
closes https://github.com/codecov/engineering-team/issues/1925

Returns count of number of modules of a bundle report with filtering applied.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
