### PR TITLE
Filter out private repos with Enforced Okta setting

### DIFF
--- a/core/commands/repository/interactors/fetch_repository.py
+++ b/core/commands/repository/interactors/fetch_repository.py
@@ -1,14 +1,27 @@
+from shared.django_apps.codecov_auth.models import Owner
+from shared.django_apps.core.models import Repository
+
 from codecov.commands.base import BaseInteractor
 from codecov.db import sync_to_async
-from core.models import Repository
 
 
 class FetchRepositoryInteractor(BaseInteractor):
     @sync_to_async
-    def execute(self, owner, name):
+    def execute(
+        self,
+        owner: Owner,
+        name: str,
+        okta_authenticated_accounts: list[int],
+        exclude_okta_enforced_repos: bool = True,
+    ):
+        queryset = Repository.objects.viewable_repos(self.current_owner)
+        if exclude_okta_enforced_repos:
+            queryset = queryset.exclude_accounts_enforced_okta(
+                okta_authenticated_accounts
+            )
+
         return (
-            Repository.objects.viewable_repos(self.current_owner)
-            .filter(author=owner, name=name)
+            queryset.filter(author=owner, name=name)
             .with_recent_coverage()
             .with_oldest_commit_at()
             .select_related("author")

--- a/core/commands/repository/interactors/tests/test_fetch_repository.py
+++ b/core/commands/repository/interactors/tests/test_fetch_repository.py
@@ -1,6 +1,10 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import TransactionTestCase
+from shared.django_apps.codecov_auth.tests.factories import (
+    AccountFactory,
+    OktaSettingsFactory,
+)
 
 from codecov.commands.exceptions import (
     NotFound,
@@ -17,36 +21,77 @@ from ..fetch_repository import FetchRepositoryInteractor
 class FetchRepositoryInteractorTest(TransactionTestCase):
     def setUp(self):
         self.org = OwnerFactory()
+
+        self.okta_account = AccountFactory()
+        self.okta_settings = OktaSettingsFactory(
+            account=self.okta_account, enforced=True
+        )
+        self.okta_org = OwnerFactory(account=self.okta_account)
+
         self.public_repo = RepositoryFactory(author=self.org, private=False)
         self.hidden_private_repo = RepositoryFactory(author=self.org, private=True)
         self.private_repo = RepositoryFactory(author=self.org, private=True)
+        self.okta_private_repo = RepositoryFactory(author=self.okta_org, private=True)
         self.current_user = OwnerFactory(
-            permission=[self.private_repo.repoid], organizations=[self.org.ownerid]
+            permission=[self.private_repo.repoid, self.okta_private_repo.repoid],
+            organizations=[self.org.ownerid, self.okta_org.ownerid],
         )
 
     # helper to execute the interactor
-    def execute(self, owner, *args):
+    def execute(self, owner, *args, **kwargs):
         service = owner.service if owner else "github"
-        return FetchRepositoryInteractor(owner, service).execute(*args)
+        return FetchRepositoryInteractor(owner, service).execute(*args, **kwargs)
 
     async def test_fetch_public_repo_unauthenticated(self):
-        repo = await self.execute(None, self.org, self.public_repo.name)
+        repo = await self.execute(None, self.org, self.public_repo.name, [])
         assert repo == self.public_repo
 
     async def test_fetch_public_repo_authenticated(self):
-        repo = await self.execute(self.current_user, self.org, self.public_repo.name)
+        repo = await self.execute(
+            self.current_user, self.org, self.public_repo.name, []
+        )
         assert repo == self.public_repo
 
     async def test_fetch_private_repo_unauthenticated(self):
-        repo = await self.execute(None, self.org, self.private_repo.name)
+        repo = await self.execute(None, self.org, self.private_repo.name, [])
         assert repo is None
 
     async def test_fetch_private_repo_authenticated_but_no_permissions(self):
         repo = await self.execute(
-            self.current_user, self.org, self.hidden_private_repo.name
+            self.current_user, self.org, self.hidden_private_repo.name, []
         )
         assert repo is None
 
     async def test_fetch_private_repo_authenticated_with_permissions(self):
-        repo = await self.execute(self.current_user, self.org, self.private_repo.name)
+        repo = await self.execute(
+            self.current_user, self.org, self.private_repo.name, []
+        )
         assert repo == self.private_repo
+
+    async def test_fetch_okta_private_repo_authenticated(self):
+        repo = await self.execute(
+            self.current_user,
+            self.okta_org,
+            self.okta_private_repo.name,
+            [self.okta_account.id],
+        )
+        assert repo == self.okta_private_repo
+
+    async def test_fetch_okta_private_repo_unauthenticated(self):
+        repo = await self.execute(
+            self.current_user,
+            self.okta_org,
+            self.okta_private_repo.name,
+            [],
+        )
+        assert repo is None
+
+    async def test_fetch_okta_private_repo_do_not_exclude_unauthenticated(self):
+        repo = await self.execute(
+            self.current_user,
+            self.okta_org,
+            self.okta_private_repo.name,
+            [],
+            exclude_okta_enforced_repos=False,
+        )
+        assert repo == self.okta_private_repo

--- a/core/commands/repository/repository.py
+++ b/core/commands/repository/repository.py
@@ -20,8 +20,19 @@ from .interactors.update_repository import UpdateRepositoryInteractor
 
 
 class RepositoryCommands(BaseCommand):
-    def fetch_repository(self, owner, name):
-        return self.get_interactor(FetchRepositoryInteractor).execute(owner, name)
+    def fetch_repository(
+        self,
+        owner,
+        name,
+        okta_authenticated_accounts: list[int],
+        exclude_okta_enforced_repos: bool = True,
+    ) -> Repository:
+        return self.get_interactor(FetchRepositoryInteractor).execute(
+            owner,
+            name,
+            okta_authenticated_accounts,
+            exclude_okta_enforced_repos=exclude_okta_enforced_repos,
+        )
 
     def regenerate_repository_upload_token(
         self,

--- a/core/commands/repository/tests/test_repository.py
+++ b/core/commands/repository/tests/test_repository.py
@@ -18,8 +18,19 @@ class RepositoryCommandsTest(TransactionTestCase):
 
     @patch("core.commands.repository.repository.FetchRepositoryInteractor.execute")
     def test_fetch_repository_to_interactor(self, interactor_mock):
-        self.command.fetch_repository(self.org, self.repo.name)
-        interactor_mock.assert_called_once_with(self.org, self.repo.name)
+        self.command.fetch_repository(self.org, self.repo.name, [])
+        interactor_mock.assert_called_once_with(
+            self.org, self.repo.name, [], exclude_okta_enforced_repos=True
+        )
+
+    @patch("core.commands.repository.repository.FetchRepositoryInteractor.execute")
+    def test_fetch_repository_to_interactor_with_enforcing_okta(self, interactor_mock):
+        self.command.fetch_repository(
+            self.org, self.repo.name, [], exclude_okta_enforced_repos=False
+        )
+        interactor_mock.assert_called_once_with(
+            self.org, self.repo.name, [], exclude_okta_enforced_repos=False
+        )
 
     @patch("core.commands.repository.repository.GetUploadTokenInteractor.execute")
     def test_get_upload_token_to_interactor(self, interactor_mock):

--- a/graphql_api/actions/repository.py
+++ b/graphql_api/actions/repository.py
@@ -1,8 +1,14 @@
-from codecov_auth.models import Owner
-from core.models import Repository
+import logging
+from typing import Any
+
+from django.db.models import QuerySet
+from shared.django_apps.codecov_auth.models import Owner
+from shared.django_apps.core.models import Repository
+
+log = logging.getLogger(__name__)
 
 
-def apply_filters_to_queryset(queryset, filters):
+def apply_filters_to_queryset(queryset, filters: dict[str, Any]) -> QuerySet:
     filters = filters or {}
     term = filters.get("term")
     active = filters.get("active")
@@ -24,9 +30,15 @@ def apply_filters_to_queryset(queryset, filters):
     return queryset
 
 
-def list_repository_for_owner(current_owner: Owner, owner: Owner, filters):
+def list_repository_for_owner(
+    current_owner: Owner,
+    owner: Owner,
+    filters: dict[str, Any] | None,
+    okta_account_auths: list[int],
+) -> QuerySet:
     queryset = (
         Repository.objects.viewable_repos(current_owner)
+        .exclude_accounts_enforced_okta(okta_account_auths)
         .with_recent_coverage()
         .with_latest_commit_at()
         .filter(author=owner)
@@ -35,10 +47,13 @@ def list_repository_for_owner(current_owner: Owner, owner: Owner, filters):
     return queryset
 
 
-def search_repos(current_owner, filters):
+def search_repos(
+    current_owner: Owner, filters: dict[str, Any] | None, okta_account_auths: list[int]
+) -> QuerySet:
     authors_from = [current_owner.ownerid] + (current_owner.organizations or [])
     queryset = (
         Repository.objects.viewable_repos(current_owner)
+        .exclude_accounts_enforced_okta(okta_account_auths)
         .with_recent_coverage()
         .with_latest_commit_at()
         .filter(author__ownerid__in=authors_from)

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/c9e07f583a8217a2f61b176a0e15fa6dcce5bc34.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/4725b149732df0253123ed643b9d226ab63ccba1.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -418,7 +418,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/c9e07f583a8217a2f61b176a0e15fa6dcce5bc34.tar.gz
+shared @ https://github.com/codecov/shared/archive/4725b149732df0253123ed643b9d226ab63ccba1.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -397,8 +397,12 @@ class UploadDownloadHandler(View):
         if owner is None:
             raise Http404("Requested report could not be found")
         repo = await RepositoryCommands(
-            self.request.current_owner, self.service
-        ).fetch_repository(owner, self.repo_name)
+            self.request.current_owner,
+            self.service,
+        ).fetch_repository(
+            owner, self.repo_name, [], exclude_okta_enforced_repos=False
+        )  # Okta sign-in is only enforced on the UI for now.
+
         if repo is None:
             raise Http404("Requested report could not be found")
         return repo


### PR DESCRIPTION
### Purpose/Motivation
For organizations with `enforced` Okta configurations, we only want to show the public repos for the user. They will need to be authenticated to get access to private repos on our UI.

### Links to relevant tickets
ref: https://github.com/codecov/engineering-team/issues/1992

### What does this PR do?
Filters out repos on the GraphQL endpoint for orgs that the user is not authenticated with for various queries that requests repository information.

### Notes to Reviewer
We aren't filtering out the repos for public API endpoints. This is because these endpoints auth through token authentication are (likely, sometimes) to be used in some automated pipeline where Okta doesn't make sense.

I would like some feedback on whether there's any other API endpoints I'm missing that should have repos filtered. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
