### PR TITLE
Log all type of "owner" arg for fetch_commit_yaml

### DIFF
--- a/services/yaml.py
+++ b/services/yaml.py
@@ -8,7 +8,7 @@ from shared.yaml import UserYaml, fetch_current_yaml_from_provider_via_reference
 from shared.yaml.validation import validate_yaml
 from yaml import safe_load
 
-from codecov_auth.models import Owner, get_config
+from codecov_auth.models import Owner, User, get_config
 from core.models import Commit
 from services.repo_providers import RepoProviderService
 
@@ -39,11 +39,21 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
         # have various exceptions, which we do not care about to get the final
         # yaml used for a commit, as any error here, the codecov.yaml would not
         # be used, so we return None here
+
+        if isinstance(owner, Owner):
+            owner_arg = owner.ownerid
+        elif isinstance(owner, User):
+            owner_arg = owner.pk
+        elif owner is not None:
+            owner_arg = str(type(owner))
+        else:
+            owner_arg = None
+
         log.warning(
             f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",
             extra={
                 "commit_id": commit.commitid,
-                "owner": owner.pk if owner else None,
+                "owner_arg": owner_arg,
             },
         )
         return None

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -8,7 +8,7 @@ from shared.yaml import UserYaml, fetch_current_yaml_from_provider_via_reference
 from shared.yaml.validation import validate_yaml
 from yaml import safe_load
 
-from codecov_auth.models import Owner, User, get_config
+from codecov_auth.models import Owner, get_config
 from core.models import Commit
 from services.repo_providers import RepoProviderService
 
@@ -40,20 +40,11 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
         # yaml used for a commit, as any error here, the codecov.yaml would not
         # be used, so we return None here
 
-        if isinstance(owner, Owner):
-            owner_arg = owner.ownerid
-        elif isinstance(owner, User):
-            owner_arg = owner.pk
-        elif owner is not None:
-            owner_arg = str(type(owner))
-        else:
-            owner_arg = "None"
-
         log.warning(
             f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",
             extra={
                 "commit_id": commit.commitid,
-                "owner_arg": owner_arg,
+                "owner_arg": type(owner),
             },
         )
         return None

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -43,7 +43,7 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
             f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",
             extra={
                 "commit_id": commit.commitid,
-                "owner": owner.ownerid if owner else None,
+                "owner": owner.pk if owner else None,
             },
         )
         return None

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -47,7 +47,7 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
         elif owner is not None:
             owner_arg = str(type(owner))
         else:
-            owner_arg = None
+            owner_arg = "None"
 
         log.warning(
             f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",


### PR DESCRIPTION
The call from this function is coming from a lot of places, while it's only expecting a `Owner` type there has been other types being passed in.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
