### PR TITLE
bundle analysis: fix slow trend query

### DIFF
--- a/graphql_api/actions/measurements.py
+++ b/graphql_api/actions/measurements.py
@@ -49,15 +49,17 @@ def measurements_by_ids(
 
 
 def measurements_last_uploaded_before_start_date(
+    owner_id: int,
     repo_id: int,
     measurable_name: str,
-    measurable_ids: List[int],
+    measurable_id: int,
     start_date: datetime,
     branch: Optional[str] = None,
 ) -> QuerySet:
     queryset = Measurement.objects.filter(
+        owner_id=owner_id,
         repo_id=repo_id,
-        measurable_id__in=measurable_ids,
+        measurable_id=measurable_id,
         name=measurable_name,
         timestamp__lt=start_date,
     )

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -412,9 +412,10 @@ class BundleAnalysisMeasurementsService(object):
         for measurable_id, measurements in all_measurements.items():
             if self.after is not None and measurements[0]["timestamp_bin"] > self.after:
                 carryover_measurement = measurements_last_uploaded_before_start_date(
+                    owner_id=self.repository.author.ownerid,
                     repo_id=self.repository.repoid,
                     measurable_name=measurable_name,
-                    measurable_ids=[measurable_id],
+                    measurable_id=measurable_id,
                     start_date=self.after,
                     branch=self.branch,
                 )


### PR DESCRIPTION
use the owner_id index when querying the timeseries_measurement table
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
