### PR TITLE
Strip Okta ISS URL of trailing slashes

### DIFF
--- a/codecov_auth/commands/owner/interactors/save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/save_okta_config.py
@@ -20,7 +20,7 @@ class SaveOktaConfigInput:
 
 
 class SaveOktaConfigInteractor(BaseInteractor):
-    def validate(self, owner: Owner) -> bool:
+    def validate(self, owner: Owner) -> None:
         if not self.current_user.is_authenticated:
             raise Unauthenticated()
         if not owner:

--- a/codecov_auth/commands/owner/interactors/save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/save_okta_config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from shared.django_apps.codecov_auth.models import AccountsUsers, User
 
@@ -11,11 +10,11 @@ from codecov_auth.models import Account, OktaSettings, Owner
 
 @dataclass
 class SaveOktaConfigInput:
-    client_id: Optional[str] = None
-    client_secret: Optional[str] = None
-    url: Optional[str] = None
-    enabled: bool = False
-    enforced: bool = False
+    enabled: bool | None
+    enforced: bool | None
+    client_id: str | None = None
+    client_secret: str | None = None
+    url: str | None = None
     org_username: str | None = None
 
 

--- a/codecov_auth/commands/owner/interactors/save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/save_okta_config.py
@@ -16,11 +16,11 @@ class SaveOktaConfigInput:
     url: Optional[str] = None
     enabled: bool = False
     enforced: bool = False
-    org_username: str = None
+    org_username: str | None = None
 
 
 class SaveOktaConfigInteractor(BaseInteractor):
-    def validate(self, owner: Owner):
+    def validate(self, owner: Owner) -> bool:
         if not self.current_user.is_authenticated:
             raise Unauthenticated()
         if not owner:
@@ -29,7 +29,7 @@ class SaveOktaConfigInteractor(BaseInteractor):
             raise Unauthorized()
 
     @sync_to_async
-    def execute(self, input: dict):
+    def execute(self, input: dict) -> None:
         typed_input = SaveOktaConfigInput(
             client_id=input.get("client_id"),
             client_secret=input.get("client_secret"),
@@ -85,6 +85,9 @@ class SaveOktaConfigInteractor(BaseInteractor):
         for field in ["client_id", "client_secret", "url", "enabled", "enforced"]:
             value = getattr(typed_input, field)
             if value is not None:
+                # Strip the URL of any trailing spaces and slashes before saving it
+                if field == "url":
+                    value = value.strip("/ ")
                 setattr(okta_config, field, value)
 
         okta_config.save()

--- a/codecov_auth/commands/owner/interactors/tests/test_save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_save_okta_config.py
@@ -164,6 +164,29 @@ class SaveOktaConfigInteractorTest(TransactionTestCase):
         assert okta_config.enabled == input_data["enabled"]
         assert okta_config.enforced == input_data["enforced"]
 
+    def test_update_okta_settings_url_remove_trailing_slashes(self):
+        input_data = {
+            "client_id": "some-client-id",
+            "client_secret": "some-client-secret",
+            "url": "https://okta.example.com/",
+            "enabled": True,
+            "enforced": True,
+            "org_username": self.owner_with_admins.username,
+        }
+
+        account = AccountFactory()
+        self.owner_with_admins.account = account
+        self.owner_with_admins.save()
+
+        interactor = SaveOktaConfigInteractor(
+            current_owner=self.current_user, service=self.service
+        )
+        self.execute(interactor=interactor, input=input_data)
+
+        okta_config = OktaSettings.objects.get(account=self.owner_with_admins.account)
+
+        assert okta_config.url == "https://okta.example.com"
+
     def test_update_okta_settings_when_okta_settings_exists(self):
         input_data = {
             "client_id": "some-client-id",

--- a/codecov_auth/commands/owner/interactors/tests/test_save_okta_config.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_save_okta_config.py
@@ -42,10 +42,16 @@ class SaveOktaConfigInteractorTest(TransactionTestCase):
         )
 
     @async_to_sync
-    def execute(self, interactor=None, input: dict = None):
-        if not interactor:
+    def execute(
+        self,
+        interactor: SaveOktaConfigInteractor | None = None,
+        input: dict | None = None,
+    ):
+        if not interactor and self.interactor:
             interactor = self.interactor
 
+        if not interactor:
+            return
         return interactor.execute(input)
 
     def test_user_is_not_authenticated(self):

--- a/codecov_auth/tests/unit/views/test_okta_cloud.py
+++ b/codecov_auth/tests/unit/views/test_okta_cloud.py
@@ -1,5 +1,6 @@
 from logging import LogRecord
 from typing import Any
+from unittest.mock import ANY
 from urllib.parse import unquote, urlencode, urlparse
 
 import pytest
@@ -47,7 +48,7 @@ def okta_account(okta_org: Owner):
     okta_org.save()
 
     okta_settings: OktaSettings = OktaSettingsFactory(account=account)
-    okta_settings.url = "https://foo-bar.okta.com"
+    okta_settings.url = "https://foo-bar.okta.com/"
     okta_settings.save()
     return account
 
@@ -210,6 +211,8 @@ def test_okta_callback_login_success(
     updated_session = signed_in_client.session
     assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) == [okta_account.id]
 
+    mocked_validate_id_token.assert_called_with("https://foo-bar.okta.com", ANY, ANY)
+
 
 @pytest.mark.django_db
 def test_okta_callback_login_success_multiple_accounts(
@@ -248,6 +251,8 @@ def test_okta_callback_login_success_multiple_accounts(
         okta_account.id + 1,
         okta_account.id,
     ]
+
+    mocked_validate_id_token.assert_called_with("https://foo-bar.okta.com", ANY, ANY)
 
 
 @pytest.mark.django_db

--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -86,7 +86,7 @@ class OktaCloudLoginView(OktaLoginMixin, View):
         # Otherwise start the process redirect them to the Issuer page to authenticate
         else:
             consent = self._redirect_to_consent(
-                iss=okta_settings.url,
+                iss=okta_settings.url.strip("/ "),
                 client_id=okta_settings.client_id,
                 oauth_redirect_url=oauth_redirect_url,
             )
@@ -166,7 +166,7 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
             log.warning("Invalid state during Okta login")
             return redirect(app_redirect_url)
 
-        issuer: str = okta_settings.url
+        issuer: str = okta_settings.url.strip("/ ")
         user_data: OktaTokenResponse | None = self._fetch_user_data(
             issuer,
             code,


### PR DESCRIPTION
### Purpose/Motivation
This removes trailing slashes from their usage in the code, and also from saving to the database. This should fix issues where we validate the payload from Okta with the ISS URL (they send it without trailing slashes).

### Links to relevant tickets
https://github.com/codecov/internal-issues/issues/709

### What does this PR do?
1. Strip the URL of trailing slashes at the point of using the URL
2. Strip the URL of trailing slashes before saving to the DB

We _probably_ don't need both, but having both will just be safer.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
