### PR TITLE
fix: replace special char in test name with space

### DIFF
--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -23,7 +23,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             author=self.owner,
         )
         self.test = TestFactory(
-            name="Test Name",
+            name="Test\x1fName",
             repository=self.repository,
         )
         _ = TestInstanceFactory(
@@ -71,10 +71,9 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
         result = self.gql_request(query, owner=self.owner)
 
         assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testResults"]["edges"][0]["node"]["name"]
-            == self.test.name
-        )
+        assert result["owner"]["repository"]["testResults"]["edges"][0]["node"][
+            "name"
+        ] == self.test.name.replace("\x1f", " ")
 
     def test_fetch_test_result_updated_at(self) -> None:
         query = """

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -9,7 +9,7 @@ test_result_bindable = ObjectType("TestResult")
 
 @test_result_bindable.field("name")
 def resolve_name(test, info) -> str:
-    return test["name"]
+    return test["name"].replace("\x1f", " ")
 
 
 @test_result_bindable.field("updatedAt")


### PR DESCRIPTION
We collate the class name and test case name parsed from the JUnit XMLs with a special char `\x1f`, we want to display it as a space though. Perhaps this logic should occur in Gazebo?