### PR TITLE
fix: guard no repo for test_results

### DIFF
--- a/upload/tests/views/test_test_results.py
+++ b/upload/tests/views/test_test_results.py
@@ -188,6 +188,33 @@ def test_test_results_no_auth(db, client, mocker, mock_redis):
     assert res.json().get("detail") == "Not valid tokenless upload"
 
 
+def test_upload_test_results_no_repo(db, client, mocker, mock_redis):
+    upload = mocker.patch.object(TaskService, "upload")
+    mocker.patch.object(TaskService, "upload")
+    mocker.patch(
+        "services.archive.StorageService.create_presigned_put",
+        return_value="test-presigned-put",
+    )
+
+    repository = RepositoryFactory.create()
+    org_token = OrganizationLevelTokenFactory.create(owner=repository.author)
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"token {org_token.token}")
+
+    res = client.post(
+        reverse("upload-test-results"),
+        {
+            "commit": "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef",
+            "slug": "FakeUser::::NonExistentName",
+        },
+        format="json",
+    )
+    assert res.status_code == 404
+    assert res.json() == {"detail": "Repository not found."}
+    assert not upload.called
+
+
 def test_upload_test_results_missing_args(db, client, mocker, mock_redis):
     upload = mocker.patch.object(TaskService, "upload")
     mocker.patch(

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.utils import timezone
 from rest_framework import serializers, status
-from rest_framework.exceptions import NotAuthenticated
+from rest_framework.exceptions import NotAuthenticated, NotFound
 from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -88,6 +88,9 @@ class TestResultsView(
             repo = request.user._repository
         else:
             raise NotAuthenticated()
+
+        if repo is None:
+            raise NotFound("Repository not found.")
 
         update_fields = []
         if not repo.active or not repo.activated:


### PR DESCRIPTION
### Purpose/Motivation

Saw sentry issue come in, we added a guard for bundle_analysis similarly here: 

https://github.com/codecov/codecov-api/blob/1c2b6a8ed0568ee45af238d46f1576bb9ae90fb9/upload/views/bundle_analysis.py#L92-L93

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/2406

### What does this PR do?

Fixes this sentry issue:
https://codecov.sentry.io/issues/5759286173/?environment=dd&environment=enova&environment=epic&environment=production&environment=roblox&environment=snowflake&project=5215654&project=5514400&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=2

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
