### PR TITLE
Remove coverage offsets related code

### DIFF
--- a/api/internal/tests/views/test_compare_viewset.py
+++ b/api/internal/tests/views/test_compare_viewset.py
@@ -427,16 +427,11 @@ class TestCompareViewSetRetrieve(APITestCase):
         new_callable=PropertyMock,
     )
     @patch(
-        "services.comparison.PullRequestComparison.allow_coverage_offsets",
-        new_callable=PropertyMock,
-    )
-    @patch(
         "services.comparison.PullRequestComparison.update_base_report_with_pseudo_diff"
     )
     def test_pull_request_pseudo_comparison_can_update_base_report(
         self,
         update_base_report_mock,
-        allow_coverage_offsets_mock,
         pseudo_diff_adjusts_tracked_lines_mock,
         adapter_mock,
         base_report_mock,
@@ -445,8 +440,6 @@ class TestCompareViewSetRetrieve(APITestCase):
         adapter_mock.return_value = self.mocked_compare_adapter
         base_report_mock.return_value = self.base_report
         head_report_mock.return_value = self.head_report
-
-        allow_coverage_offsets_mock.return_value = True
 
         pseudo_diff_adjusts_tracked_lines_mock.return_value = True
 

--- a/api/public/v2/tests/test_api_compare_viewset.py
+++ b/api/public/v2/tests/test_api_compare_viewset.py
@@ -627,16 +627,11 @@ class TestCompareViewSetRetrieve(APITestCase):
         new_callable=PropertyMock,
     )
     @patch(
-        "services.comparison.PullRequestComparison.allow_coverage_offsets",
-        new_callable=PropertyMock,
-    )
-    @patch(
         "services.comparison.PullRequestComparison.update_base_report_with_pseudo_diff"
     )
     def test_pull_request_pseudo_comparison_can_update_base_report(
         self,
         update_base_report_mock,
-        allow_coverage_offsets_mock,
         pseudo_diff_adjusts_tracked_lines_mock,
         adapter_mock,
         base_report_mock,
@@ -645,8 +640,6 @@ class TestCompareViewSetRetrieve(APITestCase):
         adapter_mock.return_value = self.mocked_compare_adapter
         base_report_mock.return_value = self.base_report
         head_report_mock.return_value = self.head_report
-
-        allow_coverage_offsets_mock.return_value = True
 
         pseudo_diff_adjusts_tracked_lines_mock.return_value = True
 

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -1132,21 +1132,6 @@ class PullRequestComparison(Comparison):
         ) and bool(self.pull.compared_to)
 
     @cached_property
-    def allow_coverage_offsets(self):
-        """
-        Returns True if "coverage offsets" are allowed, False if not, according
-        to repository yaml settings or app yaml settings if not defined in repository
-        yaml settings.
-        """
-        return walk(
-            _dict=self.pull.repository.yaml,
-            keys=("codecov", "allow_coverage_offsets"),
-            _else=get_config(
-                ("site", "codecov", "allow_coverage_offsets"), default=False
-            ),
-        )
-
-    @cached_property
     def pseudo_diff(self):
         """
         Returns the diff between the 'self.pull.compared_to' field and the

--- a/services/tests/test_comparison.py
+++ b/services/tests/test_comparison.py
@@ -1125,41 +1125,6 @@ class PullRequestComparisonTests(TestCase):
             comparison = PullRequestComparison(owner, pull)
             assert comparison.is_pseudo_comparison is False
 
-    @patch("services.comparison.get_config")
-    def test_allow_coverage_offsets(self, get_config_mock):
-        owner = OwnerFactory()
-        repository = RepositoryFactory(author=owner)
-        pull = PullFactory(
-            pullid=44,
-            repository=repository,
-            compared_to=CommitFactory(repository=repository).commitid,
-            head=CommitFactory(repository=repository).commitid,
-            base=CommitFactory(repository=repository).commitid,
-        )
-
-        with self.subTest("returns result in repo yaml if exists"):
-            repository.yaml = {"codecov": {"allow_coverage_offsets": True}}
-            repository.save()
-            comparison = PullRequestComparison(owner, pull)
-            assert comparison.allow_coverage_offsets is True
-
-            repository.yaml = {"codecov": {"allow_coverage_offsets": False}}
-            repository.save()
-            comparison = PullRequestComparison(owner, pull)
-            assert comparison.allow_coverage_offsets is False
-
-        repository.yaml = None
-        repository.save()
-
-        with self.subTest("returns app settings value if exists, True if not"):
-            get_config_mock.return_value = True
-            comparison = PullRequestComparison(owner, pull)
-            assert comparison.allow_coverage_offsets is True
-
-            get_config_mock.return_value = False
-            comparison = PullRequestComparison(owner, pull)
-            assert comparison.allow_coverage_offsets is False
-
     @patch("services.repo_providers.RepoProviderService.get_adapter")
     def test_pseudo_diff_returns_diff_between_base_and_compared_to(
         self, get_adapter_mock


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Following up from https://github.com/codecov/codecov-api/pull/780, remove unused code pertaining to the old YAML field. This closes https://github.com/orgs/codecov/projects/31/views/11?pane=issue&itemId=77144226.

### Links to relevant tickets

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
