### PR TITLE
2446 address rl bug

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -805,11 +805,11 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
     @patch("shared.rate_limits.determine_entity_redis_key")
     @patch("shared.rate_limits.determine_if_entity_is_rate_limited")
-    @patch("logging.Logger.error")
+    @patch("logging.Logger.warning")
     @override_settings(IS_ENTERPRISE=True, GUEST_ACCESS=False)
     def test_fetch_is_github_rate_limited_but_errors(
         self,
-        mock_log_error,
+        mock_log_warning,
         mock_determine_rate_limit,
         mock_determine_redis_key,
     ):
@@ -834,7 +834,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         assert data["me"]["owner"]["repository"]["isGithubRateLimited"] is None
 
-        mock_log_error.assert_called_once_with(
+        mock_log_warning.assert_called_once_with(
             "Error when checking rate limit",
             extra={
                 "repo_id": repo.repoid,

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -553,19 +553,19 @@ def resolve_is_github_rate_limited(repository: Repository, info) -> bool | None:
         and repository.service != SERVICE_GITHUB_ENTERPRISE
     ):
         return False
-    current_owner = info.context["request"].current_owner
+    repo_owner = repository.author
     try:
         redis_connection = get_redis_connection()
         rate_limit_redis_key = rate_limits.determine_entity_redis_key(
-            owner=current_owner, repository=repository
+            owner=repo_owner, repository=repository
         )
         return rate_limits.determine_if_entity_is_rate_limited(
             redis_connection, rate_limit_redis_key
         )
     except Exception:
-        log.error(
+        log.warning(
             "Error when checking rate limit",
-            extra=dict(repo_id=repository.repoid, has_owner=bool(current_owner)),
+            extra=dict(repo_id=repository.repoid, has_owner=bool(repo_owner)),
         )
         return None
 


### PR DESCRIPTION
We're getting a bunch of errors in sentry regarding rate limits. 

After looking at the logic, I believe it has to do with using the wrong owner in certain occasions. This PR addresses that.
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
