### PR TITLE
fix: Default height/width to 100% if either doesn't exist

### DIFF
--- a/graphs/views.py
+++ b/graphs/views.py
@@ -158,36 +158,36 @@ class GraphHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
         if graph == "tree":
             options["width"] = int(
                 self.request.query_params.get(
-                    "width", settings["sunburst"]["options"]["width"]
+                    "width", settings["sunburst"]["options"]["width"] or 100
                 )
             )
             options["height"] = int(
                 self.request.query_params.get(
-                    "height", settings["sunburst"]["options"]["height"]
+                    "height", settings["sunburst"]["options"]["height"] or 100
                 )
             )
             return tree(flare, None, None, **options)
         elif graph == "icicle":
             options["width"] = int(
                 self.request.query_params.get(
-                    "width", settings["icicle"]["options"]["width"]
+                    "width", settings["icicle"]["options"]["width"] or 100
                 )
             )
             options["height"] = int(
                 self.request.query_params.get(
-                    "height", settings["icicle"]["options"]["height"]
+                    "height", settings["icicle"]["options"]["height"] or 100
                 )
             )
             return icicle(flare, **options)
         elif graph == "sunburst":
             options["width"] = int(
                 self.request.query_params.get(
-                    "width", settings["sunburst"]["options"]["width"]
+                    "width", settings["sunburst"]["options"]["width"] or 100
                 )
             )
             options["height"] = int(
                 self.request.query_params.get(
-                    "height", settings["sunburst"]["options"]["height"]
+                    "height", settings["sunburst"]["options"]["height"] or 100
                 )
             )
             return sunburst(flare, **options)


### PR DESCRIPTION
### Purpose/Motivation

Fixes sentry issue: https://codecov.sentry.io/issues/2768942613/?environment=epic&environment=dd&environment=enova&environment=mailchimp&environment=production&environment=roblox&environment=snowflake&environment=prodvana&project=5514400&project=5215654&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=9


We just want to default a numerical value in the event both the .get() and the default from the get are non-integer values.

The sentry issue is complaining that the default value is '', and if you do '' or 100 (like in the PR), we will use 100

These eventually bubble up to here: https://github.com/codecov/codecov-api/blob/c9bc2c82a682f02cc6e88e804290d11eabf4ca22/graphs/helpers/graph_utils.py#L102-L117

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/2204

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
