### PR TITLE
fix: only call commit_update task when commit is newly created

### DIFF
--- a/upload/tests/views/test_commits.py
+++ b/upload/tests/views/test_commits.py
@@ -197,7 +197,7 @@ def test_create_commit_already_exists(db, client, mocker):
     }
     assert response.status_code == 201
     assert expected_response == response_json
-    mocked_call.assert_called_with(commitid=commit.commitid, repoid=repository.repoid)
+    mocked_call.assert_not_called()
 
 
 @pytest.mark.parametrize("branch", ["main", "someone:main", "someone/fork:main"])


### PR DESCRIPTION
we have to move the get_or_create call in the commits endpoint to the top level function so we can know if a commit object was newly created

we don't want to call the commit update task every time this endpoint is called because it may be the cause of lock contention in the DB for commits
