### PR TITLE
fix: Add guard when no update timestamp on pull

### DIFF
--- a/core/commands/pull/interactors/fetch_pull_request.py
+++ b/core/commands/pull/interactors/fetch_pull_request.py
@@ -12,6 +12,7 @@ class FetchPullRequestInteractor(BaseInteractor):
         return (
             pull is not None
             and pull.state == "open"
+            and pull.updatestamp is not None
             and (datetime.now(tz=None) - pull.updatestamp) > timedelta(hours=1)
         )
 

--- a/core/commands/pull/interactors/tests/test_fetch_pull_request.py
+++ b/core/commands/pull/interactors/tests/test_fetch_pull_request.py
@@ -57,3 +57,16 @@ def test_fetch_pull_should_sync(pr_state, updatestamp, expected, db):
     )._should_sync_pull(pr)
     assert pr.updatestamp == datetime.fromisoformat(updatestamp).replace(tzinfo=None)
     assert should_sync == expected
+
+
+def test_fetch_pull_updatestamp_is_none(db):
+    repo = RepositoryFactory(private=False)
+    pr = PullFactory(repository_id=repo.repoid, state="open")
+    repo.save()
+    pr.save()
+    pr.updatestamp = None
+    should_sync = FetchPullRequestInteractor(
+        repo.author, repo.service
+    )._should_sync_pull(pr)
+    assert pr.updatestamp is None
+    assert should_sync == False


### PR DESCRIPTION
### Purpose/Motivation

Closes these sentry issues: https://codecov.sentry.io/issues/?environment=production&environment=dd&environment=enova&environment=epic&environment=roblox&environment=snowflake&project=5514400&project=5215654&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+unsupported+operand+type%28s%29&referrer=issue-list&statsPeriod=7d

When a user doesn't have an updatedstamp on their pull being compared, we just error the page, leading to a bad experience for the users. This PR just adds a guard when that's the case so we return "false"

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
