### PR TITLE
Create the FlakeAggregates GQL model

### DIFF
--- a/graphql_api/tests/test_flake_aggregates.py
+++ b/graphql_api/tests/test_flake_aggregates.py
@@ -1,0 +1,77 @@
+from datetime import date, datetime, timedelta
+
+from django.test import TransactionTestCase
+from freezegun import freeze_time
+from shared.django_apps.reports.tests.factories import FlakeFactory
+
+from codecov_auth.tests.factories import OwnerFactory
+from core.tests.factories import RepositoryFactory
+from reports.tests.factories import DailyTestRollupFactory, TestFactory
+
+from .helper import GraphQLTestHelper
+
+
+@freeze_time(datetime.now().isoformat())
+class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
+    def setUp(self):
+        self.owner = OwnerFactory(username="randomOwner")
+        self.repository = RepositoryFactory(author=self.owner, branch="main")
+
+        for i in range(1, 31):
+            test = TestFactory(repository=self.repository)
+            _ = FlakeFactory(
+                repository=self.repository,
+                test=test,
+                end_date=datetime.now() - timedelta(days=i),
+            )
+            _ = DailyTestRollupFactory(
+                test=test,
+                date=date.today() - timedelta(days=i),
+                avg_duration_seconds=float(i),
+                latest_run=datetime.now() - timedelta(days=i),
+                fail_count=1,
+                skip_count=1,
+                pass_count=0,
+                flaky_fail_count=1 if i % 5 == 0 else 0,
+                branch="main",
+            )
+
+    def test_fetch_test_result_total_runtime(self) -> None:
+        query = """
+            query {
+               owner(username: "%s") {
+                    repository(name: "%s") {
+                        ... on Repository {
+                            flakeAggregates {
+                                flakeCount
+                            }
+                        }
+                    }
+                 }
+            }
+        """ % (self.owner.username, self.repository.name)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+        assert result["owner"]["repository"]["flakeAggregates"]["flakeCount"] == 29
+
+    def test_fetch_test_result_slowest_tests_runtime(self) -> None:
+        query = """
+            query {
+               owner(username: "%s") {
+                    repository(name: "%s") {
+                        ... on Repository {
+                            flakeAggregates {
+                                flakeRate
+                            }
+                        }
+                    }
+                 }
+            }
+        """ % (self.owner.username, self.repository.name)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+        assert result["owner"]["repository"]["flakeAggregates"]["flakeRate"] == 5 / 29

--- a/graphql_api/types/__init__.py
+++ b/graphql_api/types/__init__.py
@@ -29,6 +29,7 @@ from .enums import enum_types
 from .file import commit_file, file_bindable
 from .flag import flag, flag_bindable
 from .flag_comparison import flag_comparison, flag_comparison_bindable
+from .flake_aggregates import flake_aggregates, flake_aggregates_bindable
 from .impacted_file import (
     impacted_file,
     impacted_file_bindable,
@@ -66,7 +67,10 @@ from .segment_comparison import (
 from .self_hosted_license import self_hosted_license, self_hosted_license_bindable
 from .session import session, session_bindable
 from .test_results import test_result_bindable, test_results
-from .test_results_headers import test_results_headers, test_results_headers_bindable
+from .test_results_aggregates import (
+    test_results_aggregates,
+    test_results_aggregates_bindable,
+)
 from .upload import upload, upload_bindable, upload_error_bindable
 from .user import user, user_bindable
 from .user_token import user_token, user_token_bindable
@@ -117,7 +121,8 @@ types = [
     account,
     okta_config,
     test_results,
-    test_results_headers,
+    test_results_aggregates,
+    flake_aggregates,
 ]
 
 bindables = [
@@ -176,5 +181,6 @@ bindables = [
     account_bindable,
     okta_config_bindable,
     test_result_bindable,
-    test_results_headers_bindable,
+    test_results_aggregates_bindable,
+    flake_aggregates_bindable,
 ]

--- a/graphql_api/types/enums/enums.py
+++ b/graphql_api/types/enums/enums.py
@@ -17,6 +17,7 @@ class TestResultsOrderingParameter(enum.Enum):
     LAST_DURATION = "last_duration"
     AVG_DURATION = "avg_duration"
     FAILURE_RATE = "failure_rate"
+    FLAKE_RATE = "flake_rate"
     COMMITS_WHERE_FAIL = "commits_where_fail"
     UPDATED_AT = "updated_at"
 

--- a/graphql_api/types/enums/test_results_ordering_parameter.graphql
+++ b/graphql_api/types/enums/test_results_ordering_parameter.graphql
@@ -2,6 +2,7 @@ enum TestResultsOrderingParameter {
   LAST_DURATION
   AVG_DURATION
   FAILURE_RATE
+  FLAKE_RATE
   COMMITS_WHERE_FAIL
   UPDATED_AT
 }

--- a/graphql_api/types/flake_aggregates/__init__.py
+++ b/graphql_api/types/flake_aggregates/__init__.py
@@ -1,0 +1,9 @@
+from shared.license import get_current_license
+
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+
+from .flake_aggregates import flake_aggregates_bindable
+
+flake_aggregates = ariadne_load_local_graphql(__file__, "flake_aggregates.graphql")
+
+__all__ = ["get_current_license", "flake_aggregates_bindable"]

--- a/graphql_api/types/flake_aggregates/__init__.py
+++ b/graphql_api/types/flake_aggregates/__init__.py
@@ -1,9 +1,7 @@
-from shared.license import get_current_license
-
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 
 from .flake_aggregates import flake_aggregates_bindable
 
 flake_aggregates = ariadne_load_local_graphql(__file__, "flake_aggregates.graphql")
 
-__all__ = ["get_current_license", "flake_aggregates_bindable"]
+__all__ = ["flake_aggregates_bindable"]

--- a/graphql_api/types/flake_aggregates/flake_aggregates.graphql
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.graphql
@@ -1,0 +1,4 @@
+type FlakeAggregates {
+  flakeCount: Int!
+  flakeRate: Float!
+}

--- a/graphql_api/types/flake_aggregates/flake_aggregates.py
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.py
@@ -1,0 +1,13 @@
+from ariadne import ObjectType
+
+flake_aggregates_bindable = ObjectType("FlakeAggregates")
+
+
+@flake_aggregates_bindable.field("flakeCount")
+def resolve_name(obj, _) -> int:
+    return obj["flake_count"]
+
+
+@flake_aggregates_bindable.field("flakeRate")
+def resolve_updated_at(obj, _) -> float:
+    return obj["flake_rate"]

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -86,7 +86,8 @@ type Repository {
 
   "CoverageAnalytics are fields related to Codecov's Coverage product offering"
   coverageAnalytics: CoverageAnalytics
-  testResultsHeaders: TestResultsHeaders
+  testResultsHeaders: TestResultsAggregates
+  flakeAggregates: FlakeAggregates
 }
 
 type TestResultConnection {

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -35,7 +35,11 @@ from services.components import ComponentMeasurements
 from services.profiling import CriticalFile, ProfilingSummary
 from services.redis_configuration import get_redis_connection
 from timeseries.models import Dataset, Interval, MeasurementName
-from utils.test_results import aggregate_test_results, test_results_headers
+from utils.test_results import (
+    generate_flake_aggregates,
+    generate_test_results,
+    generate_test_results_aggregates,
+)
 
 log = logging.getLogger(__name__)
 
@@ -531,7 +535,7 @@ async def resolve_test_results(
     filters=None,
     **kwargs,
 ):
-    queryset = await sync_to_async(aggregate_test_results)(
+    queryset = await sync_to_async(generate_test_results)(
         repoid=repository.repoid, branch=filters.get("branch") if filters else None
     )
 
@@ -561,10 +565,20 @@ def resolve_coverage_analytics(
 
 @repository_bindable.field("testResultsHeaders")
 @convert_kwargs_to_snake_case
-async def resolve_test_results_headers(
+async def resolve_test_results_aggregates(
     repository: Repository,
     info: GraphQLResolveInfo,
 ):
-    queryset = await sync_to_async(test_results_headers)(repoid=repository.repoid)
+    queryset = await sync_to_async(generate_test_results_aggregates)(
+        repoid=repository.repoid
+    )
+
+    return queryset
+
+
+@repository_bindable.field("flakeAggregates")
+@convert_kwargs_to_snake_case
+async def resolve_flake_aggregates(repository: Repository, info: GraphQLResolveInfo):
+    queryset = await sync_to_async(generate_flake_aggregates)(repoid=repository.repoid)
 
     return queryset

--- a/graphql_api/types/test_results/test_results.graphql
+++ b/graphql_api/types/test_results/test_results.graphql
@@ -3,6 +3,7 @@ type TestResult {
   name: String!
   commitsFailed: Int
   failureRate: Float
+  flakeRate: Float
   avgDuration: Float
   lastDuration: Float
 }

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -37,6 +37,11 @@ def resolve_failure_rate(test: TestDict, _: GraphQLResolveInfo) -> float | None:
     return test["failure_rate"]
 
 
+@test_result_bindable.field("flakeRate")
+def resolve_flake_rate(test, info) -> float | None:
+    return test["flake_rate"]
+
+
 @test_result_bindable.field("avgDuration")
 def resolve_avg_duration(test: TestDict, _: GraphQLResolveInfo) -> float | None:
     return test["avg_duration"]

--- a/graphql_api/types/test_results_aggregates/__init__.py
+++ b/graphql_api/types/test_results_aggregates/__init__.py
@@ -1,0 +1,11 @@
+from shared.license import get_current_license
+
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+
+from .test_results_aggregates import test_results_aggregates_bindable
+
+test_results_aggregates = ariadne_load_local_graphql(
+    __file__, "test_results_aggregates.graphql"
+)
+
+__all__ = ["get_current_license", "test_results_aggregates_bindable"]

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
@@ -1,4 +1,4 @@
-type TestResultsHeaders {
+type TestResultsAggregates {
   totalRunTime: Float!
   slowestTestsRunTime: Float!
   totalFails: Int!

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -13,21 +13,21 @@ class TestResultsHeaders(TypedDict):
     skips: int
 
 
-@test_results_headers_bindable.field("totalRunTime")
+@test_results_aggregates_bindable.field("totalRunTime")
 def resolve_name(obj: TestResultsHeaders, _: GraphQLResolveInfo) -> float:
     return obj["total_run_time"]
 
 
-@test_results_headers_bindable.field("slowestTestsRunTime")
+@test_results_aggregates_bindable.field("slowestTestsRunTime")
 def resolve_updated_at(obj: TestResultsHeaders, _: GraphQLResolveInfo) -> float:
     return obj["slowest_tests_duration"]
 
 
-@test_results_headers_bindable.field("totalFails")
+@test_results_aggregates_bindable.field("totalFails")
 def resolve_commits_failed(obj: TestResultsHeaders, _: GraphQLResolveInfo) -> int:
     return obj["fails"]
 
 
-@test_results_headers_bindable.field("totalSkips")
+@test_results_aggregates_bindable.field("totalSkips")
 def resolve_failure_rate(obj: TestResultsHeaders, _: GraphQLResolveInfo) -> int:
     return obj["skips"]

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -3,7 +3,7 @@ from typing import TypedDict
 from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
-test_results_headers_bindable = ObjectType("TestResultsHeaders")
+test_results_aggregates_bindable = ObjectType("TestResultsAggregates")
 
 
 class TestResultsHeaders(TypedDict):

--- a/graphql_api/types/test_results_headers/__init__.py
+++ b/graphql_api/types/test_results_headers/__init__.py
@@ -1,9 +1,0 @@
-from graphql_api.helpers.ariadne import ariadne_load_local_graphql
-
-from .test_results_headers import test_results_headers_bindable
-
-test_results_headers = ariadne_load_local_graphql(
-    __file__, "test_results_headers.graphql"
-)
-
-__all__ = ["test_results_headers_bindable"]


### PR DESCRIPTION
This contains the flakeCount and flakeRate fields. 

The flakeCount is calculated by getting all flakes that are active or ended in the last 30 days

The flakeRate is calculated by accumulating the flaky_fail_count / (pass_count + fail_count) for all tests

depends on: https://github.com/codecov/shared/pull/356 and https://github.com/codecov/codecov-api/pull/816