### PR TITLE
sec: remove open redirect to codecov

### DIFF
--- a/codecov/tests/test_urls.py
+++ b/codecov/tests/test_urls.py
@@ -3,18 +3,6 @@ from django.test.client import Client
 
 
 class ViewTest(TestCase):
-    def test_redirect_app(self):
-        client = Client()
-        response = client.get(
-            "/redirect_app/gh/codecov/codecov.io/settings", follow=False
-        )
-        self.assertRedirects(
-            response,
-            "http://localhost:3000/gh/codecov/codecov.io/settings",
-            302,
-            fetch_redirect_response=False,
-        )
-
     def test_health(self):
         client = Client()
         response = client.get("")

--- a/codecov/urls.py
+++ b/codecov/urls.py
@@ -34,7 +34,6 @@ urlpatterns = [
         views.OwnerAutoCompleteSearch.as_view(),
         name="admin-owner-autocomplete",
     ),
-    re_path(r"^redirect_app", views.redirect_app),
     # /monitoring/metrics will be a public route unless you take steps at a
     # higher level to null-route or redirect it.
     path("monitoring/", include("django_prometheus.urls")),

--- a/codecov/views.py
+++ b/codecov/views.py
@@ -1,7 +1,6 @@
 from dal import autocomplete
-from django.conf import settings
 from django.db import connection
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse
 
 from codecov_auth.models import Owner, Service
 from core.models import Constants, Repository
@@ -17,19 +16,11 @@ def _get_version():
 
 
 def health(request):
-    # will raise if connection cannot be estabilished
+    # will raise if connection cannot be established
     connection.ensure_connection()
 
     version = _get_version()
     return HttpResponse("%s is live!" % version.value)
-
-
-def redirect_app(request):
-    """
-    This view is intended to be used as part of the frontend migration to redirect traffic from legacy urls to urls
-    """
-    app_domain = settings.CODECOV_DASHBOARD_URL
-    return HttpResponseRedirect(app_domain + request.path.replace("/redirect_app", ""))
 
 
 SERVICE_CHOICES = dict(Service.choices)

--- a/graphs/helpers/badge.py
+++ b/graphs/helpers/badge.py
@@ -3,7 +3,7 @@ from shared.helpers.color import coverage_to_color
 from graphs.badges.badges import large_badge, medium_badge, small_badge, unknown_badge
 
 
-def get_badge(coverage, coverage_range, precision):
+def get_badge(coverage: str | None, coverage_range: list[int], precision: str):
     """
     Returns and SVG string containing coverage badge
 

--- a/graphs/views.py
+++ b/graphs/views.py
@@ -121,7 +121,7 @@ class BadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
 
     def flag_coverage(self, flag_name, commit):
         """
-        Looks into a commit's report sessions and returns the coverage for a perticular flag
+        Looks into a commit's report sessions and returns the coverage for a particular flag
 
         Parameters
         flag_name (string): name of flag


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to fix a security backdoor where users can abuse the open redirect for codecov to potentially lead a user to a malicious website.

This was patched 3 years ago and [moved to being done at the ingress level](https://github.com/codecov/k8s-v2/commit/95bd8b323c18dc6d870d277e16d6aa675f071b2c) but the underlying code was never removed. We're just looking to remove the code now

### Links to relevant tickets

Closes https://github.com/codecov/internal-issues/issues/653

I may take a stab at also doing some sanitization of the SVGs too but this will at least close the issue

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
