### PR TITLE
chore: reduce usage of PreProcess task

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -9,8 +9,5 @@ def owner_slug(owner: Owner) -> str:
 
 __all__ = ["Feature"]
 
-NO_PREPROCESS_UPLOAD = Feature("no_PreProcessUpload")
-
-
 # By default, features have one variant:
 #    { "enabled": FeatureVariant(True, 1.0) }

--- a/upload/serializers.py
+++ b/upload/serializers.py
@@ -161,7 +161,7 @@ class CommitReportSerializer(serializers.ModelSerializer):
         )
         fields = read_only_fields + ("code",)
 
-    def create(self, validated_data):
+    def create(self, validated_data) -> tuple[CommitReport, bool]:
         report = (
             CommitReport.objects.coverage_reports()
             .filter(
@@ -174,8 +174,8 @@ class CommitReportSerializer(serializers.ModelSerializer):
             if report.report_type is None:
                 report.report_type = CommitReport.ReportType.COVERAGE
                 report.save()
-            return report
-        return super().create(validated_data)
+            return report, False
+        return super().create(validated_data), True
 
 
 class ReportResultsSerializer(serializers.ModelSerializer):

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -195,7 +195,7 @@ def test_create_report_already_exists(client, db, mocker):
     assert CommitReport.objects.filter(
         commit_id=commit.id, code="code", report_type=CommitReport.ReportType.COVERAGE
     ).exists()
-    mocked_call.assert_called_once()
+    mocked_call.assert_not_called()
 
 
 def test_reports_post_code_as_default(client, db, mocker):


### PR DESCRIPTION
Originally I wanted to delete PreProcess task completely, but after reviewing
certain usage patterns I realized the task is necessary (for `empty-upload` and
`static-analysis` for example).

So the alternative is to reduce the amount of times it is called, to only be called
when we effectively create a new report. Similar to https://github.com/codecov/codecov-api/pull/804

### Purpose/Motivation
What is the feature? Why is this being done?

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
