### PR TITLE
remove session_totals field from report json

### DIFF
--- a/api/internal/tests/views/test_repo_view.py
+++ b/api/internal/tests/views/test_repo_view.py
@@ -743,14 +743,12 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
                 "filename": "test_file_1.py",
                 "file_index": 2,
                 "file_totals": [1, 10, 8, 2, 5, "80.00000", 6, 7, 9, 8, 20, 40, 13],
-                "session_totals": [[0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0]],
                 "diff_totals": [0, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
             },
             {
                 "filename": "test_file_2.py",
                 "file_index": 0,
                 "file_totals": [1, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0],
-                "session_totals": [[0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0]],
                 "diff_totals": None,
             },
         ]
@@ -842,9 +840,6 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
                                 40,
                                 13,
                             ],
-                            "session_totals": [
-                                [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0]
-                            ],
                             "diff_totals": [
                                 0,
                                 2,
@@ -878,9 +873,6 @@ class TestRepositoryViewSetDetailActions(RepositoryViewSetTestSuite):
                                 0,
                                 0,
                                 0,
-                            ],
-                            "session_totals": [
-                                [0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0]
                             ],
                             "diff_totals": None,
                         },

--- a/core/tests/factories.py
+++ b/core/tests/factories.py
@@ -89,25 +89,18 @@ class CommitWithReportFactory(CommitFactory):
                     "filename": "tests/__init__.py",
                     "file_index": 0,
                     "file_totals": [0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0],
-                    "session_totals": [
-                        [0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0]
-                    ],
                     "diff_totals": None,
                 },
                 {
                     "filename": "tests/test_sample.py",
                     "file_index": 1,
                     "file_totals": [0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0],
-                    "session_totals": [[0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0]],
                     "diff_totals": None,
                 },
                 {
                     "filename": "awesome/__init__.py",
                     "file_index": 2,
                     "file_totals": [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0],
-                    "session_totals": [
-                        [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0]
-                    ],
                     "diff_totals": [0, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
                 },
             ],

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/49f1bc9024dab50402e170e367439b6b80e6d8a4.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/aacbd7203ffec207adf94d97dadfcbcce55126b7.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -417,7 +417,7 @@ sentry-sdk[celery]==1.44.1
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/49f1bc9024dab50402e170e367439b6b80e6d8a4.tar.gz
+shared @ https://github.com/codecov/shared/archive/aacbd7203ffec207adf94d97dadfcbcce55126b7.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/services/report.py
+++ b/services/report.py
@@ -226,7 +226,6 @@ def build_files(commit_report: CommitReport) -> dict[str, ReportFileSummary]:
         file["filename"]: ReportFileSummary(
             file_index=file["file_index"],
             file_totals=ReportTotals(*file["file_totals"]),
-            session_totals=file["session_totals"],
             diff_totals=file["diff_totals"],
         )
         for file in report_details.files_array

--- a/services/tests/test_archive.py
+++ b/services/tests/test_archive.py
@@ -31,20 +31,12 @@ class TestWriteData(object):
                 "filename": "file_1.go",
                 "file_index": 0,
                 "file_totals": [0, 8, 5, 3, 0, "62.50000", 0, 0, 0, 0, 10, 2, 0],
-                "session_totals": {
-                    "0": [0, 8, 5, 3, 0, "62.50000", 0, 0, 0, 0, 10, 2],
-                    "meta": {"session_count": 1},
-                },
                 "diff_totals": None,
             },
             {
                 "filename": "file_2.py",
                 "file_index": 1,
                 "file_totals": [0, 2, 1, 0, 1, "50.00000", 1, 0, 0, 0, 0, 0, 0],
-                "session_totals": {
-                    "0": [0, 2, 1, 0, 1, "50.00000", 1],
-                    "meta": {"session_count": 1},
-                },
                 "diff_totals": None,
             },
         ]
@@ -79,20 +71,12 @@ class TestWriteData(object):
                 "filename": "file_1.go",
                 "file_index": 0,
                 "file_totals": [0, 8, 5, 3, 0, "62.50000", 0, 0, 0, 0, 10, 2, 0],
-                "session_totals": {
-                    "0": [0, 8, 5, 3, 0, "62.50000", 0, 0, 0, 0, 10, 2],
-                    "meta": {"session_count": 1},
-                },
                 "diff_totals": None,
             },
             {
                 "filename": "file_2.py",
                 "file_index": 1,
                 "file_totals": [0, 2, 1, 0, 1, "50.00000", 1, 0, 0, 0, 0, 0, 0],
-                "session_totals": {
-                    "0": [0, 2, 1, 0, 1, "50.00000", 1],
-                    "meta": {"session_count": 1},
-                },
                 "diff_totals": None,
             },
         ]


### PR DESCRIPTION
https://github.com/codecov/internal-issues/issues/515
https://github.com/codecov/shared/pull/329

this field is bugged and, as far as i can tell, unused. see ticket + shared PR for details