### PR TITLE
chore: Remove deprecated utcnow fn

### DIFF
--- a/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import pytest
 from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase
-from django.utils import timezone
 from freezegun import freeze_time
 
 from codecov.commands.exceptions import Unauthorized, ValidationError

--- a/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from asgiref.sync import async_to_sync
@@ -58,7 +58,7 @@ class CancelTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_cancel_trial_raises_exception_when_owners_trial_status_is_expired(self):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         trial_start_date = now + timedelta(days=-10)
         trial_end_date = now + timedelta(days=-4)
         current_user = OwnerFactory(
@@ -72,7 +72,7 @@ class CancelTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_cancel_trial_starts_trial_for_org_that_has_trial_ongoing(self):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         trial_start_date = now
         trial_end_date = now + timedelta(days=3)
         current_user: Owner = OwnerFactory(
@@ -86,7 +86,7 @@ class CancelTrialInteractorTest(TransactionTestCase):
         self.execute(current_user=current_user, org_username=current_user.username)
         current_user.refresh_from_db()
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         assert current_user.trial_end_date == now
         assert current_user.trial_status == TrialStatus.EXPIRED.value
         assert current_user.plan == PlanName.BASIC_PLAN_NAME.value

--- a/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_cancel_trial.py
@@ -1,8 +1,9 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from asgiref.sync import async_to_sync
 from django.test import TransactionTestCase
+from django.utils import timezone
 from freezegun import freeze_time
 
 from codecov.commands.exceptions import Unauthorized, ValidationError
@@ -58,7 +59,7 @@ class CancelTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_cancel_trial_raises_exception_when_owners_trial_status_is_expired(self):
-        now = datetime.now(UTC)
+        now = datetime.now()
         trial_start_date = now + timedelta(days=-10)
         trial_end_date = now + timedelta(days=-4)
         current_user = OwnerFactory(
@@ -72,7 +73,7 @@ class CancelTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_cancel_trial_starts_trial_for_org_that_has_trial_ongoing(self):
-        now = datetime.now(UTC)
+        now = datetime.now()
         trial_start_date = now
         trial_end_date = now + timedelta(days=3)
         current_user: Owner = OwnerFactory(
@@ -86,7 +87,7 @@ class CancelTrialInteractorTest(TransactionTestCase):
         self.execute(current_user=current_user, org_username=current_user.username)
         current_user.refresh_from_db()
 
-        now = datetime.now(UTC)
+        now = datetime.now()
         assert current_user.trial_end_date == now
         assert current_user.trial_status == TrialStatus.EXPIRED.value
         assert current_user.plan == PlanName.BASIC_PLAN_NAME.value

--- a/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
@@ -43,8 +43,9 @@ class GetUploadsNumberPerUserInteractorTest(TransactionTestCase):
         # Trial Data
         self.trial_owner = OwnerFactory(
             trial_status=TrialStatus.EXPIRED.value,
-            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
-            trial_end_date=datetime.now(UTC) + timedelta(days=-2),
+            trial_start_date=datetime.now(UTC).replace(tzinfo=None)
+            + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=-2),
         )
         trial_repo = RepositoryFactory.create(author=self.trial_owner, private=True)
         trial_commit = CommitFactory.create(repository=trial_repo)

--- a/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.test import TransactionTestCase
 from shared.django_apps.reports.models import ReportType
@@ -43,8 +43,8 @@ class GetUploadsNumberPerUserInteractorTest(TransactionTestCase):
         # Trial Data
         self.trial_owner = OwnerFactory(
             trial_status=TrialStatus.EXPIRED.value,
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-2),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-2),
         )
         trial_repo = RepositoryFactory.create(author=self.trial_owner, private=True)
         trial_commit = CommitFactory.create(repository=trial_repo)

--- a/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 from django.test import TransactionTestCase
 from shared.django_apps.reports.models import ReportType

--- a/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_get_uploads_number_per_user.py
@@ -43,9 +43,8 @@ class GetUploadsNumberPerUserInteractorTest(TransactionTestCase):
         # Trial Data
         self.trial_owner = OwnerFactory(
             trial_status=TrialStatus.EXPIRED.value,
-            trial_start_date=datetime.now(UTC).replace(tzinfo=None)
-            + timedelta(days=-10),
-            trial_end_date=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=-2),
+            trial_start_date=datetime.now() + timedelta(days=-10),
+            trial_end_date=datetime.now() + timedelta(days=-2),
         )
         trial_repo = RepositoryFactory.create(author=self.trial_owner, private=True)
         trial_commit = CommitFactory.create(repository=trial_repo)

--- a/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
@@ -44,7 +44,7 @@ class StartTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_start_trial_raises_exception_when_owners_trial_status_is_ongoing(self):
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now()
         trial_start_date = now
         trial_end_date = now + timedelta(days=3)
         current_user = OwnerFactory(

--- a/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest

--- a/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -44,7 +44,7 @@ class StartTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_start_trial_raises_exception_when_owners_trial_status_is_ongoing(self):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         trial_start_date = now
         trial_end_date = now + timedelta(days=3)
         current_user = OwnerFactory(
@@ -59,7 +59,7 @@ class StartTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_start_trial_raises_exception_when_owners_trial_status_is_expired(self):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         trial_start_date = now + timedelta(days=-10)
         trial_end_date = now + timedelta(days=-4)
         current_user = OwnerFactory(
@@ -76,7 +76,7 @@ class StartTrialInteractorTest(TransactionTestCase):
     def test_start_trial_raises_exception_when_owners_trial_status_cannot_trial(
         self,
     ):
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         trial_start_date = now
         trial_end_date = now
         current_user = OwnerFactory(
@@ -103,7 +103,7 @@ class StartTrialInteractorTest(TransactionTestCase):
         self.execute(current_user=current_user, org_username=current_user.username)
         current_user.refresh_from_db()
 
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         assert current_user.trial_start_date == now
         assert current_user.trial_end_date == now + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value

--- a/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_start_trial.py
@@ -44,7 +44,7 @@ class StartTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_start_trial_raises_exception_when_owners_trial_status_is_ongoing(self):
-        now = datetime.now(UTC)
+        now = datetime.now(UTC).replace(tzinfo=None)
         trial_start_date = now
         trial_end_date = now + timedelta(days=3)
         current_user = OwnerFactory(
@@ -59,7 +59,7 @@ class StartTrialInteractorTest(TransactionTestCase):
 
     @freeze_time("2022-01-01T00:00:00")
     def test_start_trial_raises_exception_when_owners_trial_status_is_expired(self):
-        now = datetime.now(UTC)
+        now = datetime.now()
         trial_start_date = now + timedelta(days=-10)
         trial_end_date = now + timedelta(days=-4)
         current_user = OwnerFactory(
@@ -76,7 +76,7 @@ class StartTrialInteractorTest(TransactionTestCase):
     def test_start_trial_raises_exception_when_owners_trial_status_cannot_trial(
         self,
     ):
-        now = datetime.now(UTC)
+        now = datetime.now()
         trial_start_date = now
         trial_end_date = now
         current_user = OwnerFactory(
@@ -103,7 +103,7 @@ class StartTrialInteractorTest(TransactionTestCase):
         self.execute(current_user=current_user, org_username=current_user.username)
         current_user.refresh_from_db()
 
-        now = datetime.now(UTC)
+        now = datetime.now()
         assert current_user.trial_start_date == now
         assert current_user.trial_end_date == now + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value

--- a/codecov_auth/management/commands/set_trial_status_values.py
+++ b/codecov_auth/management/commands/set_trial_status_values.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.core.management.base import BaseCommand, CommandParser
 from django.db.models import Q
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         if trial_status_type == "all" or trial_status_type == "ongoing":
             Owner.objects.filter(
                 plan__in=SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
-                trial_end_date__gt=datetime.utcnow(),
+                trial_end_date__gt=datetime.now(UTC),
             ).update(trial_status=TrialStatus.ONGOING.value)
 
         # EXPIRED
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                     plan__in=SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
                     stripe_customer_id__isnull=False,
                     stripe_subscription_id__isnull=False,
-                    trial_end_date__lte=datetime.utcnow(),
+                    trial_end_date__lte=datetime.now(UTC),
                 )
                 # Currently paying sentry customer without trial_end_date
                 | Q(

--- a/codecov_auth/management/commands/set_trial_status_values.py
+++ b/codecov_auth/management/commands/set_trial_status_values.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 
 from django.core.management.base import BaseCommand, CommandParser
 from django.db.models import Q

--- a/codecov_auth/management/commands/set_trial_status_values.py
+++ b/codecov_auth/management/commands/set_trial_status_values.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         if trial_status_type == "all" or trial_status_type == "ongoing":
             Owner.objects.filter(
                 plan__in=SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
-                trial_end_date__gt=datetime.now(UTC),
+                trial_end_date__gt=datetime.now(),
             ).update(trial_status=TrialStatus.ONGOING.value)
 
         # EXPIRED
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                     plan__in=SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
                     stripe_customer_id__isnull=False,
                     stripe_subscription_id__isnull=False,
-                    trial_end_date__lte=datetime.now(UTC),
+                    trial_end_date__lte=datetime.now(),
                 )
                 # Currently paying sentry customer without trial_end_date
                 | Q(

--- a/codecov_auth/management/commands/tests/test_set_trial_status_values.py
+++ b/codecov_auth/management/commands/tests/test_set_trial_status_values.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 from django.core.management.base import BaseCommand
 from django.test import TestCase

--- a/codecov_auth/management/commands/tests/test_set_trial_status_values.py
+++ b/codecov_auth/management/commands/tests/test_set_trial_status_values.py
@@ -14,7 +14,7 @@ from plan.constants import PlanName, TrialStatus
 class OwnerCommandTestCase(TestCase):
     def setUp(self):
         self.command_instance = BaseCommand()
-        now = datetime.now(UTC)
+        now = datetime.now()
         later = now + timedelta(days=3)
         yesterday = now + timedelta(days=-1)
         much_before = now + timedelta(days=-20)

--- a/codecov_auth/management/commands/tests/test_set_trial_status_values.py
+++ b/codecov_auth/management/commands/tests/test_set_trial_status_values.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.core.management.base import BaseCommand
 from django.test import TestCase
@@ -14,7 +14,7 @@ from plan.constants import PlanName, TrialStatus
 class OwnerCommandTestCase(TestCase):
     def setUp(self):
         self.command_instance = BaseCommand()
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         later = now + timedelta(days=3)
         yesterday = now + timedelta(days=-1)
         much_before = now + timedelta(days=-20)

--- a/plan/service.py
+++ b/plan/service.py
@@ -151,7 +151,7 @@ class PlanService:
         end_date: Optional[datetime] = None,
         is_extension: bool = False,
     ) -> None:
-        start_date = datetime.now(UTC)
+        start_date = datetime.now()
 
         # When they are not extending a trial, have to setup all the default values
         if not is_extension:
@@ -211,7 +211,7 @@ class PlanService:
     def cancel_trial(self) -> None:
         if not self.is_org_trialing:
             raise ValidationError("Cannot cancel a trial that is not ongoing")
-        now = datetime.now(UTC)
+        now = datetime.now()
         self.current_org.trial_status = TrialStatus.EXPIRED.value
         self.current_org.trial_end_date = now
         self.set_default_plan_data()
@@ -234,7 +234,7 @@ class PlanService:
             self.current_org.plan_user_count = (
                 self.current_org.pretrial_users_count or 1
             )
-            self.current_org.trial_end_date = datetime.now(UTC)
+            self.current_org.trial_end_date = datetime.now()
 
             self.current_org.save()
 

--- a/plan/service.py
+++ b/plan/service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from codecov.commands.exceptions import ValidationError

--- a/plan/service.py
+++ b/plan/service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import List, Optional
 
 from codecov.commands.exceptions import ValidationError
@@ -151,7 +151,7 @@ class PlanService:
         end_date: Optional[datetime] = None,
         is_extension: bool = False,
     ) -> None:
-        start_date = datetime.utcnow()
+        start_date = datetime.now(UTC)
 
         # When they are not extending a trial, have to setup all the default values
         if not is_extension:
@@ -211,7 +211,7 @@ class PlanService:
     def cancel_trial(self) -> None:
         if not self.is_org_trialing:
             raise ValidationError("Cannot cancel a trial that is not ongoing")
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         self.current_org.trial_status = TrialStatus.EXPIRED.value
         self.current_org.trial_end_date = now
         self.set_default_plan_data()
@@ -234,7 +234,7 @@ class PlanService:
             self.current_org.plan_user_count = (
                 self.current_org.pretrial_users_count or 1
             )
-            self.current_org.trial_end_date = datetime.utcnow()
+            self.current_org.trial_end_date = datetime.now(UTC)
 
             self.current_org.save()
 

--- a/plan/tests/test_plan.py
+++ b/plan/tests/test_plan.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.test import TestCase

--- a/plan/tests/test_plan.py
+++ b/plan/tests/test_plan.py
@@ -32,7 +32,7 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_status == TrialStatus.NOT_STARTED.value
 
     def test_plan_service_trial_status_expired(self):
-        trial_start_date = datetime.now(UTC)
+        trial_start_date = datetime.now()
         trial_end_date_expired = trial_start_date - timedelta(days=1)
         current_org = OwnerFactory(
             plan=PlanName.BASIC_PLAN_NAME.value,
@@ -45,7 +45,7 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_status == TrialStatus.EXPIRED.value
 
     def test_plan_service_trial_status_ongoing(self):
-        trial_start_date = datetime.now(UTC)
+        trial_start_date = datetime.now()
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         current_org = OwnerFactory(
             plan=PlanName.TRIAL_PLAN_NAME.value,
@@ -72,12 +72,12 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == 1
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now()
 
     def test_plan_service_expire_trial_when_upgrading_successful_if_trial_is_ongoing(
         self,
     ):
-        trial_start_date = datetime.now(UTC)
+        trial_start_date = datetime.now()
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         current_org_with_ongoing_trial = OwnerFactory(
             plan=PlanName.BASIC_PLAN_NAME.value,
@@ -90,12 +90,12 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == 1
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now()
 
     def test_plan_service_expire_trial_users_pretrial_users_count_if_existing(
         self,
     ):
-        trial_start_date = datetime.now(UTC)
+        trial_start_date = datetime.now()
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         pretrial_users_count = 5
         current_org_with_ongoing_trial = OwnerFactory(
@@ -110,10 +110,10 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == pretrial_users_count
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now()
 
     def test_plan_service_start_trial_errors_if_status_is_ongoing(self):
-        trial_start_date = datetime.now(UTC)
+        trial_start_date = datetime.now()
         trial_end_date = trial_start_date + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
@@ -130,7 +130,7 @@ class PlanServiceTests(TestCase):
             plan_service.start_trial(current_owner=current_owner)
 
     def test_plan_service_start_trial_errors_if_status_is_expired(self):
-        trial_start_date = datetime.now(UTC)
+        trial_start_date = datetime.now()
         trial_end_date = trial_start_date + timedelta(days=-1)
         current_org = OwnerFactory(
             plan=PlanName.BASIC_PLAN_NAME.value,
@@ -185,8 +185,8 @@ class PlanServiceTests(TestCase):
         current_owner = OwnerFactory()
 
         plan_service.start_trial(current_owner=current_owner)
-        assert current_org.trial_start_date == datetime.now(UTC)
-        assert current_org.trial_end_date == datetime.now(UTC) + timedelta(
+        assert current_org.trial_start_date == datetime.now()
+        assert current_org.trial_end_date == datetime.now() + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
         assert current_org.trial_status == TrialStatus.ONGOING.value
@@ -213,7 +213,7 @@ class PlanServiceTests(TestCase):
         plan_service.start_trial_manually(
             current_owner=current_owner, end_date="2024-01-01 00:00:00"
         )
-        assert current_org.trial_start_date == datetime.now(UTC)
+        assert current_org.trial_start_date == datetime.now()
         assert current_org.trial_end_date == "2024-01-01 00:00:00"
         assert current_org.trial_status == TrialStatus.ONGOING.value
         assert current_org.plan == PlanName.TRIAL_PLAN_NAME.value
@@ -265,8 +265,8 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_total_days == basic_plan.trial_days
 
     def test_plan_service_returns_plan_data_for_trialing_user_trial_plan(self):
-        trial_start_date = datetime.now(UTC)
-        trial_end_date = datetime.now(UTC) + timedelta(
+        trial_start_date = datetime.now()
+        trial_end_date = datetime.now() + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
         current_org = OwnerFactory(
@@ -309,8 +309,8 @@ class PlanServiceTests(TestCase):
     def test_plan_service_returns_if_owner_has_trial_dates(self):
         current_org = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value,
-            trial_start_date=datetime.now(UTC),
-            trial_end_date=datetime.now(UTC) + timedelta(days=14),
+            trial_start_date=datetime.now(),
+            trial_end_date=datetime.now() + timedelta(days=14),
         )
         current_org.save()
 
@@ -508,8 +508,8 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
 
     def setUp(self):
         self.current_org = OwnerFactory(
-            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
-            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
+            trial_start_date=datetime.now() + timedelta(days=-10),
+            trial_end_date=datetime.now() + timedelta(days=-3),
             trial_status=TrialStatus.EXPIRED.value,
             plan_user_count=3,
         )
@@ -623,8 +623,8 @@ class AvailablePlansExpiredTrialMoreThanTenActivatedUsers(TestCase):
 
     def setUp(self):
         self.current_org = OwnerFactory(
-            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
-            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
+            trial_start_date=datetime.now() + timedelta(days=-10),
+            trial_end_date=datetime.now() + timedelta(days=-3),
             trial_status=TrialStatus.EXPIRED.value,
             plan_user_count=1,
             plan_activated_users=[i for i in range(13)],
@@ -708,8 +708,8 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
             plan_user_count=100,
             plan_activated_users=[i for i in range(10)],
             trial_status=TrialStatus.EXPIRED.value,
-            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
-            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
+            trial_start_date=datetime.now() + timedelta(days=-10),
+            trial_end_date=datetime.now() + timedelta(days=-3),
         )
         self.owner = OwnerFactory()
         self.plan_service = PlanService(current_org=self.current_org)
@@ -723,8 +723,8 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
             plan_user_count=100,
             plan_activated_users=[i for i in range(10)],
             trial_status=TrialStatus.ONGOING.value,
-            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
-            trial_end_date=datetime.now(UTC) + timedelta(days=3),
+            trial_start_date=datetime.now() + timedelta(days=-10),
+            trial_end_date=datetime.now() + timedelta(days=3),
         )
         self.owner = OwnerFactory()
         self.plan_service = PlanService(current_org=self.current_org)
@@ -765,8 +765,8 @@ class AvailablePlansOngoingTrial(TestCase):
     def setUp(self):
         self.current_org = OwnerFactory(
             plan=PlanName.TRIAL_PLAN_NAME.value,
-            trial_start_date=datetime.now(UTC),
-            trial_end_date=datetime.now(UTC) + timedelta(days=14),
+            trial_start_date=datetime.now(),
+            trial_end_date=datetime.now() + timedelta(days=14),
             trial_status=TrialStatus.ONGOING.value,
             plan_user_count=1000,
             plan_activated_users=None,

--- a/plan/tests/test_plan.py
+++ b/plan/tests/test_plan.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -32,7 +32,7 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_status == TrialStatus.NOT_STARTED.value
 
     def test_plan_service_trial_status_expired(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_expired = trial_start_date - timedelta(days=1)
         current_org = OwnerFactory(
             plan=PlanName.BASIC_PLAN_NAME.value,
@@ -45,7 +45,7 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_status == TrialStatus.EXPIRED.value
 
     def test_plan_service_trial_status_ongoing(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         current_org = OwnerFactory(
             plan=PlanName.TRIAL_PLAN_NAME.value,
@@ -72,12 +72,12 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == 1
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.utcnow()
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
 
     def test_plan_service_expire_trial_when_upgrading_successful_if_trial_is_ongoing(
         self,
     ):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         current_org_with_ongoing_trial = OwnerFactory(
             plan=PlanName.BASIC_PLAN_NAME.value,
@@ -90,12 +90,12 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == 1
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.utcnow()
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
 
     def test_plan_service_expire_trial_users_pretrial_users_count_if_existing(
         self,
     ):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date_ongoing = trial_start_date + timedelta(days=5)
         pretrial_users_count = 5
         current_org_with_ongoing_trial = OwnerFactory(
@@ -110,10 +110,10 @@ class PlanServiceTests(TestCase):
         assert current_org_with_ongoing_trial.trial_status == TrialStatus.EXPIRED.value
         assert current_org_with_ongoing_trial.plan_activated_users is None
         assert current_org_with_ongoing_trial.plan_user_count == pretrial_users_count
-        assert current_org_with_ongoing_trial.trial_end_date == datetime.utcnow()
+        assert current_org_with_ongoing_trial.trial_end_date == datetime.now(UTC)
 
     def test_plan_service_start_trial_errors_if_status_is_ongoing(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date = trial_start_date + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
@@ -130,7 +130,7 @@ class PlanServiceTests(TestCase):
             plan_service.start_trial(current_owner=current_owner)
 
     def test_plan_service_start_trial_errors_if_status_is_expired(self):
-        trial_start_date = datetime.utcnow()
+        trial_start_date = datetime.now(UTC)
         trial_end_date = trial_start_date + timedelta(days=-1)
         current_org = OwnerFactory(
             plan=PlanName.BASIC_PLAN_NAME.value,
@@ -185,8 +185,8 @@ class PlanServiceTests(TestCase):
         current_owner = OwnerFactory()
 
         plan_service.start_trial(current_owner=current_owner)
-        assert current_org.trial_start_date == datetime.utcnow()
-        assert current_org.trial_end_date == datetime.utcnow() + timedelta(
+        assert current_org.trial_start_date == datetime.now(UTC)
+        assert current_org.trial_end_date == datetime.now(UTC) + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
         assert current_org.trial_status == TrialStatus.ONGOING.value
@@ -213,7 +213,7 @@ class PlanServiceTests(TestCase):
         plan_service.start_trial_manually(
             current_owner=current_owner, end_date="2024-01-01 00:00:00"
         )
-        assert current_org.trial_start_date == datetime.utcnow()
+        assert current_org.trial_start_date == datetime.now(UTC)
         assert current_org.trial_end_date == "2024-01-01 00:00:00"
         assert current_org.trial_status == TrialStatus.ONGOING.value
         assert current_org.plan == PlanName.TRIAL_PLAN_NAME.value
@@ -265,8 +265,8 @@ class PlanServiceTests(TestCase):
         assert plan_service.trial_total_days == basic_plan.trial_days
 
     def test_plan_service_returns_plan_data_for_trialing_user_trial_plan(self):
-        trial_start_date = datetime.utcnow()
-        trial_end_date = datetime.utcnow() + timedelta(
+        trial_start_date = datetime.now(UTC)
+        trial_end_date = datetime.now(UTC) + timedelta(
             days=TrialDaysAmount.CODECOV_SENTRY.value
         )
         current_org = OwnerFactory(
@@ -309,8 +309,8 @@ class PlanServiceTests(TestCase):
     def test_plan_service_returns_if_owner_has_trial_dates(self):
         current_org = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value,
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
+            trial_start_date=datetime.now(UTC),
+            trial_end_date=datetime.now(UTC) + timedelta(days=14),
         )
         current_org.save()
 
@@ -508,8 +508,8 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
 
     def setUp(self):
         self.current_org = OwnerFactory(
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
             trial_status=TrialStatus.EXPIRED.value,
             plan_user_count=3,
         )
@@ -623,8 +623,8 @@ class AvailablePlansExpiredTrialMoreThanTenActivatedUsers(TestCase):
 
     def setUp(self):
         self.current_org = OwnerFactory(
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
             trial_status=TrialStatus.EXPIRED.value,
             plan_user_count=1,
             plan_activated_users=[i for i in range(13)],
@@ -708,8 +708,8 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
             plan_user_count=100,
             plan_activated_users=[i for i in range(10)],
             trial_status=TrialStatus.EXPIRED.value,
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=-3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=-3),
         )
         self.owner = OwnerFactory()
         self.plan_service = PlanService(current_org=self.current_org)
@@ -723,8 +723,8 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
             plan_user_count=100,
             plan_activated_users=[i for i in range(10)],
             trial_status=TrialStatus.ONGOING.value,
-            trial_start_date=datetime.utcnow() + timedelta(days=-10),
-            trial_end_date=datetime.utcnow() + timedelta(days=3),
+            trial_start_date=datetime.now(UTC) + timedelta(days=-10),
+            trial_end_date=datetime.now(UTC) + timedelta(days=3),
         )
         self.owner = OwnerFactory()
         self.plan_service = PlanService(current_org=self.current_org)
@@ -765,8 +765,8 @@ class AvailablePlansOngoingTrial(TestCase):
     def setUp(self):
         self.current_org = OwnerFactory(
             plan=PlanName.TRIAL_PLAN_NAME.value,
-            trial_start_date=datetime.utcnow(),
-            trial_end_date=datetime.utcnow() + timedelta(days=14),
+            trial_start_date=datetime.now(UTC),
+            trial_end_date=datetime.now(UTC) + timedelta(days=14),
             trial_status=TrialStatus.ONGOING.value,
             plan_user_count=1000,
             plan_activated_users=None,

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -334,7 +334,7 @@ class UploadHandlerHelpersTest(TestCase):
         repo = G(Repository, author=org)
         expected_response = {
             "id": 732059764,
-            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None)}",
+            "finishTime": f"{datetime.now()}",
             "status": "inProgress",
             "sourceVersion": "3be5c52bd748c508a7e96993c02cf3518c816e84",
             "buildNumber": "732059764",
@@ -342,7 +342,7 @@ class UploadHandlerHelpersTest(TestCase):
             "number": "498.1",
             "state": "passed",
             "started_at": "2020-10-01T20:02:55Z",
-            "finished_at": f"{datetime.now(UTC).replace(tzinfo=None)}".split(".")[0],
+            "finished_at": f"{datetime.now()}".split(".")[0],
             "project": {"visibility": "public", "repositoryType": "github"},
             "triggerInfo": {"pr.sourceSha": "3be5c52bd748c508a7e96993c02cf3518c816e84"},
             "build": {
@@ -1992,7 +1992,7 @@ class UploadHandlerTravisTokenlessTest(TestCase):
             "number": "498.1",
             "state": "passed",
             "started_at": "2020-10-01T20:02:55Z",
-            "finished_at": f"{datetime.now(UTC)}".split(".")[0],
+            "finished_at": f"{datetime.now()}".split(".")[0],
             "build": {
                 "@type": "build",
                 "@href": "/build/732059763",
@@ -2279,7 +2279,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_wrong_build_number(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None)}",
+            "finishTime": f"{datetime.now()}",
             "buildNumber": "BADBUILDNUM",
             "status": "completed",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2308,7 +2308,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_expired_build(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=4)}",
+            "finishTime": f"{datetime.now() - timedelta(minutes=4)}",
             "buildNumber": "20190725.8",
             "status": "completed",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2338,7 +2338,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_invalid_status(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None)}",
+            "finishTime": f"{datetime.now()}",
             "buildNumber": "20190725.8",
             "status": "BADSTATUS",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2727,7 +2727,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.now(UTC).replace(tzinfo=None)}".split(".")[0],
+            "finish_time": f"{datetime.now()}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response
@@ -2916,9 +2916,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=10)}".split(
-                "."
-            )[0],
+            "finish_time": f"{datetime.now() - timedelta(minutes=10)}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response
@@ -2947,7 +2945,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.now(UTC).replace(tzinfo=None)}".split(".")[0],
+            "finish_time": f"{datetime.now()}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -334,7 +334,7 @@ class UploadHandlerHelpersTest(TestCase):
         repo = G(Repository, author=org)
         expected_response = {
             "id": 732059764,
-            "finishTime": f"{datetime.now(UTC)}",
+            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None)}",
             "status": "inProgress",
             "sourceVersion": "3be5c52bd748c508a7e96993c02cf3518c816e84",
             "buildNumber": "732059764",
@@ -342,7 +342,7 @@ class UploadHandlerHelpersTest(TestCase):
             "number": "498.1",
             "state": "passed",
             "started_at": "2020-10-01T20:02:55Z",
-            "finished_at": f"{datetime.now(UTC)}".split(".")[0],
+            "finished_at": f"{datetime.now(UTC).replace(tzinfo=None)}".split(".")[0],
             "project": {"visibility": "public", "repositoryType": "github"},
             "triggerInfo": {"pr.sourceSha": "3be5c52bd748c508a7e96993c02cf3518c816e84"},
             "build": {
@@ -2279,7 +2279,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_wrong_build_number(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.now(UTC)}",
+            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None)}",
             "buildNumber": "BADBUILDNUM",
             "status": "completed",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2308,7 +2308,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_expired_build(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.now(UTC) - timedelta(minutes=4)}",
+            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=4)}",
             "buildNumber": "20190725.8",
             "status": "completed",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2338,7 +2338,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_invalid_status(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.now(UTC)}",
+            "finishTime": f"{datetime.now(UTC).replace(tzinfo=None)}",
             "buildNumber": "20190725.8",
             "status": "BADSTATUS",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2727,7 +2727,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.now(UTC)}".split(".")[0],
+            "finish_time": f"{datetime.now(UTC).replace(tzinfo=None)}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response
@@ -2916,7 +2916,9 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.now(UTC) - timedelta(minutes=10)}".split(".")[0],
+            "finish_time": f"{datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=10)}".split(
+                "."
+            )[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response
@@ -2945,7 +2947,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.now(UTC)}".split(".")[0],
+            "finish_time": f"{datetime.now(UTC).replace(tzinfo=None)}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -1,5 +1,5 @@
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from json import dumps, loads
 from unittest.mock import ANY, PropertyMock, patch
 from urllib.parse import urlencode

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from json import dumps, loads
 from unittest.mock import ANY, PropertyMock, patch
 from urllib.parse import urlencode
@@ -334,7 +334,7 @@ class UploadHandlerHelpersTest(TestCase):
         repo = G(Repository, author=org)
         expected_response = {
             "id": 732059764,
-            "finishTime": f"{datetime.utcnow()}",
+            "finishTime": f"{datetime.now(UTC)}",
             "status": "inProgress",
             "sourceVersion": "3be5c52bd748c508a7e96993c02cf3518c816e84",
             "buildNumber": "732059764",
@@ -342,7 +342,7 @@ class UploadHandlerHelpersTest(TestCase):
             "number": "498.1",
             "state": "passed",
             "started_at": "2020-10-01T20:02:55Z",
-            "finished_at": f"{datetime.utcnow()}".split(".")[0],
+            "finished_at": f"{datetime.now(UTC)}".split(".")[0],
             "project": {"visibility": "public", "repositoryType": "github"},
             "triggerInfo": {"pr.sourceSha": "3be5c52bd748c508a7e96993c02cf3518c816e84"},
             "build": {
@@ -1992,7 +1992,7 @@ class UploadHandlerTravisTokenlessTest(TestCase):
             "number": "498.1",
             "state": "passed",
             "started_at": "2020-10-01T20:02:55Z",
-            "finished_at": f"{datetime.utcnow()}".split(".")[0],
+            "finished_at": f"{datetime.now(UTC)}".split(".")[0],
             "build": {
                 "@type": "build",
                 "@href": "/build/732059763",
@@ -2279,7 +2279,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_wrong_build_number(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.utcnow()}",
+            "finishTime": f"{datetime.now(UTC)}",
             "buildNumber": "BADBUILDNUM",
             "status": "completed",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2308,7 +2308,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_expired_build(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.utcnow() - timedelta(minutes=4)}",
+            "finishTime": f"{datetime.now(UTC) - timedelta(minutes=4)}",
             "buildNumber": "20190725.8",
             "status": "completed",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2338,7 +2338,7 @@ class UploadHandlerAzureTokenlessTest(TestCase):
     @patch.object(requests, "get")
     def test_azure_invalid_status(self, mock_get):
         expected_response = {
-            "finishTime": f"{datetime.utcnow()}",
+            "finishTime": f"{datetime.now(UTC)}",
             "buildNumber": "20190725.8",
             "status": "BADSTATUS",
             "sourceVersion": "c739768fcac68144a3a6d82305b9c4106934d31a",
@@ -2727,7 +2727,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.utcnow()}".split(".")[0],
+            "finish_time": f"{datetime.now(UTC)}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response
@@ -2916,7 +2916,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.utcnow() - timedelta(minutes=10)}".split(".")[0],
+            "finish_time": f"{datetime.now(UTC) - timedelta(minutes=10)}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response
@@ -2945,7 +2945,7 @@ class UploadHandlerGithubActionsTokenlessTest(TestCase):
             "commit_sha": "c739768fcac68144a3a6d82305b9c4106934d31a",
             "slug": "owner/repo",
             "public": True,
-            "finish_time": f"{datetime.utcnow()}".split(".")[0],
+            "finish_time": f"{datetime.now(UTC)}".split(".")[0],
         }
         mock_get.return_value.status_code.return_value = 200
         mock_get.return_value.return_value = expected_response

--- a/upload/tokenless/azure.py
+++ b/upload/tokenless/azure.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 import requests
 from requests.exceptions import ConnectionError, HTTPError

--- a/upload/tokenless/azure.py
+++ b/upload/tokenless/azure.py
@@ -82,7 +82,7 @@ class TokenlessAzureHandler(BaseTokenlessUploadHandler):
                 finishTimestamp, "%Y-%m-%d %H:%M:%S.%f"
             )
             finishTimeWithBuffer = buildFinishDateObj + timedelta(minutes=4)
-            now = datetime.now(UTC).replace(tzinfo=None)
+            now = datetime.now()
             if not now <= finishTimeWithBuffer:
                 raise NotFound(
                     "Azure build has already finished. Please upload with the Codecov repository upload token to resolve issue."

--- a/upload/tokenless/azure.py
+++ b/upload/tokenless/azure.py
@@ -82,7 +82,7 @@ class TokenlessAzureHandler(BaseTokenlessUploadHandler):
                 finishTimestamp, "%Y-%m-%d %H:%M:%S.%f"
             )
             finishTimeWithBuffer = buildFinishDateObj + timedelta(minutes=4)
-            now = datetime.now(UTC)
+            now = datetime.now(UTC).replace(tzinfo=None)
             if not now <= finishTimeWithBuffer:
                 raise NotFound(
                     "Azure build has already finished. Please upload with the Codecov repository upload token to resolve issue."

--- a/upload/tokenless/azure.py
+++ b/upload/tokenless/azure.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import requests
 from requests.exceptions import ConnectionError, HTTPError
@@ -82,7 +82,7 @@ class TokenlessAzureHandler(BaseTokenlessUploadHandler):
                 finishTimestamp, "%Y-%m-%d %H:%M:%S.%f"
             )
             finishTimeWithBuffer = buildFinishDateObj + timedelta(minutes=4)
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             if not now <= finishTimeWithBuffer:
                 raise NotFound(
                     "Azure build has already finished. Please upload with the Codecov repository upload token to resolve issue."

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -116,7 +116,7 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
                 )
 
             finish_time_with_buffer = build_finish_date_obj + timedelta(minutes=10)
-            now = datetime.now(UTC).replace(tzinfo=None)
+            now = datetime.now()
             if not now <= finish_time_with_buffer:
                 log.warning(
                     "Actions workflow run is stale",

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -116,7 +116,7 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
                 )
 
             finish_time_with_buffer = build_finish_date_obj + timedelta(minutes=10)
-            now = datetime.now(UTC)
+            now = datetime.now(UTC).replace(tzinfo=None)
             if not now <= finish_time_with_buffer:
                 log.warning(
                     "Actions workflow run is stale",

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 from asgiref.sync import async_to_sync
 from django.conf import settings

--- a/upload/tokenless/github_actions.py
+++ b/upload/tokenless/github_actions.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
@@ -116,7 +116,7 @@ class TokenlessGithubActionsHandler(BaseTokenlessUploadHandler):
                 )
 
             finish_time_with_buffer = build_finish_date_obj + timedelta(minutes=10)
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             if not now <= finish_time_with_buffer:
                 log.warning(
                     "Actions workflow run is stale",

--- a/upload/tokenless/tokenless.py
+++ b/upload/tokenless/tokenless.py
@@ -1,12 +1,5 @@
 import logging
-import os
-from datetime import datetime, timedelta
-from json import load
 
-import requests
-from django.http import HttpResponse
-from requests.exceptions import ConnectionError, HTTPError
-from rest_framework import status
 from rest_framework.exceptions import NotFound
 
 from upload.tokenless.appveyor import TokenlessAppveyorHandler

--- a/upload/tokenless/travis.py
+++ b/upload/tokenless/travis.py
@@ -121,7 +121,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
             finishTimestamp = job["finished_at"].replace("T", " ").replace("Z", "")
             buildFinishDateObj = datetime.strptime(finishTimestamp, "%Y-%m-%d %H:%M:%S")
             finishTimeWithBuffer = buildFinishDateObj + timedelta(minutes=4)
-            now = datetime.now(UTC).replace(tzinfo=None)
+            now = datetime.now()
             if not now <= finishTimeWithBuffer:
                 log.warning(
                     "Cancelling upload: 4 mins since build",

--- a/upload/tokenless/travis.py
+++ b/upload/tokenless/travis.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 import requests
 from requests.exceptions import ConnectionError, HTTPError

--- a/upload/tokenless/travis.py
+++ b/upload/tokenless/travis.py
@@ -1,6 +1,5 @@
 import logging
-from datetime import datetime, timedelta
-from json import load
+from datetime import UTC, datetime, timedelta
 
 import requests
 from requests.exceptions import ConnectionError, HTTPError
@@ -122,7 +121,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
             finishTimestamp = job["finished_at"].replace("T", " ").replace("Z", "")
             buildFinishDateObj = datetime.strptime(finishTimestamp, "%Y-%m-%d %H:%M:%S")
             finishTimeWithBuffer = buildFinishDateObj + timedelta(minutes=4)
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             if not now <= finishTimeWithBuffer:
                 log.warning(
                     "Cancelling upload: 4 mins since build",

--- a/upload/tokenless/travis.py
+++ b/upload/tokenless/travis.py
@@ -121,7 +121,7 @@ class TokenlessTravisHandler(BaseTokenlessUploadHandler):
             finishTimestamp = job["finished_at"].replace("T", " ").replace("Z", "")
             buildFinishDateObj = datetime.strptime(finishTimestamp, "%Y-%m-%d %H:%M:%S")
             finishTimeWithBuffer = buildFinishDateObj + timedelta(minutes=4)
-            now = datetime.now(UTC)
+            now = datetime.now(UTC).replace(tzinfo=None)
             if not now <= finishTimeWithBuffer:
                 log.warning(
                     "Cancelling upload: 4 mins since build",


### PR DESCRIPTION
### Purpose/Motivation

Saw there was a python warning in my IDE that utcnow is a deprecated function

Related blog post from late 2023 -- https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated

correct way now is to use .now(UTC) instead; all the changes in this PR are basically just find and replace and import UTC when necessary

Relevant stackoverflow post: https://stackoverflow.com/questions/15307623/cant-compare-naive-and-aware-datetime-now-challenge-datetime-end for why we had to chain .replace(tzinfo=None) to some calls

### Links to relevant tickets

### What does this PR do?

Remove deprecation warnings related to utcnow()

<img width="830" alt="Screenshot 2024-08-16 at 2 04 15 PM" src="https://github.com/user-attachments/assets/890d3bdb-5bd6-44bd-96a7-c38103aa44aa">
<img width="409" alt="Screenshot 2024-08-16 at 2 04 29 PM" src="https://github.com/user-attachments/assets/149b6f73-8b95-46c8-b563-ea28c1427d68">


### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
