### PR TITLE
Add proper key to separate upload version

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -787,7 +787,7 @@ def generate_upload_sentry_metrics_tags(
     endpoint: Optional[str] = None,
     repository: Optional[Repository] = None,
     position: Optional[str] = None,
-    version: Optional[str] = None,
+    upload_version: Optional[str] = None,
 ):
     metrics_tags = dict(
         agent=get_agent_from_headers(request.headers),
@@ -802,7 +802,7 @@ def generate_upload_sentry_metrics_tags(
         )
     if position:
         metrics_tags["position"] = position
-    if version:
-        metrics_tags["version"] = version
+    if upload_version:
+        metrics_tags["upload_version"] = upload_version
 
     return metrics_tags

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -177,7 +177,7 @@ class UploadHandler(APIView, ShelterMixin):
                 repository=repository,
                 is_shelter_request=self.is_shelter_request(),
                 position="end",
-                version=version,
+                upload_version=version,
             ),
         )
 

--- a/upload/views/legacy.py
+++ b/upload/views/legacy.py
@@ -86,7 +86,7 @@ class UploadHandler(APIView, ShelterMixin):
                 request=self.request,
                 is_shelter_request=self.is_shelter_request(),
                 position="start",
-                version=version,
+                upload_version=version,
             ),
         )
 


### PR DESCRIPTION
I added the version here, https://github.com/codecov/codecov-api/pull/717, but didn't realize the "version" keyword was already in use. Changing to upload version
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
