### PR TITLE
[fix] Ensure repo token regeneration only checks for repos authored by current org

### DIFF
--- a/core/commands/repository/interactors/regenerate_repository_upload_token.py
+++ b/core/commands/repository/interactors/regenerate_repository_upload_token.py
@@ -10,12 +10,12 @@ from core.models import Repository
 class RegenerateRepositoryUploadTokenInteractor(BaseInteractor):
     @sync_to_async
     def execute(self, repo_name: str, owner_username: str) -> uuid.UUID:
-        current_owner = Owner.objects.filter(
+        author = Owner.objects.filter(
             username=owner_username, service=self.service
         ).first()
         repo = (
-            Repository.objects.viewable_repos(current_owner)
-            .filter(name=repo_name)
+            Repository.objects.viewable_repos(self.current_owner)
+            .filter(author=author, name=repo_name)
             .first()
         )
         if not repo:


### PR DESCRIPTION
### Purpose/Motivation

The front end sends the current org selected as part of the `RegenerateRepositoryUploadToken` mutation.

![image](https://github.com/user-attachments/assets/7045bb48-4d20-4f7c-9e0c-888d9591012a)

We are running into cases where a different repo with the same name can have its token updated as we are updating the first repo amongst all viewable repositories for a given org. 

This PR adds a check to only select from repos that are _**authored**_ by that org. 

This fixes https://github.com/codecov/engineering-team/issues/2377


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
