### PR TITLE
move shared change check to separate workflow with correct permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,6 @@ jobs:
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
 
-  shared-change-checker:
-    name: See if shared changed
-    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@main
-    with:
-      dep: 'shared'
-
   build-self-hosted:
     name: Build Self Hosted API
     needs: [build, test]

--- a/.github/workflows/pr_detect_shared_changes.yml
+++ b/.github/workflows/pr_detect_shared_changes.yml
@@ -1,0 +1,14 @@
+name: Detect dep version changes
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: "write"
+
+jobs:
+  shared-change-checker:
+    name: See if shared changed
+    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@pr32
+    with:
+      dep: 'shared'

--- a/.github/workflows/pr_detect_shared_changes.yml
+++ b/.github/workflows/pr_detect_shared_changes.yml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   shared-change-checker:
     name: See if shared changed
-    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@pr32
+    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@main
     with:
       dep: 'shared'


### PR DESCRIPTION
https://github.com/codecov/gha-workflows/pull/32 will change this to use `main` before merging

- [run that skips posting a comment because shared was not changed](https://github.com/codecov/codecov-api/actions/runs/10726429651/job/29746451116?pr=801)
- [run that posts a comment to this PR](https://github.com/codecov/codecov-api/actions/runs/10726447902/job/29746511187?pr=801)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
