### PR TITLE
log repo signals

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.conf import settings
 from django.db.models.signals import post_save
@@ -9,6 +10,7 @@ from shared.django_apps.core.models import Commit
 from core.models import Repository
 
 _pubsub_publisher = None
+log = logging.getLogger(__name__)
 
 
 def _get_pubsub_publisher():
@@ -20,24 +22,29 @@ def _get_pubsub_publisher():
 
 @receiver(post_save, sender=Repository, dispatch_uid="shelter_sync_repo")
 def update_repository(sender, instance: Repository, **kwargs):
+    log.info(f"Signal triggered for repository {instance.repoid}")
     created = kwargs["created"]
     changes = instance.tracker.changed()
     if created or any([field in changes for field in ["name", "upload_token"]]):
-        pubsub_project_id = settings.SHELTER_PUBSUB_PROJECT_ID
-        topic_id = settings.SHELTER_PUBSUB_SYNC_REPO_TOPIC_ID
-        if pubsub_project_id and topic_id:
-            publisher = _get_pubsub_publisher()
-            topic_path = publisher.topic_path(pubsub_project_id, topic_id)
-            publisher.publish(
-                topic_path,
-                json.dumps(
-                    {
-                        "type": "repo",
-                        "sync": "one",
-                        "id": instance.repoid,
-                    }
-                ).encode("utf-8"),
-            )
+        try:
+            pubsub_project_id = settings.SHELTER_PUBSUB_PROJECT_ID
+            topic_id = settings.SHELTER_PUBSUB_SYNC_REPO_TOPIC_ID
+            if pubsub_project_id and topic_id:
+                publisher = _get_pubsub_publisher()
+                topic_path = publisher.topic_path(pubsub_project_id, topic_id)
+                publisher.publish(
+                    topic_path,
+                    json.dumps(
+                        {
+                            "type": "repo",
+                            "sync": "one",
+                            "id": instance.repoid,
+                        }
+                    ).encode("utf-8"),
+                )
+            log.info(f"Message published for repository {instance.repoid}")
+        except Exception as e:
+            log.warning(f"Failed to publish message for repo {instance.repoid}: {e}")
 
 
 @receiver(post_save, sender=Commit, dispatch_uid="shelter_sync_commit")


### PR DESCRIPTION
The token cacher is seemingly skipping some repositories getting saved in firestore. This is an attempt to log the start/error of any of these transactions to give me more visibility on the issue

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
