### PR TITLE
Adjust the metrics to better match/represent shelter calls

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -781,13 +781,25 @@ def get_version_from_headers(headers):
 
 
 def generate_upload_sentry_metrics_tags(
-    action, request, repository, is_shelter_request, endpoint: Optional[str] = None
+    action,
+    request,
+    is_shelter_request,
+    endpoint: Optional[str] = None,
+    repository: Optional[Repository] = None,
+    position: Optional[str] = None,
 ):
-    return dict(
+    metrics_tags = dict(
         agent=get_agent_from_headers(request.headers),
         version=get_version_from_headers(request.headers),
         action=action,
         endpoint=endpoint,
-        repo_visibility="private" if repository.private is True else "public",
         is_using_shelter="yes" if is_shelter_request else "no",
     )
+    if repository:
+        metrics_tags["repo_visibility"] = (
+            "private" if repository.private is True else "public"
+        )
+    if position:
+        metrics_tags["position"] = position
+
+    return metrics_tags

--- a/upload/tests/views/test_commits.py
+++ b/upload/tests/views/test_commits.py
@@ -309,7 +309,7 @@ def test_commit_github_oidc_auth(mock_jwks_client, mock_jwt_decode, db, mocker):
     assert expected_response == response_json
     mocked_call.assert_called_with(commitid="commit_sha", repoid=repository.repoid)
     mock_sentry_metrics.assert_called_with(
-        "upload_end",
+        "upload",
         tags={
             "agent": "cli",
             "version": "0.4.7",
@@ -317,5 +317,6 @@ def test_commit_github_oidc_auth(mock_jwks_client, mock_jwt_decode, db, mocker):
             "endpoint": "create_commit",
             "repo_visibility": "public",
             "is_using_shelter": "no",
+            "position": "end",
         },
     )

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -303,7 +303,7 @@ def test_reports_results_post_successful_github_oidc_auth(
     ).exists()
     mocked_task.assert_called_once()
     mock_sentry_metrics.assert_called_with(
-        "upload_end",
+        "upload",
         tags={
             "agent": "cli",
             "version": "0.4.7",
@@ -311,6 +311,7 @@ def test_reports_results_post_successful_github_oidc_auth(
             "endpoint": "create_report_results",
             "repo_visibility": "private",
             "is_using_shelter": "no",
+            "position": "end",
         },
     )
 

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -72,6 +72,7 @@ def test_reports_post(client, db, mocker):
             "endpoint": "create_report",
             "repo_visibility": "private",
             "is_using_shelter": "no",
+            "position": "end",
         },
     )
 
@@ -311,7 +312,6 @@ def test_reports_results_post_successful_github_oidc_auth(
             "endpoint": "create_report_results",
             "repo_visibility": "private",
             "is_using_shelter": "no",
-            "position": "end",
         },
     )
 

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -609,7 +609,7 @@ def test_uploads_post_shelter(db, mocker, mock_redis):
     )
 
     mock_sentry_metrics.assert_called_with(
-        "upload_end",
+        "upload",
         tags={
             "agent": "cli",
             "version": "0.4.7",
@@ -617,6 +617,7 @@ def test_uploads_post_shelter(db, mocker, mock_redis):
             "endpoint": "create_upload",
             "repo_visibility": "private",
             "is_using_shelter": "yes",
+            "position": "end",
         },
     )
 

--- a/upload/views/commits.py
+++ b/upload/views/commits.py
@@ -52,15 +52,17 @@ class CommitViews(ListCreateAPIView, GetterMixin):
         return super().create(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        repository = self.get_repo()
-        sentry_tags = generate_upload_sentry_metrics_tags(
-            action="coverage",
-            endpoint="create_commit",
-            request=self.request,
-            repository=repository,
-            is_shelter_request=self.is_shelter_request(),
+        sentry_metrics.incr(
+            "upload",
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                endpoint="create_commit",
+                request=self.request,
+                is_shelter_request=self.is_shelter_request(),
+                position="start",
+            ),
         )
-        sentry_metrics.incr("upload_start", tags=sentry_tags)
+        repository = self.get_repo()
         commit = serializer.save(repository=repository)
         log.info(
             "Request to create new commit",
@@ -69,5 +71,15 @@ class CommitViews(ListCreateAPIView, GetterMixin):
         TaskService().update_commit(
             commitid=commit.commitid, repoid=commit.repository.repoid
         )
-        sentry_metrics.incr("upload_end", tags=sentry_tags)
+        sentry_metrics.incr(
+            "upload",
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                endpoint="create_commit",
+                request=self.request,
+                repository=repository,
+                is_shelter_request=self.is_shelter_request(),
+                position="end",
+            ),
+        )
         return commit

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -77,6 +77,16 @@ class UploadHandler(APIView, ShelterMixin):
 
     def post(self, request, *args, **kwargs):
         # Extract the version
+        sentry_metrics.incr(
+            "upload",
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                endpoint="legacy_upload",
+                request=self.request,
+                is_shelter_request=self.is_shelter_request(),
+                position="start",
+            ),
+        )
         version = self.kwargs["version"]
 
         log.info(
@@ -157,23 +167,28 @@ class UploadHandler(APIView, ShelterMixin):
             ),
         )
 
-        sentry_tags = generate_upload_sentry_metrics_tags(
-            action="coverage",
-            endpoint="legacy_upload",
-            request=self.request,
-            repository=repository,
-            is_shelter_request=self.is_shelter_request(),
-        )
-
         sentry_metrics.incr(
-            "upload_end",
-            tags=sentry_tags,
+            "upload",
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                endpoint="legacy_upload",
+                request=self.request,
+                repository=repository,
+                is_shelter_request=self.is_shelter_request(),
+                position="end",
+            ),
         )
 
         sentry_metrics.set(
             "upload_set",
             repository.author.ownerid,
-            tags=sentry_tags,
+            tags=generate_upload_sentry_metrics_tags(
+                action="coverage",
+                endpoint="legacy_upload",
+                request=self.request,
+                repository=repository,
+                is_shelter_request=self.is_shelter_request(),
+            ),
         )
 
         # Validate the upload to make sure the org has enough repo credits and is allowed to upload for this commit

--- a/upload/views/reports.py
+++ b/upload/views/reports.py
@@ -126,7 +126,7 @@ class ReportResultsView(
             report_code=report.code,
         )
         sentry_metrics.incr(
-            "upload_end",
+            "upload",
             tags=generate_upload_sentry_metrics_tags(
                 action="coverage",
                 endpoint="create_report_results",


### PR DESCRIPTION
I'm comparing the calls bw Shelter + API upload endpoints. I want to make sure the position bw them and Shelter's are the same, so we can accurately map if calls are getting lost in the switch
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
