### PR TITLE
update plan service to work with self-hosted and DEC

### DIFF
--- a/plan/service.py
+++ b/plan/service.py
@@ -21,6 +21,8 @@ from plan.constants import (
     TrialStatus,
 )
 from services import sentry
+from services.self_hosted import license_seats
+from utils.config import get_config
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +73,8 @@ class PlanService:
 
     @property
     def plan_user_count(self) -> int:
+        if get_config("setup", "enterprise_license"):
+            return license_seats()
         return self.current_org.plan_user_count
 
     @property


### PR DESCRIPTION
### Purpose/Motivation
When an Org has a license, the `plan_user_count` on their Org is not accurate, the `number_allowed_users` from the license should be used for this value. Some self-hosted or DEC customers are getting a false positive on an alert that checks the seat count, because it's not checking whether they have a license.

### Links to relevant tickets
https://github.com/codecov/internal-issues/issues/679

### What does this PR do?
When checking `plan_user_count` in PlanService, if they have a license, return `number_allowed_users` as the value, which is the correct paid seat count for an Org with a license.
