### PR TITLE
Improve aggregate test results function

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -11,7 +11,7 @@ from core.tests.factories import (
     RepositoryFactory,
     RepositoryTokenFactory,
 )
-from reports.tests.factories import TestFactory, TestInstanceFactory
+from reports.tests.factories import DailyTestRollupFactory, TestFactory
 from services.profiling import CriticalFile
 
 from .helper import GraphQLTestHelper
@@ -882,9 +882,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     def test_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
-            test=test, created_at=datetime.datetime.now(), repoid=repo.repoid
-        )
+
+        _ = DailyTestRollupFactory(test=test)
         res = self.fetch_repository(
             repo.name, """testResults { edges { node { name } } }"""
         )
@@ -900,14 +899,15 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     def test_branch_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        test2 = TestFactory(repository=repo)
+        _ = DailyTestRollupFactory(
             test=test,
             created_at=datetime.datetime.now(),
             repoid=repo.repoid,
             branch="main",
         )
-        _test_instance_2 = TestInstanceFactory(
-            test=test,
+        _ = DailyTestRollupFactory(
+            test=test2,
             created_at=datetime.datetime.now(),
             repoid=repo.repoid,
             branch="feature",
@@ -921,24 +921,24 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     def test_commits_failed_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today() - datetime.timedelta(days=1),
             repoid=repo.repoid,
-            commitid="1",
+            commits_where_fail=["1"],
         )
-        _test_instance_2 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            commitid="2",
+            commits_where_fail=["2"],
         )
         test_2 = TestFactory(repository=repo)
-        _test_instance_3 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test_2,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            commitid="3",
+            commits_where_fail=["3"],
         )
         res = self.fetch_repository(
             repo.name,
@@ -954,24 +954,24 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     def test_desc_commits_failed_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today() - datetime.timedelta(days=1),
             repoid=repo.repoid,
-            commitid="1",
+            commits_where_fail=["1"],
         )
-        _test_instance_2 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            commitid="2",
+            commits_where_fail=["2"],
         )
         test_2 = TestFactory(repository=repo)
-        _test_instance_3 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test_2,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            commitid="3",
+            commits_where_fail=["3"],
         )
         res = self.fetch_repository(
             repo.name,
@@ -984,27 +984,98 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             ]
         }
 
+    def test_last_duration_ordering_on_test_results(self) -> None:
+        repo = RepositoryFactory(author=self.owner, active=True, private=True)
+        test = TestFactory(repository=repo)
+        _ = DailyTestRollupFactory(
+            test=test,
+            date=datetime.date.today() - datetime.timedelta(days=1),
+            repoid=repo.repoid,
+            last_duration_seconds=1,
+            latest_run=datetime.datetime.now() - datetime.timedelta(days=1),
+        )
+        _ = DailyTestRollupFactory(
+            test=test,
+            date=datetime.date.today(),
+            repoid=repo.repoid,
+            last_duration_seconds=2,
+            latest_run=datetime.datetime.now(),
+        )
+        test_2 = TestFactory(repository=repo)
+        _ = DailyTestRollupFactory(
+            test=test_2,
+            date=datetime.date.today(),
+            repoid=repo.repoid,
+            last_duration_seconds=3,
+        )
+        res = self.fetch_repository(
+            repo.name,
+            """testResults(ordering: { parameter: LAST_DURATION, direction: ASC }) { edges { node { name lastDuration } } }""",
+        )
+        assert res["testResults"] == {
+            "edges": [
+                {"node": {"name": test.name, "lastDuration": 2.0}},
+                {"node": {"name": test_2.name, "lastDuration": 3.0}},
+            ]
+        }
+
+    def test_desc_last_duration_ordering_on_test_results(self) -> None:
+        repo = RepositoryFactory(author=self.owner, active=True, private=True)
+        test = TestFactory(repository=repo)
+        _ = DailyTestRollupFactory(
+            test=test,
+            date=datetime.date.today() - datetime.timedelta(days=1),
+            repoid=repo.repoid,
+            last_duration_seconds=1,
+            latest_run=datetime.datetime.now() - datetime.timedelta(days=1),
+        )
+        _ = DailyTestRollupFactory(
+            test=test,
+            date=datetime.date.today(),
+            repoid=repo.repoid,
+            last_duration_seconds=2,
+            latest_run=datetime.datetime.now(),
+        )
+        test_2 = TestFactory(repository=repo)
+        _ = DailyTestRollupFactory(
+            test=test_2,
+            date=datetime.date.today(),
+            repoid=repo.repoid,
+            last_duration_seconds=3,
+        )
+        res = self.fetch_repository(
+            repo.name,
+            """testResults(ordering: { parameter: LAST_DURATION, direction: DESC }) { edges { node { name lastDuration } } }""",
+        )
+        assert res["testResults"] == {
+            "edges": [
+                {"node": {"name": test_2.name, "lastDuration": 3}},
+                {"node": {"name": test.name, "lastDuration": 2}},
+            ]
+        }
+
     def test_avg_duration_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        test = TestFactory(repository=repo)
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today() - datetime.timedelta(days=1),
             repoid=repo.repoid,
-            duration_seconds=1,
+            avg_duration_seconds=1,
         )
-        _test_instance_2 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            duration_seconds=2,
+            avg_duration_seconds=2,
         )
         test_2 = TestFactory(repository=repo)
-        _test_instance_3 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test_2,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            duration_seconds=3,
+            avg_duration_seconds=3,
         )
         res = self.fetch_repository(
             repo.name,
@@ -1020,24 +1091,24 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     def test_desc_avg_duration_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today() - datetime.timedelta(days=1),
             repoid=repo.repoid,
-            duration_seconds=1,
+            avg_duration_seconds=1,
         )
-        _test_instance_2 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            duration_seconds=2,
+            avg_duration_seconds=2,
         )
         test_2 = TestFactory(repository=repo)
-        _test_instance_3 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test_2,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            duration_seconds=3,
+            avg_duration_seconds=3,
         )
         res = self.fetch_repository(
             repo.name,
@@ -1053,30 +1124,27 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     def test_failure_rate_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today() - datetime.timedelta(days=1),
             repoid=repo.repoid,
-            outcome="pass",
+            pass_count=1,
+            fail_count=1,
         )
-        _test_instance_2 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            outcome="failure",
+            pass_count=3,
+            fail_count=0,
         )
         test_2 = TestFactory(repository=repo)
-        _test_instance_3 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test_2,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            outcome="failure",
-        )
-        _test_instance_4 = TestInstanceFactory(
-            test=test_2,
-            created_at=datetime.datetime.now(),
-            repoid=repo.repoid,
-            outcome="failure",
+            pass_count=2,
+            fail_count=3,
         )
         res = self.fetch_repository(
             repo.name,
@@ -1085,38 +1153,35 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         assert res["testResults"] == {
             "edges": [
-                {"node": {"name": test.name, "failureRate": 0.5}},
-                {"node": {"name": test_2.name, "failureRate": 1.0}},
+                {"node": {"name": test.name, "failureRate": 0.2}},
+                {"node": {"name": test_2.name, "failureRate": 0.6}},
             ]
         }
 
     def test_desc_failure_rate_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
-        _test_instance_1 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today() - datetime.timedelta(days=1),
             repoid=repo.repoid,
-            outcome="pass",
+            pass_count=1,
+            fail_count=1,
         )
-        _test_instance_2 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            outcome="failure",
+            pass_count=3,
+            fail_count=0,
         )
         test_2 = TestFactory(repository=repo)
-        _test_instance_3 = TestInstanceFactory(
+        _ = DailyTestRollupFactory(
             test=test_2,
-            created_at=datetime.datetime.now(),
+            date=datetime.date.today(),
             repoid=repo.repoid,
-            outcome="failure",
-        )
-        _test_instance_4 = TestInstanceFactory(
-            test=test_2,
-            created_at=datetime.datetime.now(),
-            repoid=repo.repoid,
-            outcome="failure",
+            pass_count=2,
+            fail_count=3,
         )
         res = self.fetch_repository(
             repo.name,
@@ -1125,7 +1190,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         assert res["testResults"] == {
             "edges": [
-                {"node": {"name": test_2.name, "failureRate": 1.0}},
-                {"node": {"name": test.name, "failureRate": 0.5}},
+                {"node": {"name": test_2.name, "failureRate": 0.6}},
+                {"node": {"name": test.name, "failureRate": 0.2}},
             ]
         }

--- a/graphql_api/types/enums/enums.py
+++ b/graphql_api/types/enums/enums.py
@@ -14,6 +14,7 @@ class OrderingParameter(enum.Enum):
 
 
 class TestResultsOrderingParameter(enum.Enum):
+    LAST_DURATION = "last_duration"
     AVG_DURATION = "avg_duration"
     FAILURE_RATE = "failure_rate"
     COMMITS_WHERE_FAIL = "commits_where_fail"

--- a/graphql_api/types/enums/test_results_ordering_parameter.graphql
+++ b/graphql_api/types/enums/test_results_ordering_parameter.graphql
@@ -1,4 +1,5 @@
 enum TestResultsOrderingParameter {
+  LAST_DURATION
   AVG_DURATION
   FAILURE_RATE
   COMMITS_WHERE_FAIL

--- a/graphql_api/types/test_results/test_results.graphql
+++ b/graphql_api/types/test_results/test_results.graphql
@@ -4,4 +4,5 @@ type TestResult {
   commitsFailed: Int
   failureRate: Float
   avgDuration: Float
+  lastDuration: Float
 }

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -26,5 +26,10 @@ def resolve_failure_rate(test, info) -> float | None:
 
 
 @test_result_bindable.field("avgDuration")
-def resolve_last_duration(test, info) -> float | None:
+def resolve_avg_duration(test, info) -> float | None:
     return test["avg_duration"]
+
+
+@test_result_bindable.field("lastDuration")
+def resolve_last_duration(test, info) -> float | None:
+    return test["last_duration"]

--- a/reports/tests/factories.py
+++ b/reports/tests/factories.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 import factory
 from factory.django import DjangoModelFactory
 
@@ -101,8 +103,8 @@ class TestFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Test
 
-    id = factory.Faker("word")
-    name = factory.Faker("word")
+    id = factory.Sequence(lambda n: f"{n}")
+    name = factory.Sequence(lambda n: f"{n}")
     repository = factory.SubFactory(RepositoryFactory)
     commits_where_fail = []
 
@@ -119,3 +121,24 @@ class TestInstanceFactory(factory.django.DjangoModelFactory):
     repoid = factory.SelfAttribute("test.repository.repoid")
     commitid = "123456"
     upload = factory.SubFactory(UploadFactory)
+
+
+class DailyTestRollupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.DailyTestRollup
+
+    test = factory.SubFactory(TestFactory)
+
+    repoid = factory.SelfAttribute("test.repository.repoid")
+    branch = "main"
+
+    last_duration_seconds = 1.0
+    avg_duration_seconds = 0.5
+    pass_count = 1
+    skip_count = 2
+    fail_count = 3
+
+    latest_run = datetime.now()
+    date = date.today()
+
+    commits_where_fail = ["123", "456", "789"]

--- a/reports/tests/factories.py
+++ b/reports/tests/factories.py
@@ -137,6 +137,7 @@ class DailyTestRollupFactory(factory.django.DjangoModelFactory):
     pass_count = 1
     skip_count = 2
     fail_count = 3
+    flaky_fail_count = 0
 
     latest_run = datetime.now()
     date = date.today()

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -1,22 +1,20 @@
 import datetime as dt
 from dataclasses import dataclass
 
-from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import (
+    Aggregate,
     Avg,
-    Case,
     F,
     FloatField,
     Func,
-    IntegerField,
     Max,
-    Q,
+    OuterRef,
     QuerySet,
-    Value,
-    When,
+    Subquery,
+    Sum,
 )
-from django.db.models.functions import Coalesce
-from shared.django_apps.reports.models import TestInstance
+from django.db.models.functions import Cast
+from shared.django_apps.reports.models import DailyTestRollup, TestInstance
 
 thirty_days_ago = dt.datetime.now(dt.UTC) - dt.timedelta(days=30)
 
@@ -30,6 +28,18 @@ class TestResultsAggregation:
 
 class ArrayLength(Func):
     function = "CARDINALITY"
+
+
+class Unnest(Func):
+    function = "unnest"
+
+
+class Distinct(Func):
+    function = "distinct"
+
+
+class Array(Aggregate):
+    function = "array"
 
 
 def aggregate_test_results(
@@ -62,38 +72,42 @@ def aggregate_test_results(
             branch=branch
         )
 
-    failure_rates_queryset = (
-        pass_failure_error_test_instances.values("test")
-        .annotate(
-            failure_rate=Avg(
-                Case(
-                    When(outcome="pass", then=Value(0.0)),
-                    When(outcome__in=["failure", "error"], then=Value(1.0)),
-                    output_field=FloatField(),
-                )
-            ),
-            updated_at=Max("created_at"),
-            commits_where_fail=Coalesce(
-                ArrayLength(
-                    ArrayAgg(
-                        "commitid",
-                        distinct=True,
-                        filter=Q(outcome__in=["failure", "error"]),
-                    )
-                ),
-                0,
-                output_field=IntegerField(),
-            ),
-            avg_duration=Avg("duration_seconds"),
-            name=F("test__name"),
-        )
-        .values(
-            "failure_rate",
-            "commits_where_fail",
-            "avg_duration",
-            "name",
-            "updated_at",
-        )
+    totals = DailyTestRollup.objects.filter(repoid=repoid, date__gt=time_ago)
+
+    print([(t.pass_count, t.fail_count) for t in totals], branch)
+
+    if branch is not None:
+        totals = totals.filter(branch=branch)
+
+    commits_where_fail_sq = (
+        totals.filter(test_id=OuterRef("test_id"))
+        .annotate(v=Distinct(Unnest(F("commits_where_fail"))))
+        .values("v")
+    )
+    latest_duration_sq = (
+        totals.filter(test_id=OuterRef("test_id"))
+        .values("last_duration_seconds")
+        .order_by("-latest_run")[:1]
     )
 
-    return failure_rates_queryset
+    aggregation_of_test_results = totals.values("test").annotate(
+        failure_rate=(
+            Cast(Sum(F("fail_count")), output_field=FloatField())
+            / (
+                Cast(
+                    Sum(F("pass_count")),
+                    output_field=FloatField(),
+                )
+                + Cast(Sum(F("fail_count")), output_field=FloatField())
+            )
+        ),
+        updated_at=Max("latest_run"),
+        commits_where_fail=ArrayLength(Array(Subquery(commits_where_fail_sq))),
+        last_duration=Subquery(latest_duration_sq),
+        avg_duration=Avg("avg_duration_seconds"),
+        name=F("test__name"),
+    )
+
+    print(aggregation_of_test_results.query)
+
+    return aggregation_of_test_results

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -49,12 +49,12 @@ def aggregate_test_results(
 ) -> QuerySet:
     """
     Function that retrieves aggregated information about all tests in a given repository, for a given time range, optionally filtered by branch name.
-    The fields it calculates are: the test failure rate, commits where this test failed, and average duration of the test.
+    The fields it calculates are: the test failure rate, commits where this test failed, last duration and average duration of the test.
 
     :param repoid: repoid of the repository we want to calculate aggregates for
     :param branch: optional name of the branch we want to filter on, if this is provided the aggregates calculated will only take into account test instances generated on that branch. By default branches will not be filtered and test instances on all branches wil be taken into account.
     :param history: optional timedelta field for filtering test instances used to calculated the aggregates by time, the test instances used will be those with a created at larger than now - history.
-    :returns: dictionary mapping test id to dictionary containing
+    :returns: queryset object containing list of dictionaries of results
 
     """
     time_ago = (
@@ -73,8 +73,6 @@ def aggregate_test_results(
         )
 
     totals = DailyTestRollup.objects.filter(repoid=repoid, date__gt=time_ago)
-
-    print([(t.pass_count, t.fail_count) for t in totals], branch)
 
     if branch is not None:
         totals = totals.filter(branch=branch)
@@ -107,7 +105,5 @@ def aggregate_test_results(
         avg_duration=Avg("avg_duration_seconds"),
         name=F("test__name"),
     )
-
-    print(aggregation_of_test_results.query)
 
     return aggregation_of_test_results


### PR DESCRIPTION
This PR does 2 things:
- add the lastDuration field to the TestResult GQL model
- use the DailyTestRollup object to query for aggregates, this is being done for perf reasons

depends on: https://github.com/codecov/worker/pull/699