### PR TITLE
fix: Resolve race condition when resolving measurements

### DIFF
--- a/timeseries/helpers.py
+++ b/timeseries/helpers.py
@@ -354,11 +354,12 @@ def repository_coverage_measurements_with_fallback(
     else:
         if settings.TIMESERIES_ENABLED and not dataset:
             # we need to backfill
-            dataset = Dataset.objects.create(
+            dataset, created = Dataset.objects.get_or_create(
                 name=MeasurementName.COVERAGE.value,
                 repository_id=repository.pk,
             )
-            trigger_backfill(dataset)
+            if created:
+                trigger_backfill(dataset)
 
         # we're still backfilling or timeseries is disabled
         return coverage_fallback_query(


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to fix these two Sentry issues:
https://codecov.sentry.io/issues/3984451805
https://codecov.sentry.io/issues/3984451718

where we're trying to resolve measurements on the repository object but there is a race condition that exists where calling create may result in a duplicate key value (race condition)

The fix was to change the create to a get_or_Create and add some conditional logic to only backfill if the function returns "true" for created

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/2525

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
