### PR TITLE
fix(test_results): graphql endpoint ordering bug

### DIFF
--- a/graphql_api/helpers/connection.py
+++ b/graphql_api/helpers/connection.py
@@ -70,6 +70,17 @@ class Connection:
 
 class DictCursorPaginator(CursorPaginator):
     """
+    WARNING: DictCursorPaginator does not work for dict objects where a key contains the following string: "__"
+    TODO: if instance is a dictionary and not an object, don't split the ordering
+
+    ordering = "test__name"
+    Django object:
+    -> obj.test.name
+
+    Dict:
+    -> obj["test"]["name"] X wrong
+    we want obj["test__name"]
+
     overrides CursorPaginator's position_from_instance method
     because it assumes that instance's fields are attributes on the
     instance. This doesn't work with the aggregate_test_results query

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -573,9 +573,12 @@ async def resolve_test_results(
     queryset = await sync_to_async(aggregate_test_results)(
         repoid=repository.repoid, branch=filters.get("branch") if filters else None
     )
+
     return await queryset_to_connection(
         queryset,
-        ordering=(ordering.get("parameter"),) if ordering else ("avg_duration",),
+        ordering=(ordering.get("parameter"), "name")
+        if ordering
+        else ("avg_duration", "name"),
         ordering_direction=ordering.get("direction")
         if ordering
         else OrderingDirection.DESC,

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -9,7 +9,7 @@ test_result_bindable = ObjectType("TestResult")
 
 @test_result_bindable.field("name")
 def resolve_name(test, info) -> str:
-    return test["test__name"]
+    return test["name"]
 
 
 @test_result_bindable.field("updatedAt")


### PR DESCRIPTION
There was a bug with the test results graphql endpoint that when ordering was set, the second page and onwards would be empty.

This was due to the need for part of the ordering parameter to have compeletely unique values due to how the CursorPagination class works.

Closes https://github.com/codecov/engineering-team/issues/2168
