### PR TITLE
fix Repo form in django admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib import admin
 from django.core.paginator import Paginator
 from django.db import connections
@@ -42,6 +43,19 @@ class EstimatedCountPaginator(Paginator):
         return int(result[0])
 
 
+class RepositoryAdminForm(forms.ModelForm):
+    # the model field has null=True but not blank=True, so we have to add a workaround
+    # to be able to clear out this field through the django admin
+    webhook_secret = forms.CharField(required=False, empty_value=None)
+    yaml = forms.JSONField(required=False)
+    using_integration = forms.BooleanField(required=False)
+    hookid = forms.CharField(required=False, empty_value=None)
+
+    class Meta:
+        model = Repository
+        fields = "__all__"
+
+
 @admin.register(Repository)
 class RepositoryAdmin(AdminMixin, admin.ModelAdmin):
     inlines = [RepositoryTokenInline]
@@ -49,6 +63,7 @@ class RepositoryAdmin(AdminMixin, admin.ModelAdmin):
     search_fields = ("author__username__exact",)
     show_full_result_count = False
     autocomplete_fields = ("bot",)
+    form = RepositoryAdminForm
 
     paginator = EstimatedCountPaginator
 


### PR DESCRIPTION
### Purpose/Motivation
It's a common issue to have `null=True` or a `default_value` _without_ `blank=True` on a field in a django model. This causes a conflict in forms, which interprets the field as `required` even though you intend for the value to be `null` or the `default_value` set on the field. In my case, I was trying to clear out the `webhook_secret` field, but my changes were blocked because the `webhook_secret` cannot be blank, therefore there was no way to get it back to the `null` value I wanted, which is allowed in the database.

### Links to relevant tickets
part of https://github.com/codecov/internal-issues/issues/366

### What does this PR do?
I need to be able to delete the webhook_secret, this was not allowed by the form. These changes allow me to clear out that field, fixed it on a few other fields on the model as well so that it behaves closer to how we intended.