### PR TITLE
add percent changes to test results and flakes aggregates

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -1412,12 +1412,12 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             """testResultsAggregates { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
         assert res["testResultsAggregates"] == {
-            "totalRunTime": 580.0,
-            "slowestTestsRunTime": 54.0,
+            "totalRunTime": 570.0,
+            "slowestTestsRunTime": 29.0,
             "totalFails": 10,
             "totalSkips": 5,
-            "totalRunTimePercentChange": -62.76083467094703,
-            "slowestTestsRunTimePercentChange": -50.0,
+            "totalRunTimePercentChange": -63.10679611650486,
+            "slowestTestsRunTimePercentChange": -50.847457627118644,
             "totalFailsPercentChange": 100.0,
             "totalSkipsPercentChange": -50.0,
         }
@@ -1446,8 +1446,8 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             """testResultsAggregates { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
         assert res["testResultsAggregates"] == {
-            "totalRunTime": 580.0,
-            "slowestTestsRunTime": 54.0,
+            "totalRunTime": 570.0,
+            "slowestTestsRunTime": 29.0,
             "totalFails": 10,
             "totalSkips": 5,
             "totalRunTimePercentChange": None,

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -1464,11 +1464,36 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         test = TestFactory(repository=repo)
 
-        _ = FlakeFactory(repository=repo, test=test, start_date=datetime.datetime.now() - datetime.timedelta(days=1), end_date=None)
-        _ = FlakeFactory(repository=repo, test=test, start_date=datetime.datetime.now() - datetime.timedelta(days=90), end_date=None)
-        _ = FlakeFactory(repository=repo, test=test, start_date=datetime.datetime.now() - datetime.timedelta(days=70), end_date=datetime.datetime.now() - datetime.timedelta(days=30))
-        _ = FlakeFactory(repository=repo, test=test, start_date=datetime.datetime.now() - datetime.timedelta(days=80), end_date=datetime.datetime.now() - datetime.timedelta(days=59))
-        _ = FlakeFactory(repository=repo, test=test, start_date=datetime.datetime.now() - datetime.timedelta(days=70), end_date=datetime.datetime.now() - datetime.timedelta(days=61))
+        _ = FlakeFactory(
+            repository=repo,
+            test=test,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=1),
+            end_date=None,
+        )
+        _ = FlakeFactory(
+            repository=repo,
+            test=test,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=90),
+            end_date=None,
+        )
+        _ = FlakeFactory(
+            repository=repo,
+            test=test,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=70),
+            end_date=datetime.datetime.now() - datetime.timedelta(days=30),
+        )
+        _ = FlakeFactory(
+            repository=repo,
+            test=test,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=80),
+            end_date=datetime.datetime.now() - datetime.timedelta(days=59),
+        )
+        _ = FlakeFactory(
+            repository=repo,
+            test=test,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=70),
+            end_date=datetime.datetime.now() - datetime.timedelta(days=61),
+        )
 
         for i in range(0, 30):
             _ = DailyTestRollupFactory(
@@ -1515,7 +1540,12 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         )
 
         test = TestFactory(repository=repo)
-        _ = FlakeFactory(repository=repo, test=test, start_date=datetime.datetime.now() - datetime.timedelta(days=1), end_date=None)
+        _ = FlakeFactory(
+            repository=repo,
+            test=test,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=1),
+            end_date=None,
+        )
 
         for i in range(0, 30):
             _ = DailyTestRollupFactory(

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -1409,15 +1409,15 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             )
         res = self.fetch_repository(
             repo.name,
-            """testResultsAggregates { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
+            """testResultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
         assert res["testResultsAggregates"] == {
-            "totalRunTime": 570.0,
-            "slowestTestsRunTime": 29.0,
+            "totalDuration": 570.0,
+            "slowestTestsDuration": 29.0,
             "totalFails": 10,
             "totalSkips": 5,
-            "totalRunTimePercentChange": -63.10679611650486,
-            "slowestTestsRunTimePercentChange": -50.847457627118644,
+            "totalDurationPercentChange": -63.10679611650486,
+            "slowestTestsDurationPercentChange": -50.847457627118644,
             "totalFailsPercentChange": 100.0,
             "totalSkipsPercentChange": -50.0,
         }
@@ -1443,16 +1443,16 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         res = self.fetch_repository(
             repo.name,
-            """testResultsAggregates { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
+            """testResultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
 
         assert res["testResultsAggregates"] == {
-            "totalRunTime": 570.0,
-            "slowestTestsRunTime": 29.0,
+            "totalDuration": 570.0,
+            "slowestTestsDuration": 29.0,
             "totalFails": 10,
             "totalSkips": 5,
-            "totalRunTimePercentChange": None,
-            "slowestTestsRunTimePercentChange": None,
+            "totalDurationPercentChange": None,
+            "slowestTestsDurationPercentChange": None,
             "totalFailsPercentChange": None,
             "totalSkipsPercentChange": None,
         }

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -1409,9 +1409,9 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             )
         res = self.fetch_repository(
             repo.name,
-            """testResultsHeaders { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
+            """testResultsAggregates { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
-        assert res["testResultsHeaders"] == {
+        assert res["testResultsAggregates"] == {
             "totalRunTime": 580.0,
             "slowestTestsRunTime": 54.0,
             "totalFails": 10,
@@ -1443,9 +1443,9 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         res = self.fetch_repository(
             repo.name,
-            """testResultsHeaders { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
+            """testResultsAggregates { totalRunTime, slowestTestsRunTime, totalFails, totalSkips, totalRunTimePercentChange, slowestTestsRunTimePercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
-        assert res["testResultsHeaders"] == {
+        assert res["testResultsAggregates"] == {
             "totalRunTime": 580.0,
             "slowestTestsRunTime": 54.0,
             "totalFails": 10,

--- a/graphql_api/tests/test_test_results_headers.py
+++ b/graphql_api/tests/test_test_results_headers.py
@@ -37,7 +37,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testResultsAggregates {
-                                totalRunTime
+                                totalDuration
                             }
                         }
                     }
@@ -49,7 +49,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testResultsAggregates"]["totalRunTime"]
+            result["owner"]["repository"]["testResultsAggregates"]["totalDuration"]
             == 435.0
         )
 
@@ -60,7 +60,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testResultsAggregates {
-                                slowestTestsRunTime
+                                slowestTestsDuration
                             }
                         }
                     }
@@ -73,7 +73,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
         assert "errors" not in result
         assert (
             result["owner"]["repository"]["testResultsAggregates"][
-                "slowestTestsRunTime"
+                "slowestTestsDuration"
             ]
             == 29.0
         )

--- a/graphql_api/types/flake_aggregates/flake_aggregates.graphql
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.graphql
@@ -1,6 +1,6 @@
 type FlakeAggregates {
   flakeCount: Int!
-  flakeRate: Float!
   flakeCountPercentChange: Float
+  flakeRate: Float!
   flakeRatePercentChange: Float
 }

--- a/graphql_api/types/flake_aggregates/flake_aggregates.graphql
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.graphql
@@ -1,4 +1,6 @@
 type FlakeAggregates {
   flakeCount: Int!
   flakeRate: Float!
+  flakeCountPercentChange: Float
+  flakeRatePercentChange: Float
 }

--- a/graphql_api/types/flake_aggregates/flake_aggregates.py
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.py
@@ -19,3 +19,13 @@ def resolve_flake_count(obj: FlakeAggregate, _: GraphQLResolveInfo) -> int:
 @flake_aggregates_bindable.field("flakeRate")
 def resolve_flake_rate(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float:
     return obj["flake_rate"]
+
+
+@flake_aggregates_bindable.field("flakeCountPercentChange")
+def resolve_flake_count_percent_change(obj, _) -> float | None:
+    return obj.get("flake_count_percent_change")
+
+
+@flake_aggregates_bindable.field("flakeRatePercentChange")
+def resolve_flake_rate_percent_change(obj, _) -> float | None:
+    return obj.get("flake_rate_percent_change")

--- a/graphql_api/types/flake_aggregates/flake_aggregates.py
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.py
@@ -8,24 +8,24 @@ flake_aggregates_bindable = ObjectType("FlakeAggregates")
 
 class FlakeAggregate(TypedDict):
     flake_count: int
+    flake_count_percent_change: float | None
     flake_rate: float
+    flake_rate_percent_change: float | None
 
 
 @flake_aggregates_bindable.field("flakeCount")
 def resolve_flake_count(obj: FlakeAggregate, _: GraphQLResolveInfo) -> int:
     return obj["flake_count"]
 
+@flake_aggregates_bindable.field("flakeCountPercentChange")
+def resolve_flake_count_percent_change(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float | None:
+    return obj.get("flake_count_percent_change")
+
 
 @flake_aggregates_bindable.field("flakeRate")
 def resolve_flake_rate(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float:
     return obj["flake_rate"]
 
-
-@flake_aggregates_bindable.field("flakeCountPercentChange")
-def resolve_flake_count_percent_change(obj, _) -> float | None:
-    return obj.get("flake_count_percent_change")
-
-
 @flake_aggregates_bindable.field("flakeRatePercentChange")
-def resolve_flake_rate_percent_change(obj, _) -> float | None:
+def resolve_flake_rate_percent_change(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float | None:
     return obj.get("flake_rate_percent_change")

--- a/graphql_api/types/flake_aggregates/flake_aggregates.py
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.py
@@ -17,8 +17,11 @@ class FlakeAggregate(TypedDict):
 def resolve_flake_count(obj: FlakeAggregate, _: GraphQLResolveInfo) -> int:
     return obj["flake_count"]
 
+
 @flake_aggregates_bindable.field("flakeCountPercentChange")
-def resolve_flake_count_percent_change(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float | None:
+def resolve_flake_count_percent_change(
+    obj: FlakeAggregate, _: GraphQLResolveInfo
+) -> float | None:
     return obj.get("flake_count_percent_change")
 
 
@@ -26,6 +29,9 @@ def resolve_flake_count_percent_change(obj: FlakeAggregate, _: GraphQLResolveInf
 def resolve_flake_rate(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float:
     return obj["flake_rate"]
 
+
 @flake_aggregates_bindable.field("flakeRatePercentChange")
-def resolve_flake_rate_percent_change(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float | None:
+def resolve_flake_rate_percent_change(
+    obj: FlakeAggregate, _: GraphQLResolveInfo
+) -> float | None:
     return obj.get("flake_rate_percent_change")

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -586,16 +586,12 @@ async def resolve_test_results_aggregates(
     repository: Repository,
     info: GraphQLResolveInfo,
 ):
-    queryset = await sync_to_async(generate_test_results_aggregates)(
+    return await sync_to_async(generate_test_results_aggregates)(
         repoid=repository.repoid
     )
-
-    return queryset
 
 
 @repository_bindable.field("flakeAggregates")
 @convert_kwargs_to_snake_case
 async def resolve_flake_aggregates(repository: Repository, info: GraphQLResolveInfo):
-    queryset = await sync_to_async(generate_flake_aggregates)(repoid=repository.repoid)
-
-    return queryset
+    return await sync_to_async(generate_flake_aggregates)(repoid=repository.repoid)

--- a/graphql_api/types/test_results/test_results.graphql
+++ b/graphql_api/types/test_results/test_results.graphql
@@ -1,9 +1,9 @@
 type TestResult {
   updatedAt: DateTime!
   name: String!
-  commitsFailed: Int
-  failureRate: Float
-  flakeRate: Float
-  avgDuration: Float
-  lastDuration: Float
+  commitsFailed: Int!
+  failureRate: Float!
+  flakeRate: Float!
+  avgDuration: Float!
+  lastDuration: Float!
 }

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -8,10 +8,11 @@ from graphql import GraphQLResolveInfo
 class TestDict(TypedDict):
     name: str
     updated_at: datetime
-    commits_where_fail: int | None
-    failure_rate: float | None
-    avg_duration: float | None
-    last_duration: float | None
+    commits_where_fail: int
+    failure_rate: float
+    avg_duration: float
+    last_duration: float
+    flake_rate: float
 
 
 test_result_bindable = ObjectType("TestResult")
@@ -28,25 +29,25 @@ def resolve_updated_at(test: TestDict, _: GraphQLResolveInfo) -> datetime:
 
 
 @test_result_bindable.field("commitsFailed")
-def resolve_commits_failed(test: TestDict, _: GraphQLResolveInfo) -> int | None:
+def resolve_commits_failed(test: TestDict, _: GraphQLResolveInfo) -> int:
     return test["commits_where_fail"]
 
 
 @test_result_bindable.field("failureRate")
-def resolve_failure_rate(test: TestDict, _: GraphQLResolveInfo) -> float | None:
+def resolve_failure_rate(test: TestDict, _: GraphQLResolveInfo) -> float:
     return test["failure_rate"]
 
 
 @test_result_bindable.field("flakeRate")
-def resolve_flake_rate(test, info) -> float | None:
+def resolve_flake_rate(test: TestDict, _: GraphQLResolveInfo) -> float:
     return test["flake_rate"]
 
 
 @test_result_bindable.field("avgDuration")
-def resolve_avg_duration(test: TestDict, _: GraphQLResolveInfo) -> float | None:
+def resolve_avg_duration(test: TestDict, _: GraphQLResolveInfo) -> float:
     return test["avg_duration"]
 
 
 @test_result_bindable.field("lastDuration")
-def resolve_last_duration(test: TestDict, _: GraphQLResolveInfo) -> float | None:
+def resolve_last_duration(test: TestDict, _: GraphQLResolveInfo) -> float:
     return test["last_duration"]

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
@@ -1,10 +1,10 @@
 type TestResultsAggregates {
   totalDuration: Float!
-  slowestTestsDuration: Float!
-  totalFails: Int!
-  totalSkips: Int!
   totalDurationPercentChange: Float
+  slowestTestsDuration: Float!
   slowestTestsDurationPercentChange: Float
+  totalFails: Int!
   totalFailsPercentChange: Float
+  totalSkips: Int!
   totalSkipsPercentChange: Float
 }

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
@@ -3,4 +3,8 @@ type TestResultsAggregates {
   slowestTestsRunTime: Float!
   totalFails: Int!
   totalSkips: Int!
+  totalRunTimePercentChange: Float
+  slowestTestsRunTimePercentChange: Float
+  totalFailsPercentChange: Float
+  totalSkipsPercentChange: Float
 }

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.graphql
@@ -1,10 +1,10 @@
 type TestResultsAggregates {
-  totalRunTime: Float!
-  slowestTestsRunTime: Float!
+  totalDuration: Float!
+  slowestTestsDuration: Float!
   totalFails: Int!
   totalSkips: Int!
-  totalRunTimePercentChange: Float
-  slowestTestsRunTimePercentChange: Float
+  totalDurationPercentChange: Float
+  slowestTestsDurationPercentChange: Float
   totalFailsPercentChange: Float
   totalSkipsPercentChange: Float
 }

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -7,19 +7,19 @@ test_results_aggregates_bindable = ObjectType("TestResultsAggregates")
 
 
 class TestResultsAggregates(TypedDict):
-    total_run_time: float
+    total_duration: float
     slowest_tests_duration: float
     fails: int
     skips: int
 
 
-@test_results_aggregates_bindable.field("totalRunTime")
-def resolve_total_run_time(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float:
-    return obj["total_run_time"]
+@test_results_aggregates_bindable.field("totalDuration")
+def resolve_total_duration(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float:
+    return obj["total_duration"]
 
 
-@test_results_aggregates_bindable.field("slowestTestsRunTime")
-def resolve_slowest_tests_run_time(
+@test_results_aggregates_bindable.field("slowestTestsDuration")
+def resolve_slowest_tests_duration(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float:
     return obj["slowest_tests_duration"]
@@ -35,13 +35,13 @@ def resolve_total_skips(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> in
     return obj["skips"]
 
 
-@test_results_aggregates_bindable.field("totalRunTimePercentChange")
-def resolve_run_time_percent_change(obj, _) -> float | None:
-    return obj.get("total_run_time_percent_change")
+@test_results_aggregates_bindable.field("totalDurationPercentChange")
+def resolve_duration_percent_change(obj, _) -> float | None:
+    return obj.get("total_duration_percent_change")
 
 
-@test_results_aggregates_bindable.field("slowestTestsRunTimePercentChange")
-def resolve_slowest_tests_run_time_percent_change(obj, _) -> float | None:
+@test_results_aggregates_bindable.field("slowestTestsDurationPercentChange")
+def resolve_slowest_tests_duration_percent_change(obj, _) -> float | None:
     return obj.get("slowest_tests_duration_percent_change")
 
 

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -8,14 +8,22 @@ test_results_aggregates_bindable = ObjectType("TestResultsAggregates")
 
 class TestResultsAggregates(TypedDict):
     total_duration: float
+    total_duration_percent_change: float | None
     slowest_tests_duration: float
+    slowest_tests_duration_percent_change: float | None
     fails: int
+    fails_percent_change: float | None
     skips: int
+    skips_percent_change: float | None
 
 
 @test_results_aggregates_bindable.field("totalDuration")
 def resolve_total_duration(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float:
     return obj["total_duration"]
+
+@test_results_aggregates_bindable.field("totalDurationPercentChange")
+def resolve_total_duration_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+    return obj.get("total_duration_percent_change")
 
 
 @test_results_aggregates_bindable.field("slowestTestsDuration")
@@ -24,32 +32,24 @@ def resolve_slowest_tests_duration(
 ) -> float:
     return obj["slowest_tests_duration"]
 
+@test_results_aggregates_bindable.field("slowestTestsDurationPercentChange")
+def resolve_slowest_tests_duration_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+    return obj.get("slowest_tests_duration_percent_change")
+
 
 @test_results_aggregates_bindable.field("totalFails")
 def resolve_total_fails(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
     return obj["fails"]
+
+@test_results_aggregates_bindable.field("totalFailsPercentChange")
+def resolve_total_fails_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+    return obj.get("fails_percent_change")
 
 
 @test_results_aggregates_bindable.field("totalSkips")
 def resolve_total_skips(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
     return obj["skips"]
 
-
-@test_results_aggregates_bindable.field("totalDurationPercentChange")
-def resolve_duration_percent_change(obj, _) -> float | None:
-    return obj.get("total_duration_percent_change")
-
-
-@test_results_aggregates_bindable.field("slowestTestsDurationPercentChange")
-def resolve_slowest_tests_duration_percent_change(obj, _) -> float | None:
-    return obj.get("slowest_tests_duration_percent_change")
-
-
-@test_results_aggregates_bindable.field("totalFailsPercentChange")
-def resolve_total_fails_percent_change(obj, _) -> float | None:
-    return obj.get("fails_percent_change")
-
-
 @test_results_aggregates_bindable.field("totalSkipsPercentChange")
-def resolve_total_skips_percent_change(obj, _) -> float | None:
+def resolve_total_skips_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
     return obj.get("skips_percent_change")

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -21,8 +21,11 @@ class TestResultsAggregates(TypedDict):
 def resolve_total_duration(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float:
     return obj["total_duration"]
 
+
 @test_results_aggregates_bindable.field("totalDurationPercentChange")
-def resolve_total_duration_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+def resolve_total_duration_percent_change(
+    obj: TestResultsAggregates, _: GraphQLResolveInfo
+) -> float | None:
     return obj.get("total_duration_percent_change")
 
 
@@ -32,8 +35,11 @@ def resolve_slowest_tests_duration(
 ) -> float:
     return obj["slowest_tests_duration"]
 
+
 @test_results_aggregates_bindable.field("slowestTestsDurationPercentChange")
-def resolve_slowest_tests_duration_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+def resolve_slowest_tests_duration_percent_change(
+    obj: TestResultsAggregates, _: GraphQLResolveInfo
+) -> float | None:
     return obj.get("slowest_tests_duration_percent_change")
 
 
@@ -41,8 +47,11 @@ def resolve_slowest_tests_duration_percent_change(obj: TestResultsAggregates, _:
 def resolve_total_fails(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
     return obj["fails"]
 
+
 @test_results_aggregates_bindable.field("totalFailsPercentChange")
-def resolve_total_fails_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+def resolve_total_fails_percent_change(
+    obj: TestResultsAggregates, _: GraphQLResolveInfo
+) -> float | None:
     return obj.get("fails_percent_change")
 
 
@@ -50,6 +59,9 @@ def resolve_total_fails_percent_change(obj: TestResultsAggregates, _: GraphQLRes
 def resolve_total_skips(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
     return obj["skips"]
 
+
 @test_results_aggregates_bindable.field("totalSkipsPercentChange")
-def resolve_total_skips_percent_change(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float | None:
+def resolve_total_skips_percent_change(
+    obj: TestResultsAggregates, _: GraphQLResolveInfo
+) -> float | None:
     return obj.get("skips_percent_change")

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -33,3 +33,23 @@ def resolve_total_fails(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> in
 @test_results_aggregates_bindable.field("totalSkips")
 def resolve_total_skips(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
     return obj["skips"]
+
+
+@test_results_aggregates_bindable.field("totalRunTimePercentChange")
+def resolve_run_time_percent_change(obj, _) -> float | None:
+    return obj.get("total_run_time_percent_change")
+
+
+@test_results_aggregates_bindable.field("slowestTestsRunTimePercentChange")
+def resolve_slowest_tests_run_time_percent_change(obj, _) -> float | None:
+    return obj.get("slowest_tests_duration_percent_change")
+
+
+@test_results_aggregates_bindable.field("totalFailsPercentChange")
+def resolve_total_fails_percent_change(obj, _) -> float | None:
+    return obj.get("fails_percent_change")
+
+
+@test_results_aggregates_bindable.field("totalSkipsPercentChange")
+def resolve_total_skips_percent_change(obj, _) -> float | None:
+    return obj.get("skips_percent_change")

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -173,11 +173,11 @@ def generate_test_results(
 
 
 def percent_diff(
-    numerator: int | float, denominator: int | float
+    current_value: int | float, past_value: int | float
 ) -> int | float | None:
-    if denominator == 0:
+    if past_value == 0:
         return None
-    return (numerator - denominator) / denominator * 100
+    return (current_value - past_value) / past_value * 100
 
 
 def get_percent_change(

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -74,7 +74,7 @@ def generate_test_results(
     :returns: queryset object containing list of dictionaries of results
 
     """
-    since = (dt.datetime.now(dt.UTC) - history)
+    since = dt.datetime.now(dt.UTC) - history
 
     totals = DailyTestRollup.objects.filter(repoid=repoid, date__gt=since)
 
@@ -172,7 +172,9 @@ def generate_test_results(
     return aggregation_of_test_results
 
 
-def percent_diff(numerator: int | float, denominator: int | float) -> int | float | None:
+def percent_diff(
+    numerator: int | float, denominator: int | float
+) -> int | float | None:
     if denominator == 0:
         return None
     return (numerator - denominator) / denominator * 100
@@ -186,7 +188,9 @@ def get_percent_change(
     percent_change_fields = {}
 
     percent_change_fields = {
-        f"{field}_percent_change": percent_diff(curr_numbers[field], past_numbers[field])
+        f"{field}_percent_change": percent_diff(
+            curr_numbers[field], past_numbers[field]
+        )
         for field in fields
         if past_numbers.get(field)
     }
@@ -243,7 +247,7 @@ def generate_test_results_aggregates(
     repoid: int, history: dt.timedelta = dt.timedelta(days=30)
 ) -> dict[str, float | int] | None:
     repo = Repository.objects.get(repoid=repoid)
-    since = (dt.datetime.now(dt.UTC) - history)
+    since = dt.datetime.now(dt.UTC) - history
 
     curr_numbers = get_test_results_aggregate_numbers(repo, since)
 
@@ -269,14 +273,18 @@ def get_flake_aggregate_numbers(
     else:
         flakes = Flake.objects.filter(
             Q(repository_id=repo.repoid)
-            & ((Q(end_date__isnull=True)) | (Q(end_date__date__lte=until.date()) & Q(end_date__date__gt=since.date())))
+            & (
+                (Q(end_date__isnull=True))
+                | (
+                    Q(end_date__date__lte=until.date())
+                    & Q(end_date__date__gt=since.date())
+                )
+            )
         )
 
     flake_count = flakes.count()
 
-
     test_ids = [flake.test_id for flake in flakes]
-
 
     test_rollups = DailyTestRollup.objects.filter(
         repoid=repo.repoid,
@@ -286,8 +294,6 @@ def get_flake_aggregate_numbers(
     )
     if until:
         test_rollups = test_rollups.filter(date__lte=until.date())
-
-
 
     if len(test_rollups) == 0:
         return {"flake_count": 0, "flake_rate": 0}
@@ -310,7 +316,7 @@ def generate_flake_aggregates(
     repoid: int, history: dt.timedelta = dt.timedelta(days=30)
 ) -> dict[str, int | float]:
     repo = Repository.objects.get(repoid=repoid)
-    since = (dt.datetime.today() - history)
+    since = dt.datetime.today() - history
 
     curr_numbers = get_flake_aggregate_numbers(repo, since)
 

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -277,9 +277,7 @@ def get_flake_aggregate_numbers(
             & (Q(end_date__date__lte=until.date()) & Q(end_date__date__gt=since.date()))
         )
 
-    print(until, since)
     flake_count = flakes.count()
-    print(flakes.count(), len(flakes))
 
     test_ids = [flake.test_id for flake in flakes]
 
@@ -325,8 +323,6 @@ def generate_flake_aggregates(
     )
 
     past_numbers = get_flake_aggregate_numbers(repo, double_time_ago, time_ago)
-
-    print(past_numbers)
 
     return curr_numbers | helper(
         ["flake_count", "flake_rate"],


### PR DESCRIPTION
This adds PercentChange fields to both the TestResultsAggregates
and the FlakeAggregates. These work by getting the aggregates
for the previous historical period and comparing them with the
ones for the current historical period and getting a percentage difference.