### PR TITLE
Redirect with an error param on okta callback

### DIFF
--- a/codecov_auth/tests/unit/views/test_okta_cloud.py
+++ b/codecov_auth/tests/unit/views/test_okta_cloud.py
@@ -409,7 +409,10 @@ def test_okta_callback_perform_login_invalid_state(
         },
     )
     assert res.status_code == 302
-    assert res.url == f"http://localhost:3000/github/{okta_org.username}"
+    assert (
+        res.url
+        == f"http://localhost:3000/github/{okta_org.username}?error=invalid_state"
+    )
 
     assert log_message_exists("Invalid state during Okta login", caplog.records)
 
@@ -448,7 +451,11 @@ def test_okta_callback_perform_login_no_user_data(
             "state": state,
         },
     )
-    assert res.status_code == 400
+    assert res.status_code == 302
+    assert (
+        res.url
+        == f"http://localhost:3000/github/{okta_org.username}?error=invalid_token_response"
+    )
 
     assert log_message_exists(
         "Can't log in. Invalid Okta Token Response", caplog.records

--- a/codecov_auth/tests/unit/views/test_okta_cloud.py
+++ b/codecov_auth/tests/unit/views/test_okta_cloud.py
@@ -466,6 +466,54 @@ def test_okta_callback_perform_login_no_user_data(
 
 
 @pytest.mark.django_db
+def test_okta_callback_perform_login_invalid_id_token(
+    mocker: MockerFixture,
+    signed_in_client: TestClient,
+    caplog: LogCaptureFixture,
+    okta_org: Owner,
+    okta_account: Account,
+    mocked_okta_token_request: Any,
+):
+    state = "test-state"
+    session = signed_in_client.session
+    assert session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+    session["okta_cloud_oauth_state"] = state
+
+    session[OKTA_CURRENT_SESSION] = {
+        "org_ownerid": okta_org.ownerid,
+        "okta_settings_id": okta_account.okta_settings.first().id,
+    }
+
+    session.save()
+
+    mocked_okta_token_request.return_value = mocker.MagicMock(
+        status_code=200,
+        json=lambda: {"access_token": "mock_access_token", "id_token": "mock_id_token"},
+    )
+
+    mocker.patch(
+        "codecov_auth.views.okta_cloud.validate_id_token",
+        side_effect=Exception("Invalid ID token"),
+    )
+
+    res = signed_in_client.get(
+        "/login/okta/callback",
+        data={
+            "code": "random-code",
+            "state": state,
+        },
+    )
+    assert res.status_code == 302
+    assert (
+        res.url
+        == f"http://localhost:3000/github/{okta_org.username}?error=invalid_id_token"
+    )
+
+    updated_session = signed_in_client.session
+    assert updated_session.get(OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY) is None
+
+
+@pytest.mark.django_db
 def test_okta_callback_perform_login_access_denied(
     mocker: MockerFixture,
     signed_in_client: TestClient,

--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -142,7 +142,9 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
                 f"Okta authentication error: {error}. Description: {error_description}",
                 extra=log_context,
             )
-            return redirect(f"{app_redirect_url}?error={error}&error_description={error_description}")
+            return redirect(
+                f"{app_redirect_url}?error={error}&error_description={error_description}"
+            )
 
         # Redirect URL, need to validate and mark user as logged in
         if request.GET.get("code"):

--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -137,14 +137,11 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
         # Check for error in the callback
         error = request.GET.get("error")
         if error:
-            error_description = request.GET.get("error_description", "Unknown error")
             log.warning(
-                f"Okta authentication error: {error}. Description: {error_description}",
+                f"Okta authentication error: {error}",
                 extra=log_context,
             )
-            return redirect(
-                f"{app_redirect_url}?error={error}&error_description={error_description}"
-            )
+            return redirect(f"{app_redirect_url}?error={error}")
 
         # Redirect URL, need to validate and mark user as logged in
         if request.GET.get("code"):

--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -134,6 +134,16 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
         app_redirect_url = get_app_redirect_url(org_owner.username, org_owner.service)
         oauth_redirect_url = get_oauth_redirect_url()
 
+        # Check for error in the callback
+        error = request.GET.get("error")
+        if error:
+            error_description = request.GET.get("error_description", "Unknown error")
+            log.warning(
+                f"Okta authentication error: {error}. Description: {error_description}",
+                extra=log_context,
+            )
+            return redirect(f"{app_redirect_url}?error={error}&error_description={error_description}")
+
         # Redirect URL, need to validate and mark user as logged in
         if request.GET.get("code"):
             return self._perform_login(
@@ -164,7 +174,7 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
 
         if not self.verify_state(state):
             log.warning("Invalid state during Okta login")
-            return redirect(app_redirect_url)
+            return redirect(f"{app_redirect_url}?error=invalid_state")
 
         issuer: str = okta_settings.url.strip("/ ")
         user_data: OktaTokenResponse | None = self._fetch_user_data(
@@ -177,9 +187,13 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
 
         if user_data is None:
             log.warning("Can't log in. Invalid Okta Token Response", exc_info=True)
-            return HttpResponse(status=400)
+            return redirect(f"{app_redirect_url}?error=invalid_token_response")
 
-        _ = validate_id_token(issuer, user_data.id_token, okta_settings.client_id)
+        try:
+            _ = validate_id_token(issuer, user_data.id_token, okta_settings.client_id)
+        except Exception as e:
+            log.warning(f"Invalid ID token: {str(e)}", exc_info=True)
+            return redirect(f"{app_redirect_url}?error=invalid_id_token")
 
         self._login_user(request, organization)
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
We need a way to tell frontend that it's erroring, this is redirecting to the dashboard with an error param that will be caught in gazebo. 

### Links to relevant tickets
[Improve Okta Login Error Handling for users](https://github.com/codecov/engineering-team/issues/2347)

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.
Check for error in the callback -> redirect to app wit the error and err description sent via OKTA 
### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
