### PR TITLE
fix(test results): accept null branch and add default branch

### DIFF
--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -42,7 +42,7 @@ class UploadSerializer(serializers.Serializer):
     job = serializers.CharField(required=False)
     flags = FlagListField(required=False)
     pr = serializers.CharField(required=False)
-    branch = serializers.CharField(required=False)
+    branch = serializers.CharField(required=False, allow_null=True)
     service = serializers.CharField(required=False)
     storage_path = serializers.CharField(required=False)
 
@@ -105,7 +105,7 @@ class TestResultsView(
             commitid=data["commit"],
             repository=repo,
             defaults={
-                "branch": data.get("branch"),
+                "branch": data.get("branch") or repo.branch,
                 "pullid": data.get("pr"),
                 "merged": False if data.get("pr") is not None else None,
                 "state": "pending",


### PR DESCRIPTION
previously the test results upload endpoint did not require a branch field in the data included with the upload but it also did not allow null values for the branch field, so in v0.7.3 of the CLI when we added the branch field to the upload, some uploads were broken because the CLI would not be able to detect a branch and so the branch field would be set to None.

This change modifies the endpoint to accept null values for the branch and if the endpoint is creating the Commit object in the database and the branch field is set to null then it will set the branch field of the commit to the default branch of the repo it's targetting.