### PR TITLE
[fix] Update regen repo upload token mutation to work on inactive repos

### DIFF
--- a/core/commands/repository/interactors/regenerate_repository_upload_token.py
+++ b/core/commands/repository/interactors/regenerate_repository_upload_token.py
@@ -15,7 +15,7 @@ class RegenerateRepositoryUploadTokenInteractor(BaseInteractor):
         ).first()
         repo = (
             Repository.objects.viewable_repos(current_owner)
-            .filter(name=repo_name, active=True)
+            .filter(name=repo_name)
             .first()
         )
         if not repo:

--- a/graphql_api/tests/mutation/test_regenerate_repository_upload_token.py
+++ b/graphql_api/tests/mutation/test_regenerate_repository_upload_token.py
@@ -22,7 +22,7 @@ mutation($input: RegenerateRepositoryUploadTokenInput!) {
 class RegenerateRepositoryUploadTokenTests(GraphQLTestHelper, TransactionTestCase):
     def setUp(self):
         self.org = OwnerFactory(username="codecov")
-        self.repo = RepositoryFactory(author=self.org, name="gazebo", active=True)
+        self.repo = RepositoryFactory(author=self.org, name="gazebo")
         self.old_repo_token = self.repo.upload_token
 
     def test_when_authenticated_updates_token(self):


### PR DESCRIPTION
### Purpose/Motivation

Fix customer issue and revert to old behaviour. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
