### PR TITLE
Make sure calls to fetch_commit_yaml are Owner type

### DIFF
--- a/api/public/v2/compare/views.py
+++ b/api/public/v2/compare/views.py
@@ -117,7 +117,7 @@ class CompareViewSet(
         Returns component comparisons
         """
         comparison = self.get_object()
-        components = commit_components(comparison.head_commit, request.user)
+        components = commit_components(comparison.head_commit, self.owner)
         component_comparisons = [
             ComponentComparison(comparison, component) for component in components
         ]

--- a/api/public/v2/component/views.py
+++ b/api/public/v2/component/views.py
@@ -40,7 +40,7 @@ class ComponentViewSet(viewsets.ViewSet, RepoPropertyMixin):
         """
         commit = self.get_commit()
         report = commit.full_report
-        components = commit_components(commit, request.user)
+        components = commit_components(commit, self.owner)
         components_with_coverage = []
         for component in components:
             component_report = component_filtered_report(report, [component])

--- a/api/public/v2/report/views.py
+++ b/api/public/v2/report/views.py
@@ -98,7 +98,7 @@ class BaseReportViewSet(
             component = next(
                 (
                     component
-                    for component in commit_components(commit, self.request.user)
+                    for component in commit_components(commit, self.owner)
                     if component.component_id == component_id
                 ),
                 None,

--- a/api/public/v2/tests/test_api_compare_viewset.py
+++ b/api/public/v2/tests/test_api_compare_viewset.py
@@ -715,6 +715,7 @@ class TestCompareViewSetRetrieve(APITestCase):
             content_type="application/json",
         )
 
+        commit_components.assert_called_once_with(self.head, self.org)
         assert res.status_code == 200
         assert res.json() == [
             {

--- a/api/public/v2/tests/test_api_component_viewset.py
+++ b/api/public/v2/tests/test_api_component_viewset.py
@@ -72,11 +72,11 @@ class ComponentViewSetTestCase(TestCase):
     @patch("api.public.v2.component.views.commit_components")
     @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_component_list(
-        self, build_report_from_commit, commit_compontents, get_repo_permissions
+        self, build_report_from_commit, commit_components, get_repo_permissions
     ):
         get_repo_permissions.return_value = (True, True)
         build_report_from_commit.side_effect = [sample_report()]
-        commit_compontents.return_value = [
+        commit_components.return_value = [
             Component(
                 component_id="foo",
                 paths=[r".*foo"],
@@ -94,6 +94,7 @@ class ComponentViewSetTestCase(TestCase):
         ]
 
         res = self._request_components()
+        commit_components.assert_called_once_with(self.commit, self.org)
         assert res.status_code == 200
         assert res.json() == [
             {"component_id": "foo", "name": "Foo", "coverage": 62.5},
@@ -103,11 +104,11 @@ class ComponentViewSetTestCase(TestCase):
     @patch("api.public.v2.component.views.commit_components")
     @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_component_list_no_coverage(
-        self, build_report_from_commit, commit_compontents, get_repo_permissions
+        self, build_report_from_commit, commit_components, get_repo_permissions
     ) -> None:
         get_repo_permissions.return_value = (True, True)
         build_report_from_commit.side_effect = [empty_report()]
-        commit_compontents.return_value = [
+        commit_components.return_value = [
             Component(
                 component_id="foo",
                 paths=[r".*foo"],
@@ -118,6 +119,7 @@ class ComponentViewSetTestCase(TestCase):
         ]
 
         res = self._request_components()
+        commit_components.assert_called_once_with(self.commit, self.org)
         assert res.status_code == 200
         assert res.json() == [
             {

--- a/api/public/v2/tests/test_report_viewset.py
+++ b/api/public/v2/tests/test_report_viewset.py
@@ -971,6 +971,7 @@ class ReportViewSetTestCase(TestCase):
         build_report_from_commit.return_value = flags_report()
 
         res = self._request_report(component_id="foo")
+        commit_components.assert_called_once_with(self.commit1, self.org)
         assert res.status_code == 200
         assert res.json() == {
             "totals": {

--- a/api/public/v2/tests/test_totals_viewset.py
+++ b/api/public/v2/tests/test_totals_viewset.py
@@ -617,6 +617,7 @@ class TotalsViewSetTestCase(TestCase):
         build_report_from_commit.return_value = sample_report()
 
         res = self._request_report(component_id="foo")
+        commit_components.assert_called_once_with(self.commit1, self.org)
         assert res.status_code == 200
         assert res.json() == {
             "totals": {

--- a/services/tests/test_yaml.py
+++ b/services/tests/test_yaml.py
@@ -40,7 +40,7 @@ class YamlServiceTest(TransactionTestCase):
           notify:
             require_ci_to_pass: no
         """
-        with pytest.raises(AssertionError) as exc_info:
+        with pytest.raises(TypeError) as exc_info:
             yaml.final_commit_yaml(self.commit, "something else")
         assert (
             str(exc_info.value)

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -30,9 +30,10 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
     # Previously this issue is masked by the catch all exception handling. Most badly typed calls have
     # been addressed, but there might still be some entrypoints unaccounted for, will fix new discoveries
     # from this assertion being raised.
-    assert owner is None or isinstance(
-        owner, Owner
-    ), f"fetch_commit_yaml owner arg must be Owner or None. Provided: {type(owner)}"
+    if owner is not None and not isinstance(owner, Owner):
+        raise TypeError(
+            f"fetch_commit_yaml owner arg must be Owner or None. Provided: {type(owner)}"
+        )
 
     try:
         repository_service = RepoProviderService().get_adapter(

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -25,6 +25,15 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
     Fetches the codecov.yaml file for a particular commit from the service provider.
     Service provider API request is made on behalf of the given `owner`.
     """
+
+    # There's been a lot of instances where this function is called where the owner arg is not Owner type
+    # Previously this issue is masked by the catch all exception handling. Most badly typed calls have
+    # been addressed, but there might still be some entrypoints unaccounted for, will fix new discoveries
+    # from this assertion being raised.
+    assert owner is None or isinstance(
+        owner, Owner
+    ), f"fetch_commit_yaml owner arg must be Owner or None. Provided: {type(owner)}"
+
     try:
         repository_service = RepoProviderService().get_adapter(
             owner=owner, repo=commit.repository

--- a/services/yaml.py
+++ b/services/yaml.py
@@ -34,14 +34,17 @@ def fetch_commit_yaml(commit: Commit, owner: Owner | None) -> Dict | None:
         )
         yaml_dict = safe_load(yaml_str)
         return validate_yaml(yaml_dict, show_secrets_for=None)
-    except Exception:
+    except Exception as e:
         # fetching, parsing, validating the yaml inside the commit can
         # have various exceptions, which we do not care about to get the final
         # yaml used for a commit, as any error here, the codecov.yaml would not
         # be used, so we return None here
         log.warning(
-            "Was not able to fetch yaml file for commit. Ignoring error and returning None.",
-            extra={"commit_id": commit.commitid},
+            f"Was not able to fetch yaml file for commit. Ignoring error and returning None. Exception: {e}",
+            extra={
+                "commit_id": commit.commitid,
+                "owner": owner,
+            },
         )
         return None
 

--- a/upload/tests/views/test_empty_upload.py
+++ b/upload/tests/views/test_empty_upload.py
@@ -484,12 +484,28 @@ def test_empty_upload_no_auth(db, mocker):
     )
 
 
-def test_empty_upload_org_token(db, mocker):
+@patch("services.yaml.fetch_commit_yaml")
+@patch("services.task.TaskService.notify")
+@patch("services.repo_providers.RepoProviderService.get_adapter")
+def test_empty_upload_commit_yaml_org_token(
+    mock_repo_provider_service, notify_mock, fetch_yaml_mock, db, mocker
+):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+    mock_repo_provider_service.return_value = MockedProviderAdapter(
+        ["README.md", "codecov.yml", "template.txt", "base.py"]
+    )
+    fetch_yaml_mock.return_value = None
+
     repository = RepositoryFactory(
         name="the_repo", author__username="codecov", author__service="github"
     )
-    org_token = OrganizationLevelTokenFactory.create(owner=repository.author)
     commit = CommitFactory(repository=repository)
+    org_token = OrganizationLevelTokenFactory.create(owner=repository.author)
+    repository.save()
+    commit.save()
+    org_token.save()
 
     client = APIClient()
     url = reverse(
@@ -505,9 +521,62 @@ def test_empty_upload_org_token(db, mocker):
         headers={"Authorization": f"token {org_token.token}"},
     )
     response_json = response.json()
-    assert response.status_code == 401
+    assert response.status_code == 200
     assert (
-        response_json.get("detail")
-        == "Failed token authentication, please double-check that your repository token matches in the Codecov UI, "
-        "or review the docs https://docs.codecov.com/docs/adding-the-codecov-token"
+        response_json.get("result")
+        == "Some files cannot be ignored. Triggering failing notifications."
     )
+    assert response_json.get("non_ignored_files") == ["base.py"]
+    notify_mock.assert_called_once_with(
+        repoid=repository.repoid, commitid=commit.commitid, empty_upload="fail"
+    )
+
+    fetch_yaml_mock.assert_called_once_with(commit, repository.author)
+
+
+@patch("services.yaml.fetch_commit_yaml")
+@patch("services.task.TaskService.notify")
+@patch("services.repo_providers.RepoProviderService.get_adapter")
+def test_empty_upload_ommit_yaml_repo_token(
+    mock_repo_provider_service, notify_mock, fetch_yaml_mock, db, mocker
+):
+    mocker.patch.object(
+        CanDoCoverageUploadsPermission, "has_permission", return_value=True
+    )
+    mock_repo_provider_service.return_value = MockedProviderAdapter(
+        ["README.md", "codecov.yml", "template.txt", "base.py"]
+    )
+    fetch_yaml_mock.return_value = None
+
+    repository = RepositoryFactory(
+        name="the_repo", author__username="codecov", author__service="github"
+    )
+    commit = CommitFactory(repository=repository)
+    repository.save()
+    commit.save()
+
+    client = APIClient()
+    url = reverse(
+        "new_upload.empty_upload",
+        args=[
+            "github",
+            "codecov::::the_repo",
+            commit.commitid,
+        ],
+    )
+    response = client.post(
+        url,
+        headers={"Authorization": f"token {repository.upload_token}"},
+    )
+    response_json = response.json()
+    assert response.status_code == 200
+    assert (
+        response_json.get("result")
+        == "Some files cannot be ignored. Triggering failing notifications."
+    )
+    assert response_json.get("non_ignored_files") == ["base.py"]
+    notify_mock.assert_called_once_with(
+        repoid=repository.repoid, commitid=commit.commitid, empty_upload="fail"
+    )
+
+    fetch_yaml_mock.assert_called_once_with(commit, repository.author)

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -119,7 +119,7 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
             owner = request.user
         elif isinstance(request.user, RepositoryAsUser):
             # repository token
-            owner = request.user._repository.owner
+            owner = request.user._repository.author
 
         yaml = final_commit_yaml(commit, owner).to_dict()
         token = try_to_get_best_possible_bot_token(repo)

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -113,7 +113,7 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
                 status=status.HTTP_200_OK,
             )
 
-        # Depending on the authen class used, the request.user may need to be converted to a Owner
+        # Depending on the authentication class used, the request.user may need to be converted to a Owner
         owner = request.user
         if isinstance(request.user, RepositoryAsUser):
             owner = request.user._repository.author

--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -19,7 +19,6 @@ from codecov_auth.authentication.repo_auth import (
     repo_auth_custom_exception_handler,
 )
 from codecov_auth.authentication.types import RepositoryAsUser
-from codecov_auth.models import Owner
 from services.repo_providers import RepoProviderService
 from services.task import TaskService
 from services.yaml import final_commit_yaml
@@ -114,11 +113,9 @@ class EmptyUploadView(CreateAPIView, GetterMixin):
                 status=status.HTTP_200_OK,
             )
 
-        if isinstance(request.user, Owner):
-            # using org token
-            owner = request.user
-        elif isinstance(request.user, RepositoryAsUser):
-            # repository token
+        # Depending on the authen class used, the request.user may need to be converted to a Owner
+        owner = request.user
+        if isinstance(request.user, RepositoryAsUser):
             owner = request.user._repository.author
 
         yaml = final_commit_yaml(commit, owner).to_dict()


### PR DESCRIPTION
- In empty-upload depending on the auth classes used, the `request.user` can be `Owner` or `RepositoryAsUser`, need to make sure when sending to `final_commit_yaml` it will be `Owner`
- Several places in public API, it passes in to `fetch_commit_yaml ` a `User` object of the authenticated request maker, which is wrong. Instead it should be the `Owner` of the requested organization
- Add an assertion to `fetch_commit_yaml` to make sure if an `owner` arg is passed in it is in fact `Owner`, previously this error is not surfaced because we just do a catch all exception.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
