### PR TITLE
update account-detail endpoint to show info on Account if the Org has an Account

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/cee7681d68ce0d9f57899d41a6241d0772b07905.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/14d8093f85adf1b99df763354c10ec0eaf86ee43.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -417,7 +417,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/cee7681d68ce0d9f57899d41a6241d0772b07905.tar.gz
+shared @ https://github.com/codecov/shared/archive/14d8093f85adf1b99df763354c10ec0eaf86ee43.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in


### PR DESCRIPTION
### What does this PR do?
There are certain fields that are controlled by the Account if the Org has an Account. These changes make it so that when you view the `plan` or `member` page, if your Org has an Account, you see the details from the Account, not the Org.

Also adds logic to make sure that a user cannot do self-serve functions (changing their plan) if they have an Account. The current implementation of Accounts are that they are sales-led only, they have to change their plan details through their sales contact, and if they were able to change the plan on a single Org in the Account, weird things would happen. So if they have an Account we want to block these actions.
