### PR TITLE
fix: Add validation for trial start/cancel for user in calling org

### DIFF
--- a/codecov_auth/commands/owner/interactors/cancel_trial.py
+++ b/codecov_auth/commands/owner/interactors/cancel_trial.py
@@ -1,14 +1,17 @@
 from codecov.commands.base import BaseInteractor
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthorized, ValidationError
 from codecov.db import sync_to_async
+from codecov_auth.helpers import current_user_part_of_org
 from codecov_auth.models import Owner
 from plan.service import PlanService
 
 
 class CancelTrialInteractor(BaseInteractor):
-    def validate(self, owner: Owner):
+    def validate(self, owner: Owner | None):
         if not owner:
             raise ValidationError("Cannot find owner record in the database")
+        if not current_user_part_of_org(self.current_owner, owner):
+            raise Unauthorized()
 
     def _cancel_trial(self, owner: Owner):
         plan_service = PlanService(current_org=owner)

--- a/codecov_auth/commands/owner/interactors/start_trial.py
+++ b/codecov_auth/commands/owner/interactors/start_trial.py
@@ -1,14 +1,17 @@
 from codecov.commands.base import BaseInteractor
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthorized, ValidationError
 from codecov.db import sync_to_async
+from codecov_auth.helpers import current_user_part_of_org
 from codecov_auth.models import Owner
 from plan.service import PlanService
 
 
 class StartTrialInteractor(BaseInteractor):
-    def validate(self, current_org: Owner):
+    def validate(self, current_org: Owner | None):
         if not current_org:
             raise ValidationError("Cannot find owner record in the database")
+        if not current_user_part_of_org(self.current_owner, current_org):
+            raise Unauthorized()
 
     def _start_trial(self, current_org: Owner) -> None:
         plan_service = PlanService(current_org=current_org)

--- a/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
@@ -5,10 +5,10 @@ from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase
 from freezegun import freeze_time
 
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthorized, ValidationError
 from codecov_auth.models import Owner
 from codecov_auth.tests.factories import OwnerFactory
-from plan.constants import PlanName, TrialDaysAmount, TrialStatus
+from plan.constants import PlanName, TrialStatus
 
 from ..cancel_trial import CancelTrialInteractor
 
@@ -28,6 +28,18 @@ class CancelTrialInteractorTest(TransactionTestCase):
         )
         with pytest.raises(ValidationError):
             self.execute(current_user=current_user, org_username="some-other-username")
+
+    def test_cancel_trial_raises_exception_when_current_user_not_part_of_org(self):
+        current_user = OwnerFactory(
+            username="random-user-123",
+            service="github",
+        )
+        OwnerFactory(
+            username="random-user-456",
+            service="github",
+        )
+        with pytest.raises(Unauthorized):
+            self.execute(current_user=current_user, org_username="random-user-456")
 
     @freeze_time("2022-01-01T00:00:00")
     def test_cancel_trial_raises_exception_when_owners_trial_status_is_not_started(

--- a/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
@@ -6,7 +6,7 @@ from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase
 from freezegun import freeze_time
 
-from codecov.commands.exceptions import ValidationError
+from codecov.commands.exceptions import Unauthorized, ValidationError
 from codecov_auth.models import Owner
 from codecov_auth.tests.factories import OwnerFactory
 from plan.constants import TRIAL_PLAN_SEATS, PlanName, TrialDaysAmount, TrialStatus
@@ -29,6 +29,18 @@ class StartTrialInteractorTest(TransactionTestCase):
         )
         with pytest.raises(ValidationError):
             self.execute(current_user=current_user, org_username="some-other-username")
+
+    def test_cancel_trial_raises_exception_when_current_user_not_part_of_org(self):
+        current_user = OwnerFactory(
+            username="random-user-123",
+            service="github",
+        )
+        OwnerFactory(
+            username="random-user-456",
+            service="github",
+        )
+        with pytest.raises(Unauthorized):
+            self.execute(current_user=current_user, org_username="random-user-456")
 
     @freeze_time("2022-01-01T00:00:00")
     def test_start_trial_raises_exception_when_owners_trial_status_is_ongoing(self):


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to fix the IDOR hole mentioned in https://github.com/codecov/internal-issues/issues/646 where users can start or cancel trials even if they don't belong to the organization

To fix, we simply check to see that the user is part of the organization in the validate step prior to executing the mutation

### Links to relevant tickets

Closes https://github.com/codecov/internal-issues/issues/646


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
