### PR TITLE
[fix] Fix duplicate key value violates unique constraint "owner_service_ids" Sentry errors 

### DIFF
--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -691,7 +691,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_creates_new_owner_if_dne_all_repos_non_default_app(self):
         username, service_id = "newuser", 123456
@@ -733,7 +739,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
@@ -770,7 +782,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_update_repos_existing_ghapp_installation(self):
         owner = OwnerFactory(service=Service.GITHUB.value)
@@ -873,7 +891,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_update_existing_ghapp(self):
         # Should set integration_id to null for owner,
@@ -971,7 +995,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_with_other_actions_sets_owner_integration_id_if_none(
         self,
@@ -1017,7 +1047,13 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
+        lambda self,
+        ownerid,
+        username,
+        sync_teams,
+        sync_repos,
+        using_integration,
+        repos_affected: None,
     )
     def test_installation_repositories_with_other_actions_sets_owner_itegration_id_if_none(
         self,

--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -691,13 +691,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self,
-        ownerid,
-        username,
-        sync_teams,
-        sync_repos,
-        using_integration,
-        repos_affected: None,
+        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
     def test_installation_creates_new_owner_if_dne_all_repos_non_default_app(self):
         username, service_id = "newuser", 123456
@@ -739,13 +733,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self,
-        ownerid,
-        username,
-        sync_teams,
-        sync_repos,
-        using_integration,
-        repos_affected: None,
+        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
     def test_installation_repositories_creates_new_owner_if_dne(self):
         username, service_id = "newuser", 123456
@@ -764,9 +752,7 @@ class GithubWebhookHandlerTests(APITestCase):
             },
         )
 
-        owner_set = Owner.objects.filter(
-            service="github", service_id=service_id
-        )
+        owner_set = Owner.objects.filter(service="github", service_id=service_id)
 
         assert owner_set.exists()
 
@@ -784,13 +770,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self,
-        ownerid,
-        username,
-        sync_teams,
-        sync_repos,
-        using_integration,
-        repos_affected: None,
+        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
     def test_installation_update_repos_existing_ghapp_installation(self):
         owner = OwnerFactory(service=Service.GITHUB.value)
@@ -893,13 +873,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self,
-        ownerid,
-        username,
-        sync_teams,
-        sync_repos,
-        using_integration,
-        repos_affected: None,
+        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
     def test_installation_repositories_update_existing_ghapp(self):
         # Should set integration_id to null for owner,
@@ -997,13 +971,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self,
-        ownerid,
-        username,
-        sync_teams,
-        sync_repos,
-        using_integration,
-        repos_affected: None,
+        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
     def test_installation_with_other_actions_sets_owner_integration_id_if_none(
         self,
@@ -1049,13 +1017,7 @@ class GithubWebhookHandlerTests(APITestCase):
 
     @patch(
         "services.task.TaskService.refresh",
-        lambda self,
-        ownerid,
-        username,
-        sync_teams,
-        sync_repos,
-        using_integration,
-        repos_affected: None,
+        lambda self, ownerid, username, sync_teams, sync_repos, using_integration, repos_affected: None,
     )
     def test_installation_repositories_with_other_actions_sets_owner_itegration_id_if_none(
         self,

--- a/webhook_handlers/tests/test_github.py
+++ b/webhook_handlers/tests/test_github.py
@@ -765,7 +765,7 @@ class GithubWebhookHandlerTests(APITestCase):
         )
 
         owner_set = Owner.objects.filter(
-            service="github", service_id=service_id, username=username
+            service="github", service_id=service_id
         )
 
         assert owner_set.exists()

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -438,9 +438,12 @@ class GithubWebhookHandler(APIView):
         owner, _ = Owner.objects.get_or_create(
             service=self.service_name,
             service_id=service_id,
-            username=username,
-            defaults={"createstamp": timezone.now()},
+            defaults={
+                "username": username,
+                "createstamp": timezone.now(),
+            },
         )
+
         installation_id = request.data["installation"]["id"]
 
         ghapp_installation, _ = GithubAppInstallation.objects.get_or_create(
@@ -479,8 +482,10 @@ class GithubWebhookHandler(APIView):
         owner, _ = Owner.objects.get_or_create(
             service=self.service_name,
             service_id=service_id,
-            username=username,
-            defaults={"createstamp": timezone.now()},
+            defaults={
+                "username": username,
+                "createstamp": timezone.now(),
+            },
         )
 
         installation_id = request.data["installation"]["id"]
@@ -488,11 +493,11 @@ class GithubWebhookHandler(APIView):
         # https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation
         if action == "deleted":
             if event == GitHubWebhookEvents.INSTALLATION:
-                ghapp_installation: Optional[GithubAppInstallation] = (
-                    owner.github_app_installations.filter(
-                        installation_id=installation_id
-                    ).first()
-                )
+                ghapp_installation: Optional[
+                    GithubAppInstallation
+                ] = owner.github_app_installations.filter(
+                    installation_id=installation_id
+                ).first()
                 if ghapp_installation is not None:
                     ghapp_installation.delete()
             # Deprecated flow - BEGIN

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -493,11 +493,11 @@ class GithubWebhookHandler(APIView):
         # https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation
         if action == "deleted":
             if event == GitHubWebhookEvents.INSTALLATION:
-                ghapp_installation: Optional[
-                    GithubAppInstallation
-                ] = owner.github_app_installations.filter(
-                    installation_id=installation_id
-                ).first()
+                ghapp_installation: Optional[GithubAppInstallation] = (
+                    owner.github_app_installations.filter(
+                        installation_id=installation_id
+                    ).first()
+                )
                 if ghapp_installation is not None:
                     ghapp_installation.delete()
             # Deprecated flow - BEGIN


### PR DESCRIPTION
### Purpose/Motivation

This PR closes https://github.com/codecov/internal-issues/issues/493

We query for an owner during webhook events using `get_or_create` based on their service, service_id, and username. The combination of service and service_id serves as a unique key. We have cases where we have entries in the users table with no username so the `get` part of the `get_or_create` would return `None` and the `create` part attempts to create a new entry but fails due to violating the constraint. This change moves the username field to be a default argument. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
