### PR TITLE
Get app_redirect_url from owner object rather than request params

### DIFF
--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -29,7 +29,7 @@ def get_app_redirect_url(org_username: str, service: str) -> str:
     return f"{settings.CODECOV_DASHBOARD_URL}/{service}/{org_username}"
 
 
-def get_oauth_redirect_url(org_username: str, service: str) -> str:
+def get_oauth_redirect_url() -> str:
     """The Okta callback URL for us to finish the authentication."""
     return f"{settings.CODECOV_API_URL}/login/okta/callback"
 
@@ -72,8 +72,10 @@ class OktaCloudLoginView(OktaLoginMixin, View):
             )
             return HttpResponse(status=404)
 
-        app_redirect_url = get_app_redirect_url(org_username, service)
-        oauth_redirect_url = get_oauth_redirect_url(org_username, service)
+        app_redirect_url = get_app_redirect_url(
+            organization.username, organization.service
+        )
+        oauth_redirect_url = get_oauth_redirect_url()
 
         # User is already logged in, redirect them to the org page
         if organization.account.id in request.session.get(
@@ -130,9 +132,7 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
             return HttpResponse(status=404)
 
         app_redirect_url = get_app_redirect_url(org_owner.username, org_owner.service)
-        oauth_redirect_url = get_oauth_redirect_url(
-            org_owner.username, org_owner.service
-        )
+        oauth_redirect_url = get_oauth_redirect_url()
 
         # Redirect URL, need to validate and mark user as logged in
         if request.GET.get("code"):


### PR DESCRIPTION


### Purpose/Motivation
This is to appease the static analysis security scan to ensure that we are not directly using user input for redirect.

### Links to relevant tickets
https://github.com/codecov/internal-issues/issues/645

### What does this PR do?
Change which username and service we're using to generate the app url.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
