### PR TITLE
query errors during async process

### DIFF
--- a/graphql_api/actions/owner.py
+++ b/graphql_api/actions/owner.py
@@ -19,7 +19,11 @@ def get_owner(service, username):
         raise MissingService()
 
     long_service = get_long_service_name(service)
-    return Owner.objects.filter(username=username, service=long_service).first()
+    return (
+        Owner.objects.filter(username=username, service=long_service)
+        .prefetch_related("account")
+        .first()
+    )
 
 
 def get_owner_login_sessions(current_user):


### PR DESCRIPTION
### Purpose/Motivation
In django, adding a dot notation to an object does a db query, so when I added `self.current_org.account` to `PlanService`, this adds a db call. This breaks an async flow, which gazebo uses. Solution is to do a prefetch_related when we get the `current_org` so that `self.current_org.account` does not call the db.

### Links to relevant tickets
https://codecov.sentry.io/issues/5771897965/events/a320d20a70534672bac6ce9db263f4e0/
