### PR TITLE
fix: Update DATA_UPLOAD_MAX_MEMORY_SIZE to 25 MB

### DIFF
--- a/codecov/settings_prod.py
+++ b/codecov/settings_prod.py
@@ -53,7 +53,9 @@ CORS_ALLOWED_ORIGINS = [
 # Redirect after authentication, update this setting with care
 CORS_ALLOWED_ORIGIN_REGEXES = []
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = 15000000
+# 25MB in bytes
+DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
+
 SILENCED_SYSTEM_CHECKS = ["urls.W002"]
 
 # Reinforcing the Cookie SameSite configuration to be sure it's Lax in prod

--- a/codecov/settings_staging.py
+++ b/codecov/settings_staging.py
@@ -62,7 +62,8 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
 ]
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = 15000000
+# 25MB in bytes
+DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
 
 # Same site is set to none on Staging as we want to be able to call the API
 # From Netlify preview deploy

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -735,7 +735,7 @@ class GithubWebhookHandler(APIView):
 
     def post(self, request, *args, **kwargs):
         self.event = self.request.META.get(GitHubHTTPHeaders.EVENT)
-        log.debug(
+        log.info(
             "GitHub Webhook Handler invoked",
             extra=dict(
                 github_webhook_event=self.event,


### PR DESCRIPTION
### Purpose/Motivation

When looking through sentry issues, I saw one related to request body exceeding the max memory size, with [~800 events in the last 30 days](https://console.cloud.google.com/logs/query;query=jsonPayload.message%3D%22Request%20body%20exceeded%20settings.DATA_UPLOAD_MAX_MEMORY_SIZE.%22;summaryFields=jsonPayload%252Fusername:false:32:beginning;cursorTimestamp=2024-08-08T16:34:48.355847094Z;duration=P30D?project=genuine-polymer-165712&authuser=1&rapt=AEjHL4NstEBFMmkju6lWhfES-l36CF3N8JNO5BmHLfqmHGs074dXJ2LmKSBNlH3qpCYA1MLpwrBaPiHMeOfmV0cDHg1WIlGWtopDp8GaSYIUC2SlWj6bBWI). Looking at the stack trace, these all looked to be coming from the github webhook handler. Checking our current limit in API, it looks like our max size we currently allowed was set to 15MB; but then looking at the max github webhook size, they call out[ their size limit as 25MB.](https://docs.github.com/en/webhooks/webhook-events-and-payloads) Anyone have any objections with increasing our max size allowed to 25MB to match with github? The value was set in API 4+ years ago and hasn't changed, it wouldn't surprise me if Github has increased their limits over time, but it also wouldn't surprise me if this was a design decision made purposefully either.

This PR updates the value to be 25MB, as well as updating the log for all webhook coming in from debug to info, so we can track roughly how many events we were dropping over time (pre/post)

Github webhooks are responsible for repository, owner, installations, commits, pulls, etc. so it's imperative that we don't drop any of these events if we can help it!

[Sentry Issue](https://codecov.sentry.io/issues/4012653858/?project=5215654&project=5514400&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=3) -> mentions 6.6k events since we first noticed (March 2023)

Closes https://github.com/codecov/engineering-team/issues/2235

References:
- https://docs.github.com/en/webhooks/about-webhooks
- https://docs.djangoproject.com/en/5.0/ref/settings/

### Links to relevant tickets


### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
