### PR TITLE
fix: Allow multiple owners per subscription in relevant stripe webhook handlers

### DIFF
--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -491,10 +491,11 @@ class StripeWebhookHandlerTests(APITestCase):
             invoice_settings={"default_payment_method": "pm_1LhiRsGlVGuVgOrkQguJXdeV"},
         )
 
+    @patch("logging.Logger.info")
     @patch("services.billing.stripe.PaymentMethod.attach")
     @patch("services.billing.stripe.Customer.modify")
     def test_customer_subscription_updated_does_not_change_subscription_if_there_is_a_schedule(
-        self, c_mock, pm_mock
+        self, c_mock, pm_mock, log_info_mock
     ):
         self.owner.plan = "users-pr-inappy"
         self.owner.plan_user_count = 10
@@ -508,7 +509,7 @@ class StripeWebhookHandlerTests(APITestCase):
                     "object": {
                         "id": self.owner.stripe_subscription_id,
                         "customer": self.owner.stripe_customer_id,
-                        "plan": {"id": "?"},
+                        "plan": {"id": "plan_H6P16wij3lUuxg"},
                         "metadata": {"obo_organization": self.owner.ownerid},
                         "quantity": 20,
                         "status": "active",
@@ -529,6 +530,11 @@ class StripeWebhookHandlerTests(APITestCase):
         c_mock.assert_called_once_with(
             self.owner.stripe_customer_id,
             invoice_settings={"default_payment_method": "pm_1LhiRsGlVGuVgOrkQguJXdeV"},
+        )
+
+        log_info_mock.assert_called_once_with(
+            "Stripe webhook event received",
+            extra={"stripe_webhook_event": "customer.subscription.updated"},
         )
 
     @patch("services.billing.stripe.PaymentMethod.attach")

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -270,6 +270,9 @@ class StripeWebhookHandlerTests(APITestCase):
         RepositoryFactory(author=self.other_owner, activated=True, active=True)
         RepositoryFactory(author=self.other_owner, activated=True, active=True)
 
+        self.owner.refresh_from_db()
+        self.other_owner.refresh_from_db()
+
         assert (
             self.owner.repository_set.filter(activated=True, active=True).count() == 3
         )
@@ -797,7 +800,7 @@ class StripeWebhookHandlerTests(APITestCase):
         )
 
         log_error_mock.assert_called_with(
-            "Subscription update requested with invalid plan",
+            "Subscription update requested with for plan attached to no owners",
             extra={
                 "stripe_subscription_id": "sub_notexist",
                 "stripe_customer_id": "cus_notexist",

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -270,9 +270,6 @@ class StripeWebhookHandlerTests(APITestCase):
         RepositoryFactory(author=self.other_owner, activated=True, active=True)
         RepositoryFactory(author=self.other_owner, activated=True, active=True)
 
-        self.owner.refresh_from_db()
-        self.other_owner.refresh_from_db()
-
         assert (
             self.owner.repository_set.filter(activated=True, active=True).count() == 3
         )
@@ -293,6 +290,9 @@ class StripeWebhookHandlerTests(APITestCase):
                 },
             }
         )
+
+        self.owner.refresh_from_db()
+        self.other_owner.refresh_from_db()
 
         assert (
             self.owner.repository_set.filter(activated=False, active=False).count() == 3

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -47,13 +47,12 @@ class StripeWebhookHandlerTests(APITestCase):
         )
 
     # Creates a second owner that shares billing details with self.owner.
-    # This is used to test the case where owners are manually set to share a 
+    # This is used to test the case where owners are manually set to share a
     # subscription in Stripe.
     def add_second_owner(self):
         self.other_owner = OwnerFactory(
             stripe_customer_id="cus_123", stripe_subscription_id="sub_123"
         )
-
 
     def _send_event(self, payload, errorSig=None):
         timestamp = time.time_ns()
@@ -275,7 +274,8 @@ class StripeWebhookHandlerTests(APITestCase):
             self.owner.repository_set.filter(activated=True, active=True).count() == 3
         )
         assert (
-            self.other_owner.repository_set.filter(activated=True, active=True).count() == 3
+            self.other_owner.repository_set.filter(activated=True, active=True).count()
+            == 3
         )
 
         self._send_event(
@@ -295,7 +295,10 @@ class StripeWebhookHandlerTests(APITestCase):
             self.owner.repository_set.filter(activated=False, active=False).count() == 3
         )
         assert (
-            self.other_owner.repository_set.filter(activated=False, active=False).count() == 3
+            self.other_owner.repository_set.filter(
+                activated=False, active=False
+            ).count()
+            == 3
         )
 
     @patch("logging.Logger.info")
@@ -668,7 +671,8 @@ class StripeWebhookHandlerTests(APITestCase):
         assert self.other_owner.plan_auto_activate == False
         assert self.other_owner.stripe_subscription_id is None
         assert (
-            self.other_owner.repository_set.filter(active=True, activated=True).count() == 0
+            self.other_owner.repository_set.filter(active=True, activated=True).count()
+            == 0
         )
         pm_mock.assert_called_once_with(
             "pm_1LhiRsGlVGuVgOrkQguJXdeV", customer=self.owner.stripe_customer_id
@@ -840,7 +844,10 @@ class StripeWebhookHandlerTests(APITestCase):
         self.other_owner.refresh_from_db()
         assert self.owner.plan == settings.STRIPE_PLAN_VALS[self.new_params["new_plan"]]
         assert self.owner.plan_user_count == self.new_params["new_quantity"]
-        assert self.other_owner.plan == settings.STRIPE_PLAN_VALS[self.new_params["new_plan"]]
+        assert (
+            self.other_owner.plan
+            == settings.STRIPE_PLAN_VALS[self.new_params["new_plan"]]
+        )
         assert self.other_owner.plan_user_count == self.new_params["new_quantity"]
 
     @patch("services.billing.stripe.Subscription.retrieve")

--- a/billing/views.py
+++ b/billing/views.py
@@ -38,12 +38,12 @@ class StripeWebhookHandler(APIView):
                 stripe_subscription_id=invoice.subscription,
             ),
         )
-        updated: QuerySet[Owner] = Owner.objects.filter(
+        updated: int = Owner.objects.filter(
             stripe_customer_id=invoice.customer,
             stripe_subscription_id=invoice.subscription,
         ).update(delinquent=False)
 
-        self._log_updated(updated.count())
+        self._log_updated(updated)
 
     def invoice_payment_failed(self, invoice: stripe.Invoice) -> None:
         log.info(
@@ -53,11 +53,11 @@ class StripeWebhookHandler(APIView):
                 stripe_subscription_id=invoice.subscription,
             ),
         )
-        updated: QuerySet[Owner] = Owner.objects.filter(
+        updated: int = Owner.objects.filter(
             stripe_customer_id=invoice.customer,
             stripe_subscription_id=invoice.subscription,
         ).update(delinquent=True)
-        self._log_updated(updated.count())
+        self._log_updated(updated)
 
     def customer_subscription_deleted(self, subscription: stripe.Subscription) -> None:
         log.info(

--- a/billing/views.py
+++ b/billing/views.py
@@ -133,7 +133,6 @@ class StripeWebhookHandler(APIView):
         self, schedule: stripe.SubscriptionSchedule
     ) -> None:
         subscription = stripe.Subscription.retrieve(schedule["released_subscription"])
-        print(schedule)
         owners: QuerySet[Owner] = Owner.objects.filter(
             stripe_subscription_id=subscription.id,
             stripe_customer_id=subscription.customer,

--- a/billing/views.py
+++ b/billing/views.py
@@ -31,8 +31,6 @@ class StripeWebhookHandler(APIView):
                 f"Successfully updated info for {len(updated)} owner(s)",
                 extra=dict(owners=[owner.ownerid for owner in updated]),
             )
-        else:
-            log.warning("Could not find owner associated with customer")
 
     def invoice_payment_succeeded(self, invoice: stripe.Invoice) -> None:
         log.info(

--- a/billing/views.py
+++ b/billing/views.py
@@ -1,8 +1,8 @@
 import logging
 
-from django.db.models import QuerySet
 import stripe
 from django.conf import settings
+from django.db.models import QuerySet
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -128,12 +128,14 @@ class StripeWebhookHandler(APIView):
                 ),
             )
 
-    def subscription_schedule_released(self, schedule: stripe.SubscriptionSchedule) -> None:
+    def subscription_schedule_released(
+        self, schedule: stripe.SubscriptionSchedule
+    ) -> None:
         subscription = stripe.Subscription.retrieve(schedule["released_subscription"])
         print(schedule)
         owners: QuerySet[Owner] = Owner.objects.filter(
             stripe_subscription_id=subscription.id,
-            stripe_customer_id=subscription.customer
+            stripe_customer_id=subscription.customer,
         )
         if not owners.exists():
             log.error(
@@ -165,7 +167,6 @@ class StripeWebhookHandler(APIView):
                 requesting_user_id=requesting_user_id,
             ),
         )
-
 
     def customer_created(self, customer: stripe.Customer) -> None:
         # Based on what stripe doesn't gives us (an ownerid!)

--- a/billing/views.py
+++ b/billing/views.py
@@ -86,7 +86,7 @@ class StripeWebhookHandler(APIView):
             return
 
         for owner in owners:
-            plan_service = PlanService(owner)
+            plan_service = PlanService(current_org=owner)
             plan_service.set_default_plan_data()
             owner.repository_set.update(active=False, activated=False)
 
@@ -155,7 +155,7 @@ class StripeWebhookHandler(APIView):
         sub_item_plan_id = subscription.plan.id
         plan_name = settings.STRIPE_PLAN_VALS[sub_item_plan_id]
         for owner in owners:
-            plan_service = PlanService(owner)
+            plan_service = PlanService(current_org=owner)
             plan_service.update_plan(name=plan_name, user_count=subscription.quantity)
 
         requesting_user_id = subscription.metadata.get("obo")
@@ -298,7 +298,7 @@ class StripeWebhookHandler(APIView):
 
         owner_ids = []
         for owner in owners:
-            plan_service = PlanService(owner)
+            plan_service = PlanService(current_org=owner)
             if incomplete_expired:
                 plan_service.set_default_plan_data()
                 owner.repository_set.update(active=False, activated=False)

--- a/billing/views.py
+++ b/billing/views.py
@@ -258,12 +258,12 @@ class StripeWebhookHandler(APIView):
             # payment failed, raise this to user by setting as delinquent
             owners.update(delinquent=True)
             log.info(
-                f"Stripe subscription upgrade failed",
+                "Stripe subscription upgrade failed",
                 extra=dict(
                     pending_update=indication_of_payment_failure,
                     stripe_subscription_id=subscription.id,
                     stripe_customer_id=subscription.customer,
-                    owners=[owner.ownerid for owner in owners]
+                    owners=[owner.ownerid for owner in owners],
                 ),
             )
             return

--- a/billing/views.py
+++ b/billing/views.py
@@ -1,9 +1,9 @@
 import logging
 
-from django.http import HttpRequest
 import stripe
 from django.conf import settings
 from django.db.models import QuerySet
+from django.http import HttpRequest
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response

--- a/billing/views.py
+++ b/billing/views.py
@@ -256,11 +256,15 @@ class StripeWebhookHandler(APIView):
         indication_of_payment_failure = getattr(subscription, "pending_update", None)
         if indication_of_payment_failure:
             # payment failed, raise this to user by setting as delinquent
-            owner.delinquent = True
-            owner.save()
+            owners.update(delinquent=True)
             log.info(
-                f"Stripe subscription upgrade failed for owner {owner.ownerid}",
-                extra=dict(pending_update=indication_of_payment_failure),
+                f"Stripe subscription upgrade failed",
+                extra=dict(
+                    pending_update=indication_of_payment_failure,
+                    stripe_subscription_id=subscription.id,
+                    stripe_customer_id=subscription.customer,
+                    owners=[owner.ownerid for owner in owners]
+                ),
             )
             return
 


### PR DESCRIPTION
This PR updates the Stripe webhook handlers to accept requests for subscriptions shared by multiple owners.

It seems previously we baked in the expectation that this could not occur, but it turns out there are cases where this is a valid state. Specifically, this was the old way we handled users with multiple orgs billed jointly. With the new Account model, we can handle this case for Enterprise cloud users, but there still exists non-enterprise cloud users who have joint billing setups which cannot be migrated to Account billing as they are not on enterprise cloud plans. Support has a spreadsheet containing some of these customers, but it seems there are more than listed there. 

Note that we do not need to handle this case for customer_subscription_created as that can only occur during the normal billing flow, where multiple owners are not possible.

Fixes https://codecov.sentry.io/issues/4282794340
Fixes https://codecov.sentry.io/issues/2972074583
Closes https://github.com/codecov/engineering-team/issues/2200
