### PR TITLE
Add extra log debugging for unable to fetch_commit_yaml

### DIFF
--- a/services/yaml.py
+++ b/services/yaml.py
@@ -43,7 +43,7 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
             f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",
             extra={
                 "commit_id": commit.commitid,
-                "owner": owner,
+                "owner": owner.ownerid if owner else None,
             },
         )
         return None

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -34,14 +34,17 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
         )
         yaml_dict = safe_load(yaml_str)
         return validate_yaml(yaml_dict, show_secrets_for=None)
-    except Exception:
+    except Exception as e:
         # fetching, parsing, validating the yaml inside the commit can
         # have various exceptions, which we do not care about to get the final
         # yaml used for a commit, as any error here, the codecov.yaml would not
         # be used, so we return None here
         log.warning(
-            "Was not able to fetch yaml file for commit. Ignoring error and returning None.",
-            extra={"commit_id": commit.commitid},
+            f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",
+            extra={
+                "commit_id": commit.commitid,
+                "owner": owner,
+            },
         )
         return None
 


### PR DESCRIPTION

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
