### PR TITLE
fix: isGithubRateLimited can return null

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -804,6 +804,47 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         assert data["me"]["owner"]["repository"]["isGithubRateLimited"] == False
 
+    @patch("shared.rate_limits.determine_entity_redis_key")
+    @patch("shared.rate_limits.determine_if_entity_is_rate_limited")
+    @patch("logging.Logger.error")
+    @override_settings(IS_ENTERPRISE=True, GUEST_ACCESS=False)
+    def test_fetch_is_github_rate_limited_but_errors(
+        self,
+        mock_determine_rate_limit,
+        mock_determine_redis_key,
+        mock_log_error,
+    ):
+        repo = RepositoryFactory(
+            author=self.owner,
+            active=True,
+            private=True,
+            yaml={"component_management": {}},
+        )
+
+        mock_determine_redis_key.return_value = Exception("some random error lol")
+        mock_determine_rate_limit.return_value = True
+
+        data = self.gql_request(
+            query_repository
+            % """
+                isGithubRateLimited
+            """,
+            owner=self.owner,
+            variables={"name": repo.name},
+        )
+
+        # Check if the log.error was called with the correct parameters
+        mock_log_error.assert_called_once_with(
+            "Error when checking rate limit",
+            extra=dict(
+                repo_id=repo.repoid,
+                has_owner=True,
+                exc_info=mock_determine_redis_key.side_effect,
+            ),
+        )
+
+        assert data["me"]["owner"]["repository"]["isGithubRateLimited"] is None
+
     def test_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -838,7 +838,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         mock_log_error.assert_called_once_with(
             "Error when checking rate limit",
             extra={
-                "repo_id": 31,
+                "repo_id": repo.repoid,
                 "has_owner": True,
                 "exc_info": mock_determine_redis_key.side_effect,
             },

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -82,7 +82,7 @@ type Repository {
   ): [ComponentMeasurements!]!
   componentsYaml(termId: String): [ComponentsYaml]!
   testAnalyticsEnabled: Boolean
-  isGithubRateLimited: Boolean!
+  isGithubRateLimited: Boolean
   testResults(
     filters: TestResultsFilters
     ordering: TestResultsOrdering

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import Iterable, List, Mapping, Optional
 
@@ -35,6 +36,8 @@ from services.redis_configuration import get_redis_connection
 from timeseries.helpers import fill_sparse_measurements
 from timeseries.models import Dataset, Interval, MeasurementName, MeasurementSummary
 from utils.test_results import aggregate_test_results
+
+log = logging.getLogger(__name__)
 
 repository_bindable = ObjectType("Repository")
 
@@ -552,13 +555,22 @@ def resolve_is_github_rate_limited(repository: Repository, info) -> bool | None:
     ):
         return False
     current_owner = info.context["request"].current_owner
-    redis_connection = get_redis_connection()
-    rate_limit_redis_key = rate_limits.determine_entity_redis_key(
-        owner=current_owner, repository=repository
-    )
-    return rate_limits.determine_if_entity_is_rate_limited(
-        redis_connection, rate_limit_redis_key
-    )
+    try:
+        redis_connection = get_redis_connection()
+        rate_limit_redis_key = rate_limits.determine_entity_redis_key(
+            owner=current_owner, repository=repository
+        )
+        return rate_limits.determine_if_entity_is_rate_limited(
+            redis_connection, rate_limit_redis_key
+        )
+    except Exception as e:
+        log.error(
+            "Error when checking rate limit",
+            extra=dict(
+                repo_id=repository.repoid, has_owner=bool(current_owner), exc_info=e
+            ),
+        )
+        return None
 
 
 @repository_bindable.field("testResults")


### PR DESCRIPTION
### Purpose/Motivation

Saw this on my App, hook returning internal server error.


<img width="1893" alt="Screenshot 2024-07-31 at 4 42 39 PM" src="https://github.com/user-attachments/assets/ed234b51-abd9-4308-835d-422a6bf13138">

Should hopefully [fix these sentry issues](https://codecov.sentry.io/issues/?project=5514400&project=5215654&project=4165036&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+ratelimit&referrer=issue-list&statsPeriod=7d)

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
