### PR TITLE
[temp] Add additional permissions to pulls and test results endpoint

### DIFF
--- a/api/public/v2/pull/views.py
+++ b/api/public/v2/pull/views.py
@@ -2,10 +2,16 @@ import django_filters
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins
+from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 
 from api.public.v2.schema import repo_parameters
 from api.shared.pagination import PaginationMixin
+from api.shared.permissions import RepositoryArtifactPermissions, SuperTokenPermissions
 from api.shared.pull.mixins import PullViewSetMixin
+from codecov_auth.authentication import (
+    SuperTokenAuthentication,
+    UserTokenAuthentication,
+)
 from core.models import Pull, PullStates
 
 from .serializers import PullSerializer
@@ -26,6 +32,15 @@ class PullViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
 ):
+    authentication_classes = [
+        SuperTokenAuthentication,
+        UserTokenAuthentication,
+        BasicAuthentication,
+        SessionAuthentication,
+    ]
+
+    permission_classes = [SuperTokenPermissions | RepositoryArtifactPermissions]
+
     serializer_class = PullSerializer
     queryset = Pull.objects.none()
     filterset_class = PullFilters

--- a/api/public/v2/test_results/views.py
+++ b/api/public/v2/test_results/views.py
@@ -3,9 +3,14 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, viewsets
+from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 
 from api.shared.mixins import RepoPropertyMixin
-from api.shared.permissions import RepositoryArtifactPermissions
+from api.shared.permissions import RepositoryArtifactPermissions, SuperTokenPermissions
+from codecov_auth.authentication import (
+    SuperTokenAuthentication,
+    UserTokenAuthentication,
+)
 from reports.models import TestInstance
 
 from .serializers import TestInstanceSerializer
@@ -69,8 +74,15 @@ class TestResultsView(
     mixins.RetrieveModelMixin,
     RepoPropertyMixin,
 ):
+    authentication_classes = [
+        SuperTokenAuthentication,
+        UserTokenAuthentication,
+        BasicAuthentication,
+        SessionAuthentication,
+    ]
+
     serializer_class = TestInstanceSerializer
-    permission_classes = [RepositoryArtifactPermissions]
+    permission_classes = [SuperTokenPermissions | RepositoryArtifactPermissions]
     filter_backends = [DjangoFilterBackend]
     filterset_class = TestResultsFilters
 

--- a/api/public/v2/tests/test_api_pull_viewset.py
+++ b/api/public/v2/tests/test_api_pull_viewset.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
 
-from django.test import override_settings
 from codecov.tests.base_test import InternalAPITest
 from codecov_auth.tests.factories import OwnerFactory
 from core.models import Pull
@@ -236,7 +236,7 @@ class PullViewsetTests(InternalAPITest):
         self, repository_artifact_permisssions_has_permission
     ):
         repository_artifact_permisssions_has_permission.return_value = False
-        
+
         res = self.client.get(
             reverse(
                 "api-v2-pulls-detail",
@@ -247,7 +247,7 @@ class PullViewsetTests(InternalAPITest):
                     "pullid": self.pulls[0].pullid,
                 },
             ),
-            HTTP_AUTHORIZATION=f"Bearer 73c8d301-2e0b-42c0-9ace-95eef6b68e86"
+            HTTP_AUTHORIZATION="Bearer 73c8d301-2e0b-42c0-9ace-95eef6b68e86",
         )
         assert res.status_code == 401
         assert res.data["detail"] == "Invalid token."
@@ -268,7 +268,7 @@ class PullViewsetTests(InternalAPITest):
                     "pullid": self.pulls[0].pullid,
                 },
             ),
-            HTTP_AUTHORIZATION=f"Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r"
+            HTTP_AUTHORIZATION="Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r",
         )
         assert res.status_code == 403
         assert (
@@ -291,7 +291,7 @@ class PullViewsetTests(InternalAPITest):
                     "pullid": self.pulls[0].pullid,
                 },
             ),
-            HTTP_AUTHORIZATION=f"Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r"
+            HTTP_AUTHORIZATION="Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r",
         )
         assert res.status_code == 200
         assert res.json() == {
@@ -304,4 +304,3 @@ class PullViewsetTests(InternalAPITest):
             "ci_passed": None,
             "author": None,
         }
-

--- a/api/public/v2/tests/test_api_pull_viewset.py
+++ b/api/public/v2/tests/test_api_pull_viewset.py
@@ -224,7 +224,6 @@ class PullViewsetTests(InternalAPITest):
                 },
             )
         )
-        print(res)
         assert res.status_code == 403
         assert (
             res.data["detail"] == "You do not have permission to perform this action."

--- a/api/public/v2/tests/test_api_pull_viewset.py
+++ b/api/public/v2/tests/test_api_pull_viewset.py
@@ -232,7 +232,7 @@ class PullViewsetTests(InternalAPITest):
 
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
-    def test_no_report_if_not_super_token_nor_user_token(
+    def test_no_pull_if_not_super_token_nor_user_token(
         self, repository_artifact_permisssions_has_permission
     ):
         repository_artifact_permisssions_has_permission.return_value = False

--- a/api/public/v2/tests/test_api_pull_viewset.py
+++ b/api/public/v2/tests/test_api_pull_viewset.py
@@ -208,9 +208,9 @@ class PullViewsetTests(InternalAPITest):
     def test_no_pull_if_unauthenticated_token_request(
         self,
         super_token_permissions_has_permission,
-        repository_artifact_permisssions_has_permission,
+        repository_artifact_permissions_has_permission,
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         super_token_permissions_has_permission.return_value = False
 
         res = self.client.get(
@@ -232,9 +232,9 @@ class PullViewsetTests(InternalAPITest):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_pull_if_not_super_token_nor_user_token(
-        self, repository_artifact_permisssions_has_permission
+        self, repository_artifact_permissions_has_permission
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
 
         res = self.client.get(
             reverse(
@@ -254,9 +254,9 @@ class PullViewsetTests(InternalAPITest):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_pull_if_super_token_but_no_GET_request(
-        self, repository_artifact_permisssions_has_permission
+        self, repository_artifact_permissions_has_permission
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         res = self.client.post(
             reverse(
                 "api-v2-pulls-detail",
@@ -275,11 +275,7 @@ class PullViewsetTests(InternalAPITest):
         )
 
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
-    @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
-    def test_pull_with_valid_super_token(
-        self, repository_artifact_permisssions_has_permission
-    ):
-        repository_artifact_permisssions_has_permission.return_value = False
+    def test_pull_with_valid_super_token(self):
         res = self.client.get(
             reverse(
                 "api-v2-pulls-detail",

--- a/api/public/v2/tests/test_report_viewset.py
+++ b/api/public/v2/tests/test_report_viewset.py
@@ -742,11 +742,11 @@ class ReportViewSetTestCase(TestCase):
     def test_no_report_if_unauthenticated_token_request(
         self,
         super_token_permissions_has_permission,
-        repository_artifact_permisssions_has_permission,
+        repository_artifact_permissions_has_permission,
         _,
     ):
         super_token_permissions_has_permission.return_value = False
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
 
         res = self._request_report()
         assert res.status_code == 403
@@ -757,9 +757,9 @@ class ReportViewSetTestCase(TestCase):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_report_if_not_super_token_nor_user_token(
-        self, repository_artifact_permisssions_has_permission, _
+        self, repository_artifact_permissions_has_permission, _
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         res = self._request_report("73c8d301-2e0b-42c0-9ace-95eef6b68e86")
         assert res.status_code == 401
         assert res.data["detail"] == "Invalid token."
@@ -767,9 +767,9 @@ class ReportViewSetTestCase(TestCase):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_report_if_super_token_but_no_GET_request(
-        self, repository_artifact_permisssions_has_permission, _
+        self, repository_artifact_permissions_has_permission, _
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         res = self._post_report("testaxs3o76rdcdpfzexuccx3uatui2nw73r")
         assert res.status_code == 403
         assert (

--- a/api/public/v2/tests/test_test_results_view.py
+++ b/api/public/v2/tests/test_test_results_view.py
@@ -1,10 +1,10 @@
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status
 
-from django.test import override_settings
 from codecov.tests.base_test import InternalAPITest
 from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import RepositoryFactory
@@ -173,7 +173,7 @@ class TestResultsViewsetTests(InternalAPITest):
         self, repository_artifact_permisssions_has_permission
     ):
         repository_artifact_permisssions_has_permission.return_value = False
-        
+
         res = self.client.get(
             reverse(
                 "api-v2-tests-results-detail",
@@ -184,7 +184,7 @@ class TestResultsViewsetTests(InternalAPITest):
                     "pk": self.test_instances[0].pk,
                 },
             ),
-            HTTP_AUTHORIZATION=f"Bearer 73c8d301-2e0b-42c0-9ace-95eef6b68e86"
+            HTTP_AUTHORIZATION="Bearer 73c8d301-2e0b-42c0-9ace-95eef6b68e86",
         )
         assert res.status_code == 401
         assert res.data["detail"] == "Invalid token."
@@ -205,7 +205,7 @@ class TestResultsViewsetTests(InternalAPITest):
                     "pk": self.test_instances[0].pk,
                 },
             ),
-            HTTP_AUTHORIZATION=f"Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r"
+            HTTP_AUTHORIZATION="Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r",
         )
         assert res.status_code == 403
         assert (
@@ -228,7 +228,7 @@ class TestResultsViewsetTests(InternalAPITest):
                     "pk": self.test_instances[0].pk,
                 },
             ),
-            HTTP_AUTHORIZATION=f"Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r"
+            HTTP_AUTHORIZATION="Bearer testaxs3o76rdcdpfzexuccx3uatui2nw73r",
         )
         assert res.status_code == 200
         assert res.json() == {

--- a/api/public/v2/tests/test_test_results_view.py
+++ b/api/public/v2/tests/test_test_results_view.py
@@ -147,9 +147,9 @@ class TestResultsViewsetTests(InternalAPITest):
     def test_no_test_result_if_unauthenticated_token_request(
         self,
         super_token_permissions_has_permission,
-        repository_artifact_permisssions_has_permission,
+        repository_artifact_permissions_has_permission,
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         super_token_permissions_has_permission.return_value = False
 
         url = reverse(
@@ -170,9 +170,9 @@ class TestResultsViewsetTests(InternalAPITest):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_result_if_not_super_token_nor_user_token(
-        self, repository_artifact_permisssions_has_permission
+        self, repository_artifact_permissions_has_permission
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
 
         res = self.client.get(
             reverse(
@@ -192,9 +192,9 @@ class TestResultsViewsetTests(InternalAPITest):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_result_if_super_token_but_no_GET_request(
-        self, repository_artifact_permisssions_has_permission
+        self, repository_artifact_permissions_has_permission
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         res = self.client.post(
             reverse(
                 "api-v2-tests-results-detail",
@@ -215,9 +215,9 @@ class TestResultsViewsetTests(InternalAPITest):
     @override_settings(SUPER_API_TOKEN="testaxs3o76rdcdpfzexuccx3uatui2nw73r")
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_result_with_valid_super_token(
-        self, repository_artifact_permisssions_has_permission
+        self, repository_artifact_permissions_has_permission
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
         res = self.client.get(
             reverse(
                 "api-v2-tests-results-detail",

--- a/api/public/v2/tests/test_totals_viewset.py
+++ b/api/public/v2/tests/test_totals_viewset.py
@@ -580,10 +580,10 @@ class TotalsViewSetTestCase(TestCase):
     @patch("api.shared.permissions.RepositoryArtifactPermissions.has_permission")
     def test_no_report_if_unauthenticated_token_request(
         self,
-        repository_artifact_permisssions_has_permission,
+        repository_artifact_permissions_has_permission,
         _,
     ):
-        repository_artifact_permisssions_has_permission.return_value = False
+        repository_artifact_permissions_has_permission.return_value = False
 
         res = self._request_report()
         assert res.status_code == 403


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

This change unblocks some short term workflows between Codecov and Sentry's Seer service. Seer will query Codecov's pulls endpoint for a given PR and use coverage information to generate tests. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
