### PR TITLE
Pin setuptools to a version that works

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ FROM us-docker.pkg.dev/berglas/berglas/berglas:$BERGLAS_VERSION as berglas
 FROM $REQUIREMENTS_IMAGE as app
 COPY . /app
 WORKDIR /app
+RUN pip install setuptools==70.3.0
 RUN python manage.py collectstatic --no-input
 
 FROM app as local


### PR DESCRIPTION
`setuptools` was updated today and the new version is causing problems with our build process. Pinning this to an older version for now.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
