### PR TITLE
fix: hasDifferentNumbersofHeadAndBase short term fix

### DIFF
--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -263,7 +263,7 @@ def resolve_has_different_number_of_head_and_base_reports(
     comparison: Comparison = info.context["comparison"]
     try:
         comparison.validate()
-    except MissingComparisonReport:
+    except Exception:
         return False
     return comparison.has_different_number_of_head_and_base_sessions
 

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -718,7 +718,6 @@ class Comparison(object):
 
     @cached_property
     def has_different_number_of_head_and_base_sessions(self):
-        self.validate()
         head_sessions = self.head_report.sessions
         base_sessions = self.base_report.sessions
         # We're treating this case as false since considering CFF's complicates the logic


### PR DESCRIPTION
### Purpose/Motivation

When viewing the pulls page, user may run into an error with hasDIfferentNumberOfHeadAndBaseSessions erroring out due to a github API call when fetching the "fresh" head_report here: https://github.com/codecov/codecov-api/blob/20b3a8199d43e5f96eaa3fd39cd8bae6f06c833e/services/comparison.py#L716

When discussing with @adrian-codecov, we thought that this check may not actually be needed; and that the implication of having a "stale" head report doesn't necessarily change the boolean "hasDifferentNumberOfHeadAndBaseSessions" value meaningfully.

Additionally, we found[ some logic related to CFF](https://github.com/codecov/codecov-api/blob/20b3a8199d43e5f96eaa3fd39cd8bae6f06c833e/services/comparison.py#L723-L728) (Carry Forward Flags) that needs to be revisited as well, since right now we're just rudimentarily saying "if CFF exists, return False."

For now, just to unblock pulls page for most cases, we're going to ship this, but I'll be creating a follow up to revisit a lot of this comparison logic later.

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/1699

Related to https://github.com/codecov/engineering-team/issues/2160 (long term fix)

### What does this PR do?

Captures all exceptions and returns false for this resolver param

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
