### PR TITLE
feat: Expose delinquent status on owner in gql

### DIFF
--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -83,7 +83,7 @@ class StripeWebhookHandlerTests(APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_invoice_payment_succeeded_sets_owner_delinquent_false(self):
-        self.owner.deliquent = True
+        self.owner.delinquent = True
         self.owner.save()
 
         response = self._send_event(

--- a/billing/views.py
+++ b/billing/views.py
@@ -49,7 +49,7 @@ class StripeWebhookHandler(APIView):
 
     def invoice_payment_failed(self, invoice: stripe.Invoice) -> None:
         log.info(
-            "Invoice Payment Failed - Setting Deliquency status True",
+            "Invoice Payment Failed - Setting Delinquency status True",
             extra=dict(
                 stripe_customer_id=invoice.customer,
                 stripe_subscription_id=invoice.subscription,

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -26,6 +26,7 @@ from .helper import GraphQLTestHelper, paginate_connection
 
 query_repositories = """{
     owner(username: "%s") {
+        delinquent
         orgUploadToken
         ownerid
         isCurrentUserPartOfOrg
@@ -88,6 +89,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(query, owner=self.owner)
         assert data == {
             "owner": {
+                "delinquent": None,
                 "orgUploadToken": None,
                 "ownerid": self.owner.ownerid,
                 "isCurrentUserPartOfOrg": True,
@@ -362,6 +364,11 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         query = query_repositories % (self.owner.username, "", "")
         data = self.gql_request(query, owner=self.owner)
         assert data["owner"]["ownerid"] == self.owner.ownerid
+
+    def test_delinquent(self):
+        query = query_repositories % (self.owner.username, "", "")
+        data = self.gql_request(query, owner=self.owner)
+        assert data["owner"]["delinquent"] == self.owner.delinquent
 
     @patch("codecov_auth.commands.owner.owner.OwnerCommands.get_org_upload_token")
     def test_get_org_upload_token(self, mocker):

--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -1,9 +1,30 @@
 type Owner {
   account: Account
+  availablePlans: [PlanRepresentation!]
   avatarUrl: String!
-  username: String
+  defaultOrgUsername: String
+  delinquent: Boolean
+  hashOwnerid: String
+  hasPrivateRepos: Boolean
+  invoice(invoiceId: String!): Invoice
+  invoices: [Invoice] @cost(complexity: 100)
+  isAdmin: Boolean
+  isCurrentUserActivated: Boolean
   isCurrentUserPartOfOrg: Boolean!
-  yaml: String
+  isGithubRateLimited: Boolean
+  measurements(
+    interval: MeasurementInterval!
+    after: DateTime
+    before: DateTime
+    repos: [String!]
+    isPublic: Boolean
+  ): [Measurement!]
+  numberOfUploads: Int
+  orgUploadToken: String
+  ownerid: Int
+  plan: Plan
+  pretrialPlan: PlanRepresentation
+  repository(name: String!): RepositoryResult!
   repositories(
     filters: RepositorySetFilters
     ordering: RepositoryOrdering
@@ -13,26 +34,6 @@ type Owner {
     last: Int
     before: String
   ): RepositoryConnection! @cost(complexity: 25, multipliers: ["first", "last"])
-  repository(name: String!): RepositoryResult!
-  numberOfUploads: Int
-  hasPrivateRepos: Boolean
-  isAdmin: Boolean
-  hashOwnerid: String
-  ownerid: Int
-  plan: Plan
-  pretrialPlan: PlanRepresentation
-  availablePlans: [PlanRepresentation!]
-  orgUploadToken: String
-  defaultOrgUsername: String
-  isCurrentUserActivated: Boolean
-  measurements(
-    interval: MeasurementInterval!
-    after: DateTime
-    before: DateTime
-    repos: [String!]
-    isPublic: Boolean
-  ): [Measurement!]
-  invoices: [Invoice] @cost(complexity: 100)
-  invoice(invoiceId: String!): Invoice
-  isGithubRateLimited: Boolean
+  username: String
+  yaml: String
 }

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -43,7 +43,7 @@ owner_bindable = ObjectType("Owner")
 @owner_bindable.field("repositories")
 @convert_kwargs_to_snake_case
 def resolve_repositories(
-    owner,
+    owner: Owner,
     info,
     filters=None,
     ordering=RepositoryOrdering.ID,
@@ -68,7 +68,7 @@ def resolve_is_current_user_part_of_org(owner, info):
 
 
 @owner_bindable.field("yaml")
-def resolve_yaml(owner, info):
+def resolve_yaml(owner: Owner, info):
     if owner.yaml is None:
         return
     current_owner = info.context["request"].current_owner
@@ -110,12 +110,12 @@ def resolve_has_private_repos(owner: Owner, info) -> List[PlanData]:
 
 @owner_bindable.field("ownerid")
 @require_part_of_org
-def resolve_ownerid(owner, info) -> int:
+def resolve_ownerid(owner: Owner, info) -> int:
     return owner.ownerid
 
 
 @owner_bindable.field("repository")
-async def resolve_repository(owner, info, name):
+async def resolve_repository(owner: Owner, info, name):
     command = info.context["executor"].get_command("repository")
     repository: Optional[Repository] = await command.fetch_repository(owner, name)
 
@@ -141,14 +141,14 @@ async def resolve_repository(owner, info, name):
 
 @owner_bindable.field("numberOfUploads")
 @require_part_of_org
-async def resolve_number_of_uploads(owner, info, **kwargs):
+async def resolve_number_of_uploads(owner: Owner, info, **kwargs):
     command = info.context["executor"].get_command("owner")
     return await command.get_uploads_number_per_user(owner)
 
 
 @owner_bindable.field("isAdmin")
 @require_part_of_org
-def resolve_is_current_user_an_admin(owner, info):
+def resolve_is_current_user_an_admin(owner: Owner, info):
     current_owner = info.context["request"].current_owner
     command = info.context["executor"].get_command("owner")
     return command.get_is_current_user_an_admin(owner, current_owner)
@@ -156,14 +156,14 @@ def resolve_is_current_user_an_admin(owner, info):
 
 @owner_bindable.field("hashOwnerid")
 @require_part_of_org
-def resolve_hash_ownerid(owner, info):
+def resolve_hash_ownerid(owner: Owner, info):
     hash_ownerid = sha1(str(owner.ownerid).encode())
     return hash_ownerid.hexdigest()
 
 
 @owner_bindable.field("orgUploadToken")
 @require_part_of_org
-def resolve_org_upload_token(owner, info, **kwargs):
+def resolve_org_upload_token(owner: Owner, info, **kwargs):
     command = info.context["executor"].get_command("owner")
     return command.get_org_upload_token(owner)
 
@@ -215,7 +215,7 @@ def resolve_measurements(
 
 @owner_bindable.field("isCurrentUserActivated")
 @sync_to_async
-def resolve_is_current_user_activated(owner, info):
+def resolve_is_current_user_activated(owner: Owner, info):
     current_user = info.context["request"].user
     if not current_user.is_authenticated:
         return False

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -272,3 +272,9 @@ def resolve_owner_invoice(
 def resolve_owner_account(owner: Owner, info) -> dict:
     account_id = owner.account_id
     return Account.objects.filter(pk=account_id).first()
+
+
+@owner_bindable.field("delinquent")
+@require_part_of_org
+def resolve_delinquent(owner: Owner, info) -> bool | None:
+    return owner.delinquent

--- a/requirements.txt
+++ b/requirements.txt
@@ -175,7 +175,6 @@ freezegun==1.1.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-storage
@@ -402,9 +401,7 @@ requests==2.32.3
     #   shared
     #   stripe
 rfc3986[idna2008]==1.4.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0


### PR DESCRIPTION
### Purpose/Motivation

Part of billing updates, https://github.com/codecov/engineering-team/issues/1814, to better show users who are currently in delinquency status, need to expose this model property in GQL to show on gazebo via query.

Also fixes a couple typos (including one on a test lol) of the word "delinquent"

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
