### PR TITLE
Handle owner user potentially null in base interactor 

### DIFF
--- a/codecov/commands/base.py
+++ b/codecov/commands/base.py
@@ -42,5 +42,5 @@ class BaseInteractor:
         if not self.service and self.requires_service:
             raise MissingService()
 
-        if self.current_owner:
+        if self.current_owner and self.current_owner.user:
             self.current_user = self.current_owner.user


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
If owner.user is null, we can't treat user as an anonymous user anymore. This is fixing to reset to anonymous user if user does not exist. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
