### PR TITLE
feat: Add delinquent to account details serializer

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -261,21 +261,22 @@ class AccountDetailsSerializer(serializers.ModelSerializer):
         fields = read_only_fields + (
             "activated_student_count",
             "activated_user_count",
+            "apply_cancellation_discount",
             "checkout_session_id",
+            "delinquent",
             "email",
             "inactive_user_count",
             "name",
             "nb_active_private_repos",
-            "plan",
             "plan_auto_activate",
             "plan_provider",
-            "uses_invoice",
+            "plan",
             "repo_total_credits",
             "root_organization",
             "schedule_detail",
             "student_count",
             "subscription_detail",
-            "apply_cancellation_discount",
+            "uses_invoice",
         )
 
     def _get_billing(self):

--- a/api/internal/tests/views/test_account_viewset.py
+++ b/api/internal/tests/views/test_account_viewset.py
@@ -170,6 +170,7 @@ class AccountViewSetTests(APITestCase):
             "student_count": 0,
             "schedule_detail": None,
             "uses_invoice": False,
+            "delinquent": None,
         }
 
     @patch("services.billing.stripe.SubscriptionSchedule.retrieve")
@@ -264,6 +265,7 @@ class AccountViewSetTests(APITestCase):
                 },
             },
             "uses_invoice": False,
+            "delinquent": None,
         }
 
     @patch("services.billing.stripe.SubscriptionSchedule.retrieve")
@@ -366,6 +368,7 @@ class AccountViewSetTests(APITestCase):
                 },
             },
             "uses_invoice": False,
+            "delinquent": None,
         }
 
     @patch("services.billing.stripe.Subscription.retrieve")
@@ -432,6 +435,7 @@ class AccountViewSetTests(APITestCase):
             "student_count": 0,
             "schedule_detail": None,
             "uses_invoice": False,
+            "delinquent": None,
         }
 
     def test_retrieve_account_gets_account_students(self):
@@ -465,6 +469,7 @@ class AccountViewSetTests(APITestCase):
             "student_count": 3,
             "schedule_detail": None,
             "uses_invoice": False,
+            "delinquent": None,
         }
 
     def test_account_with_free_user_plan(self):


### PR DESCRIPTION
### Purpose/Motivation

Part of https://github.com/codecov/engineering-team/issues/1814, originally thought we needed to update the GQL serializer, but I realized we're actually using the account-details endpoint for that component, so we should also update that serializer as well.

Long term we can swap over to the GQL serializer, but this will reduce FE code in the short term until we swap over. (And an extra network call as well)

Couple screenshots below showing null and boolean response coming back

![Screenshot 2024-07-23 at 2 56 09 PM](https://github.com/user-attachments/assets/d0312b59-f7f9-4a96-b8e5-6d8f84b69748)
![Screenshot 2024-07-23 at 2 56 20 PM](https://github.com/user-attachments/assets/a944534a-b2ca-487c-bcfb-d32d2f30e91d)


### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
