### PR TITLE
fix: Indication range from int -> float

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -403,6 +403,36 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             == 80
         )
 
+    @patch("shared.yaml.user_yaml.UserYaml.get_final_yaml")
+    def test_repository_repository_config_indication_range_float(self, mocked_useryaml):
+        mocked_useryaml.return_value = {"coverage": {"range": [61.1, 82.2]}}
+
+        repo = RepositoryFactory(
+            author=self.owner,
+            active=True,
+            private=True,
+        )
+
+        data = self.gql_request(
+            query_repository
+            % "repositoryConfig { indicationRange { upperRange lowerRange } }",
+            owner=self.owner,
+            variables={"name": repo.name},
+        )
+
+        assert (
+            data["me"]["owner"]["repository"]["repositoryConfig"]["indicationRange"][
+                "lowerRange"
+            ]
+            == 61.1
+        )
+        assert (
+            data["me"]["owner"]["repository"]["repositoryConfig"]["indicationRange"][
+                "upperRange"
+            ]
+            == 82.2
+        )
+
     @patch("services.activation.try_auto_activate")
     def test_repository_auto_activate(self, try_auto_activate):
         repo = RepositoryFactory(

--- a/graphql_api/types/repository_config/repository_config.graphql
+++ b/graphql_api/types/repository_config/repository_config.graphql
@@ -3,6 +3,6 @@ type RepositoryConfig {
 }
 
 type IndicationRange {
-  upperRange: Int!
-  lowerRange: Int!
+  upperRange: Float!
+  lowerRange: Float!
 }

--- a/graphql_api/types/repository_config/repository_config.py
+++ b/graphql_api/types/repository_config/repository_config.py
@@ -17,13 +17,15 @@ class IndicationRange(TypedDict):
 
 
 @repository_config_bindable.field("indicationRange")
-async def resolve_indication_range(repository: Repository, info) -> dict[str, int]:
+async def resolve_indication_range(repository: Repository, info) -> dict[str, float]:
     owner = await OwnerLoader.loader(info).load(repository.author_id)
 
     yaml = await sync_to_async(UserYaml.get_final_yaml)(
         owner_yaml=owner.yaml, repo_yaml=repository.yaml
     )
-    range: list[int] = yaml.get("coverage", {"range": [60, 80]}).get("range", [60, 80])
+    range: list[float] = yaml.get("coverage", {"range": [60, 80]}).get(
+        "range", [60, 80]
+    )
     return {"lowerRange": range[0], "upperRange": range[1]}
 
 

--- a/graphql_api/types/repository_config/repository_config.py
+++ b/graphql_api/types/repository_config/repository_config.py
@@ -12,8 +12,8 @@ indication_range_bindable = ObjectType("IndicationRange")
 
 
 class IndicationRange(TypedDict):
-    lowerRange: str
-    upperRange: str
+    lowerRange: float
+    upperRange: float
 
 
 @repository_config_bindable.field("indicationRange")
@@ -28,12 +28,12 @@ async def resolve_indication_range(repository: Repository, info) -> dict[str, in
 
 
 @indication_range_bindable.field("upperRange")
-def resolve_upper_range(indicationRange: IndicationRange, info) -> int:
+def resolve_upper_range(indicationRange: IndicationRange, info) -> float:
     upperRange = indicationRange.get("upperRange")
     return upperRange
 
 
 @indication_range_bindable.field("lowerRange")
-def resolve_lower_range(indicationRange: IndicationRange, info) -> int:
+def resolve_lower_range(indicationRange: IndicationRange, info) -> float:
     lowerRange = indicationRange.get("lowerRange")
     return lowerRange


### PR DESCRIPTION
### Purpose/Motivation

Fixes these sentry issues: 

https://codecov.sentry.io/issues/5416346385
https://codecov.sentry.io/issues/5416346358


I can't really tell why we would only want indication range to be an integer, we should also accept float values too for individuals who want a finer level of precision. My understanding is something else (either client or different server code) bounds the range to be between 0 and 100 so this shouldn't affect anything really.

This PR just swaps the type from an int to a float in GQL and changes the python types to match

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/2475

**Gazebo might be slightly updated now:**

![Screenshot 2024-09-05 at 10 35 19 AM](https://github.com/user-attachments/assets/1960603b-a4be-48b2-81a3-756f440bb359)



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
