### PR TITLE
add action to link users to accounts

### DIFF
--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -352,7 +352,9 @@ class AccountAdmin(AdminMixin, admin.ModelAdmin):
             )
             userless_owners = []
             for userless_owner in owners_without_user_objects:
-                new_user = User.objects.create()
+                new_user = User.objects.create(
+                    name=userless_owner.name, email=userless_owner.email
+                )
                 userless_owner.user = new_user
                 userless_owners.append(userless_owner)
             total = Owner.objects.bulk_update(userless_owners, ["user"])

--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -1,4 +1,3 @@
-from gettext import gettext, ngettext
 from typing import Optional
 
 import django.forms as forms
@@ -294,7 +293,7 @@ class OwnerOrgInline(admin.TabularInline):
 
 @admin.register(Account)
 class AccountAdmin(AdminMixin, admin.ModelAdmin):
-    list_display = ("name", "is_active")
+    list_display = ("name", "is_active", "organizations_count", "all_user_count")
     search_fields = ("name__iregex", "id")
     search_help_text = "Search by name (can use regex), or id (exact)"
     inlines = [OwnerOrgInline, StripeBillingInline, InvoiceBillingInline]


### PR DESCRIPTION
### Purpose/Motivation
Gives us a method to do the initial setup when an Account is created. This action will create the link between the Account object and the User object for any Owner who is a `plan_activated_user` on any of the Organizations linked to the Account.

Can be run multiple times safely (in case it errors or times out)
Won't do the link if the Account doesn't have enough seats

For "auditing" its behavior - it gives messages about how many Users and AccountUsers were created. You can see the Users linked to the Account on the Account edit page (when you click into an Account on the admin). You can remove a AccountUsers connection on the User admin page.

### Links to relevant tickets
Uses https://github.com/codecov/shared/pull/295
part of https://github.com/codecov/engineering-team/issues/2058
