### PR TITLE
Remove obsolete `cleanup` from BundleAnalysis

### DIFF
--- a/graphql_api/actions/measurements.py
+++ b/graphql_api/actions/measurements.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Iterable, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from django.db.models import Max, QuerySet
 
@@ -16,7 +16,7 @@ def measurements_by_ids(
     before: datetime,
     after: Optional[datetime] = None,
     branch: Optional[str] = None,
-) -> Mapping[int, Iterable[dict]]:
+) -> Dict[int, List[Dict[str, Any]]]:
     queryset = MeasurementSummary.agg_by(interval).filter(
         name=measurable_name,
         owner_id=repository.author_id,
@@ -38,7 +38,7 @@ def measurements_by_ids(
     )
 
     # group by measurable_id
-    measurements: Mapping[int, Iterable[dict]] = {}
+    measurements: Dict[int, List[Dict[str, Any]]] = {}
     for measurement in queryset:
         measurable_id = measurement["measurable_id"]
         if measurable_id not in measurements:
@@ -51,7 +51,7 @@ def measurements_by_ids(
 def measurements_last_uploaded_before_start_date(
     repo_id: int,
     measurable_name: str,
-    measurable_ids: Iterable[str],
+    measurable_ids: List[int],
     start_date: datetime,
     branch: Optional[str] = None,
 ) -> QuerySet:

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/14d8093f85adf1b99df763354c10ec0eaf86ee43.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/58c6f4f0a0fa1a5d931466e0a63f5f15349546d5.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -205,6 +205,8 @@ googleapis-common-protos[grpc]==1.59.1
     #   grpcio-status
 graphql-core==3.2.3
     # via ariadne
+greenlet==3.0.3
+    # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
 grpcio==1.62.1
@@ -417,7 +419,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/14d8093f85adf1b99df763354c10ec0eaf86ee43.tar.gz
+shared @ https://github.com/codecov/shared/archive/58c6f4f0a0fa1a5d931466e0a63f5f15349546d5.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -3,7 +3,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from django.utils.functional import cached_property
 from shared.bundle_analysis import AssetReport as SharedAssetReport
@@ -84,7 +84,7 @@ class BundleAnalysisMeasurementData(object):
         asset_type: BundleAnalysisMeasurementsAssetType,
         asset_name: Optional[str],
         interval: Interval,
-        after: datetime,
+        after: Optional[datetime],
         before: datetime,
     ):
         self.raw_measurements = raw_measurements
@@ -379,7 +379,7 @@ class BundleAnalysisMeasurementsService(object):
 
     def _compute_measurements(
         self, measurable_name: str, measurable_ids: List[str]
-    ) -> dict[int, Iterable[dict[Any, Any]]]:
+    ) -> Dict[int, List[Dict[str, Any]]]:
         all_measurements = measurements_by_ids(
             repository=self.repository,
             measurable_name=measurable_name,

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -283,11 +283,6 @@ class BundleReport(object):
 class BundleAnalysisReport(object):
     def __init__(self, report: SharedBundleAnalysisReport):
         self.report = report
-        self.cleanup()
-
-    def cleanup(self) -> None:
-        if self.report and self.report.db_session:
-            self.report.db_session.close()
 
     def bundle(
         self, name: str, filters: Dict[str, List[str]]
@@ -323,13 +318,6 @@ class BundleAnalysisComparison(object):
             head_report_key,
         )
         self.head_report = self.comparison.head_report
-        self.cleanup()
-
-    def cleanup(self) -> None:
-        if self.comparison.head_report and self.comparison.head_report.db_session:
-            self.comparison.head_report.db_session.close()
-        if self.comparison.base_report and self.comparison.base_report.db_session:
-            self.comparison.base_report.db_session.close()
 
     @cached_property
     def bundles(self) -> List["BundleComparison"]:


### PR DESCRIPTION
### Purpose/Motivation

The `shared` code completely removed the `db_session` on the `BundleAnalysisReport`. Thus there is no need to `close` those sessions and for these cleanup methods to exist.

### Links to relevant tickets

related to https://github.com/codecov/internal-issues/issues/650

### Notes to Reviewer

Depends on https://github.com/codecov/shared/pull/309