### PR TITLE
fix: Bump django to resolve vulnerability

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ ariadne_django
 celery>=5.3.6
 cerberus
 ddtrace
-Django
+Django>=4.2.14
 django-cors-headers
 django-csp
 django-dynamic-fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ deprecated==1.2.12
     # via opentelemetry-api
 distlib==0.3.1
     # via virtualenv
-django==4.2.11
+django==4.2.14
     # via
     #   -r requirements.in
     #   ariadne-django


### PR DESCRIPTION
### Purpose/Motivation
Bump to patched version of Django that resolves [CVE-2024-39614](https://github.com/advisories/GHSA-f6f8-9mx6-9mx2)

### Links to relevant tickets
Closes https://github.com/codecov/internal-issues/issues/633

### What does this PR do?
Bump to Django version 4.2.14

### Notes to Reviewer
[Django 4.2.15](https://docs.djangoproject.com/en/5.0/releases/4.2.15/) will be released in a week from now, so 4.2.14 is most current as now

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
