### PR TITLE
add version to legacy metrics

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -787,6 +787,7 @@ def generate_upload_sentry_metrics_tags(
     endpoint: Optional[str] = None,
     repository: Optional[Repository] = None,
     position: Optional[str] = None,
+    version: Optional[str] = None,
 ):
     metrics_tags = dict(
         agent=get_agent_from_headers(request.headers),
@@ -801,5 +802,7 @@ def generate_upload_sentry_metrics_tags(
         )
     if position:
         metrics_tags["position"] = position
+    if version:
+        metrics_tags["version"] = version
 
     return metrics_tags

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -141,6 +141,7 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
                 request=self.request,
                 repository=repo,
                 is_shelter_request=self.is_shelter_request(),
+                position="end",
             ),
         )
         if set(changed_files) == set(ignored_changed_files):

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -141,7 +141,6 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
                 request=self.request,
                 repository=repo,
                 is_shelter_request=self.is_shelter_request(),
-                position="end",
             ),
         )
         if set(changed_files) == set(ignored_changed_files):

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -77,6 +77,7 @@ class UploadHandler(APIView, ShelterMixin):
 
     def post(self, request, *args, **kwargs):
         # Extract the version
+        version = self.kwargs["version"]
         sentry_metrics.incr(
             "upload",
             tags=generate_upload_sentry_metrics_tags(
@@ -85,9 +86,9 @@ class UploadHandler(APIView, ShelterMixin):
                 request=self.request,
                 is_shelter_request=self.is_shelter_request(),
                 position="start",
+                version=version,
             ),
         )
-        version = self.kwargs["version"]
 
         log.info(
             f"Received upload request {version}",
@@ -176,6 +177,7 @@ class UploadHandler(APIView, ShelterMixin):
                 repository=repository,
                 is_shelter_request=self.is_shelter_request(),
                 position="end",
+                version=version,
             ),
         )
 


### PR DESCRIPTION
### Purpose/Motivation
The legacy endpoint takes on reports from different versions, v2/3/4. We're trying to compare the in/out traffic from shelter and api, but shelter only supports (and only means to) v4, so we want to add another tag to filter v4 requests

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
