### PR TITLE
fix CoverageViewSet where incorrect arg is passed to commit_components

### DIFF
--- a/api/internal/coverage/views.py
+++ b/api/internal/coverage/views.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+from django.http import HttpRequest
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -13,7 +16,7 @@ from services.path import ReportPaths
 class CoverageViewSet(viewsets.ViewSet, RepoPropertyMixin):
     permission_classes = [RepositoryArtifactPermissions]
 
-    def get_object(self):
+    def get_object(self) -> ReportPaths:
         commit_sha = self.request.query_params.get("sha")
         if not commit_sha:
             branch_name = self.request.query_params.get("branch", self.repo.branch)
@@ -39,9 +42,7 @@ class CoverageViewSet(viewsets.ViewSet, RepoPropertyMixin):
         components = self.request.query_params.getlist("components")
         component_paths = []
         if components:
-            all_components = components_service.commit_components(
-                commit, self.request.user
-            )
+            all_components = components_service.commit_components(commit, self.owner)
             filtered_components = components_service.filter_components_by_name(
                 all_components, components
             )
@@ -62,7 +63,7 @@ class CoverageViewSet(viewsets.ViewSet, RepoPropertyMixin):
         return paths
 
     @action(detail=False, methods=["get"], url_path="tree")
-    def tree(self, request, *args, **kwargs):
+    def tree(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Response:
         paths = self.get_object()
         serializer = TreeSerializer(paths.single_directory(), many=True)
         return Response(serializer.data)

--- a/api/internal/tests/views/test_coverage_viewset.py
+++ b/api/internal/tests/views/test_coverage_viewset.py
@@ -155,6 +155,7 @@ class CoverageViewSetTests(APITestCase):
         ]
 
         build_report_from_commit.assert_called_once_with(self.commit1)
+        commit_components_mock.assert_called_once_with(self.commit1, self.current_owner)
 
     @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_tree_sha(self, build_report_from_commit):
@@ -314,6 +315,7 @@ class CoverageViewSetTests(APITestCase):
         build_report_from_commit.return_value = sample_report()
         res = self._tree(components="ComponentOne")
         assert res.json() == []
+        commit_components_mock.assert_called_once_with(self.commit1, self.current_owner)
 
     @patch("shared.reports.api_report_service.build_report_from_commit")
     @patch("services.components.commit_components")
@@ -332,6 +334,7 @@ class CoverageViewSetTests(APITestCase):
         build_report_from_commit.return_value = sample_report()
         res = self._tree(components="Does_not_exist")
         assert res.status_code == 404
+        commit_components_mock.assert_called_once_with(self.commit1, self.current_owner)
 
     @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_tree_no_data_for_flags(self, build_report_from_commit):


### PR DESCRIPTION
the second arg of commit_components should be the Owner object of the commit/repo. Not the authenticated `User` object.

Fixes https://codecov.sentry.io/share/issue/46e6e17c75f34297a2e9d76a82598eef/

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
