### PR TITLE
dev: safely retrieve obo_organization for billing webhooks

### DIFF
--- a/billing/views.py
+++ b/billing/views.py
@@ -131,8 +131,8 @@ class StripeWebhookHandler(APIView):
 
     def subscription_schedule_released(self, schedule: stripe.Subscription) -> None:
         subscription = stripe.Subscription.retrieve(schedule["released_subscription"])
-        owner = Owner.objects.get(ownerid=subscription.metadata["obo_organization"])
-        requesting_user_id = subscription.metadata["obo"]
+        owner = Owner.objects.get(ownerid=subscription.metadata.get("obo_organization"))
+        requesting_user_id = subscription.metadata.get("obo")
         plan_service = PlanService(current_org=owner)
 
         sub_item_plan_id = subscription.plan.id
@@ -166,7 +166,7 @@ class StripeWebhookHandler(APIView):
                 "Subscription created, but missing plan_id",
                 extra=dict(
                     stripe_customer_id=subscription.customer,
-                    ownerid=subscription.metadata["obo_organization"],
+                    ownerid=subscription.metadata.get("obo_organization"),
                     subscription_plan=subscription.plan,
                 ),
             )
@@ -177,7 +177,7 @@ class StripeWebhookHandler(APIView):
                 "Subscription creation requested for invalid plan",
                 extra=dict(
                     stripe_customer_id=subscription.customer,
-                    ownerid=subscription.metadata["obo_organization"],
+                    ownerid=subscription.metadata.get("obo_organization"),
                     plan_id=sub_item_plan_id,
                 ),
             )
@@ -190,12 +190,12 @@ class StripeWebhookHandler(APIView):
             extra=dict(
                 stripe_customer_id=subscription.customer,
                 stripe_subscription_id=subscription.id,
-                ownerid=subscription.metadata["obo_organization"],
+                ownerid=subscription.metadata.get("obo_organization"),
                 plan=plan_name,
                 quantity=subscription.quantity,
             ),
         )
-        owner = Owner.objects.get(ownerid=subscription.metadata["obo_organization"])
+        owner = Owner.objects.get(ownerid=subscription.metadata.get("obo_organization"))
         owner.stripe_subscription_id = subscription.id
         owner.stripe_customer_id = subscription.customer
         owner.save()


### PR DESCRIPTION
### Purpose/Motivation

Couple quick .get() instead of direct key access for obo_organization


### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
