### PR TITLE
fix: Small fixes for some unhandled github webhook errors

### DIFF
--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -201,7 +201,7 @@ class GithubWebhookHandler(APIView):
         return Response()
 
     def delete(self, request, *args, **kwargs):
-        ref_type = request.data.get("ref_type")
+        ref_type = request.data.get("ref_type", "")
         _incr_event(GitHubWebhookEvents.DELETE + "." + ref_type)
         repo = self._get_repo(request)
         if ref_type != "branch":
@@ -232,7 +232,7 @@ class GithubWebhookHandler(APIView):
         return Response()
 
     def push(self, request, *args, **kwargs):
-        ref_type = "branch" if request.data.get("ref")[5:10] == "heads" else "tag"
+        ref_type = "branch" if request.data.get("ref", "")[5:10] == "heads" else "tag"
         _incr_event(GitHubWebhookEvents.PUSH + "." + ref_type)
         repo = self._get_repo(request)
         if ref_type != "branch":


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to gracefully handle a couple github webhook errors I saw in sentry

https://codecov.sentry.io/issues/2975145852
https://codecov.sentry.io/issues/4394424045

In both cases I just defaulted the get to a string so they wouldn't fail and would make it to the lines of code that exit the function early. I don't think this will have any meaningful impact, but it was a quick fix I saw so might as well

### Links to relevant tickets

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
