### PR TITLE
debug: add log and trace for impacted file

### DIFF
--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -1,6 +1,7 @@
 from asyncio import gather
 from typing import List, Optional
 
+import sentry_sdk
 from ariadne import ObjectType, UnionType, convert_kwargs_to_snake_case
 from graphql.type.definition import GraphQLResolveInfo
 
@@ -237,6 +238,7 @@ def resolve_flag_comparisons_count(
     return get_flag_comparisons(comparison.commit_comparison).count()
 
 
+@sentry_sdk.trace
 @comparison_bindable.field("hasDifferentNumberOfHeadAndBaseReports")
 @sync_to_async
 def resolve_has_different_number_of_head_and_base_reports(

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -1,6 +1,7 @@
 import hashlib
 from typing import List, Union
 
+import sentry_sdk
 from ariadne import ObjectType, UnionType, convert_kwargs_to_snake_case
 from shared.reports.types import ReportTotals
 from shared.torngit.exceptions import TorngitClientError
@@ -63,6 +64,7 @@ def resolve_hashed_path(impacted_file: ImpactedFile, info) -> str:
     return md5_path.hexdigest()
 
 
+@sentry_sdk.trace
 @impacted_file_bindable.field("segments")
 @sync_to_async
 @convert_kwargs_to_snake_case

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -721,8 +721,12 @@ class Comparison(object):
 
     @cached_property
     def has_different_number_of_head_and_base_sessions(self):
+        log.info("has_different_number_of_head_and_base_sessions - Start")
         head_sessions = self.head_report.sessions
         base_sessions = self.base_report.sessions
+        log.info(
+            f"has_different_number_of_head_and_base_sessions - Retrieved sessions - head {len(head_sessions)} / base {len(base_sessions)}"
+        )
         # We're treating this case as false since considering CFF's complicates the logic
         if self._has_cff_sessions(head_sessions) or self._has_cff_sessions(
             base_sessions
@@ -733,10 +737,12 @@ class Comparison(object):
     # I feel this method should belong to the API Report class, but we're thinking of getting rid of that class soon
     # In truth, this should be in the shared.Report class
     def _has_cff_sessions(self, sessions) -> bool:
+        log.info(f"_has_cff_sessions - sessions count {len(sessions)}")
         for session in sessions.values():
             if session.session_type.value == "carriedforward":
+                log.info("_has_cff_sessions - Found carriedforward")
                 return True
-
+        log.info("_has_cff_sessions - No carriedforward")
         return False
 
     @property


### PR DESCRIPTION
Debug why get impacted files segments and comparison hasDifferentNumberOfHeadAndBaseReports are slow. To be reverted once debugging is done.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
