### PR TITLE
add Account to Owner Serializer

### DIFF
--- a/api/internal/account/serializers.py
+++ b/api/internal/account/serializers.py
@@ -1,0 +1,47 @@
+from rest_framework import serializers
+from shared.django_apps.codecov_auth.models import (
+    Account,
+    InvoiceBilling,
+    StripeBilling,
+)
+
+from api.internal.owner.serializers import PlanSerializer
+
+
+class StripeBillingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StripeBilling
+        fields = ("customer_id", "subscription_id", "is_active")
+
+
+class InvoiceBillingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = InvoiceBilling
+        fields = ("account_manager", "is_active")
+
+
+class BaseAccountSerializer(serializers.ModelSerializer):
+    stripe_billing = StripeBillingSerializer(many=True, read_only=True)
+    invoice_billing = InvoiceBillingSerializer(many=True, read_only=True)
+    plan = PlanSerializer(source="pretty_plan")
+
+    class Meta:
+        model = Account
+        read_only_fields = (
+            "name",
+            "is_delinquent",
+            "free_seat_count",
+            "plan_seat_count",
+            "total_seat_count",  # == plan_seat_count + free_seat_count
+            "activated_user_count",
+            "activated_student_count",
+            "all_user_count",  # == activated_user_count + activated_student_count
+            "organizations_count",
+            "available_seat_count",  # == total_seat_count - activated_user_count
+            "plan",
+            "plan_auto_activate",
+            "stripe_billing",
+            "invoice_billing",
+        )
+        # right now it's a read-only experience
+        fields = read_only_fields

--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -246,18 +246,20 @@ class RootOrganizationSerializer(serializers.Serializer):
 
 
 class AccountDetailsSerializer(serializers.ModelSerializer):
+    # circular imports
+    from api.internal.account.serializers import BaseAccountSerializer
+
     plan = PlanSerializer(source="pretty_plan")
     checkout_session_id = serializers.SerializerMethodField()
     subscription_detail = serializers.SerializerMethodField()
     root_organization = RootOrganizationSerializer()
     schedule_detail = serializers.SerializerMethodField()
     apply_cancellation_discount = serializers.BooleanField(write_only=True)
+    account = BaseAccountSerializer()
 
     class Meta:
         model = Owner
-
-        read_only_fields = ("integration_id",)
-
+        read_only_fields = ("integration_id", "account")
         fields = read_only_fields + (
             "activated_student_count",
             "activated_user_count",

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/c9e07f583a8217a2f61b176a0e15fa6dcce5bc34.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/db3f917405622c872304389bed05090a7274d9c5.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -418,7 +418,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/c9e07f583a8217a2f61b176a0e15fa6dcce5bc34.tar.gz
+shared @ https://github.com/codecov/shared/archive/db3f917405622c872304389bed05090a7274d9c5.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in


### PR DESCRIPTION
### Purpose/Motivation
Provide read-only access to an Org's Account (if they have one)

### Links to relevant tickets
Part of https://github.com/codecov/engineering-team/issues/2060

### What does this PR do?
If your Org gets the "Enterprise Experience", you can access the details about your `Account` via the `account-details` endpoint

