### PR TITLE
fix: add async await for hasSeatsLeft resolver

### DIFF
--- a/graphql_api/tests/test_plan.py
+++ b/graphql_api/tests/test_plan.py
@@ -144,7 +144,7 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
         mock_enterprise_license = LicenseInformation(
             is_valid=True,
             message=None,
-            url="https://codeov.mysite.com",
+            url="https://codecov.mysite.com",
             number_allowed_users=5,
             number_allowed_repos=10,
             expires=datetime.strptime("2020-05-09 00:00:00", "%Y-%m-%d %H:%M:%S"),
@@ -189,11 +189,12 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                 }
                 """ % (enterprise_org.username)
         data = self.gql_request(query, owner=enterprise_org)
+
         assert data["owner"]["plan"]["planUserCount"] == 5
         assert data["owner"]["plan"]["hasSeatsLeft"] == False
 
     @patch("services.self_hosted.get_current_license")
-    def test_plan_user_count_for_enterprise_org_invaild_license(self, mocked_license):
+    def test_plan_user_count_for_enterprise_org_invalid_license(self, mocked_license):
         mock_enterprise_license = LicenseInformation(
             is_valid=False,
         )
@@ -219,5 +220,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                     }
                     """ % (enterprise_org.username)
         data = self.gql_request(query, owner=enterprise_org)
+
         assert data["owner"]["plan"]["planUserCount"] == 0
         assert data["owner"]["plan"]["hasSeatsLeft"] == False

--- a/graphql_api/types/plan/plan.py
+++ b/graphql_api/types/plan/plan.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from ariadne import ObjectType, convert_kwargs_to_snake_case
 
+from codecov.db import sync_to_async
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 from plan.constants import (
     TrialStatus,
@@ -93,5 +94,6 @@ def resolve_plan_user_count(plan_service: PlanService, info) -> int:
 
 @plan_bindable.field("hasSeatsLeft")
 @convert_kwargs_to_snake_case
+@sync_to_async
 def resolve_has_seats_left(plan_service: PlanService, info) -> bool:
     return plan_service.has_seats_left

--- a/graphql_api/types/plan/plan.py
+++ b/graphql_api/types/plan/plan.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 
 from ariadne import ObjectType, convert_kwargs_to_snake_case
 
-from codecov.db import sync_to_async
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 from plan.constants import (
     TrialStatus,
@@ -94,6 +93,5 @@ def resolve_plan_user_count(plan_service: PlanService, info) -> int:
 
 @plan_bindable.field("hasSeatsLeft")
 @convert_kwargs_to_snake_case
-@sync_to_async
-def resolve_has_seats_left(plan_service: PlanService, info) -> bool:
-    return plan_service.has_seats_left
+async def resolve_has_seats_left(plan_service: PlanService, info) -> bool:
+    return await plan_service.has_seats_left

--- a/plan/service.py
+++ b/plan/service.py
@@ -282,7 +282,10 @@ class PlanService:
             # AND their Account is at capacity,
             # AND they try to become a plan_activated_user on another Org in the Account,
             # has_seats_left will evaluate as False even though the User should be allowed to activate on the Org.
-            return self.current_org.account.can_activate_user()
+
+            print("GETTING HERE", self.current_org.account)
+
+            return await self.current_org.account.can_activate_user()
         return (
             self.plan_activated_users is None
             or len(self.plan_activated_users) < self.plan_user_count

--- a/plan/service.py
+++ b/plan/service.py
@@ -283,8 +283,6 @@ class PlanService:
             # AND they try to become a plan_activated_user on another Org in the Account,
             # has_seats_left will evaluate as False even though the User should be allowed to activate on the Org.
 
-            print("GETTING HERE", self.current_org.account)
-
             return await self.current_org.account.can_activate_user()
         return (
             self.plan_activated_users is None

--- a/plan/service.py
+++ b/plan/service.py
@@ -274,9 +274,9 @@ class PlanService:
         return bool(self.trial_start_date and self.trial_end_date)
 
     @property
-    def has_seats_left(self) -> bool:
+    async def has_seats_left(self) -> bool:
         if get_config("setup", "enterprise_license"):
-            return enterprise_has_seats_left()
+            return await enterprise_has_seats_left()
         if self.has_account:
             # edge case: IF the User is already a plan_activated_user on any of the Orgs in the Account,
             # AND their Account is at capacity,

--- a/plan/tests/test_plan.py
+++ b/plan/tests/test_plan.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -327,7 +328,7 @@ class PlanServiceTests(TestCase):
         )
         plan_service = PlanService(current_org=current_org)
 
-        assert plan_service.has_seats_left == True
+        assert asyncio.run(plan_service.has_seats_left) == True
 
     def test_plan_service_has_no_seats_left(self):
         current_org = OwnerFactory(
@@ -337,7 +338,7 @@ class PlanServiceTests(TestCase):
         )
         plan_service = PlanService(current_org=current_org)
 
-        assert plan_service.has_seats_left == False
+        assert asyncio.run(plan_service.has_seats_left) == False
 
     def test_plan_service_update_plan_invalid_name(self):
         current_org = OwnerFactory(plan=PlanName.BASIC_PLAN_NAME.value)
@@ -411,12 +412,12 @@ class PlanServiceTests(TestCase):
             AccountsUsersFactory(account=account)
 
         plan_service = PlanService(current_org=org)
-        self.assertEqual(plan_service.has_seats_left, True)
+        self.assertTrue(asyncio.run(plan_service.has_seats_left))
 
         org.account = account
         org.save()
         plan_service = PlanService(current_org=org)
-        self.assertEqual(plan_service.has_seats_left, False)
+        self.assertFalse(asyncio.run(plan_service.has_seats_left))
 
 
 class AvailablePlansBeforeTrial(TestCase):


### PR DESCRIPTION
### Purpose/Motivation

Fixes sentry issue https://codecov.sentry.io/issues/5772407204/?project=5514400&project=5215654&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=2

Because the user already has an "account" my thought here is we just need to convert the function to async and await the calling function

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
