### PR TITLE
fix: add try/pass when doing git comparison on comparison report

### DIFF
--- a/services/comparison.py
+++ b/services/comparison.py
@@ -713,7 +713,11 @@ class Comparison(object):
             else:
                 raise e
 
-        report.apply_diff(self.git_comparison["diff"])
+        # Return the old report if the github API call fails for any reason
+        try:
+            report.apply_diff(self.git_comparison["diff"])
+        except Exception:
+            pass
         return report
 
     @cached_property


### PR DESCRIPTION
### Purpose/Motivation

Looking to fix the comparisonReport errors that keep occurring, usually due to github API call failing

https://console.cloud.google.com/logs/query;query=%22hasDifferentNumberOfHeadAndBaseReports%22%0Aseverity%3DERROR;pinnedLogId=2024-04-08T19:18:39.852000850Z%2Fgt0cscxqclw9v94d;summaryFields=jsonPayload%252Fusername:false:32:beginning;cursorTimestamp=2024-07-30T21:35:50.079361064Z;duration=P7D?project=genuine-polymer-165712&authuser=1

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
