### PR TITLE
feat: add filtering for flags and testsuites

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -1072,7 +1072,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_repository(
             repo.name,
-            """testResults(filters: { testsuites: ["hello"] }) { edges { node { name } } }""",
+            """testResults(filters: { test_suites: ["hello"] }) { edges { node { name } } }""",
         )
         assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
 

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -1030,7 +1030,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
         repo_flag = RepositoryFlagFactory(repository=repo, flag_name="hello_world")
 
-        bridge = TestFlagBridgeFactory(flag=repo_flag, test=test)
+        _ = TestFlagBridgeFactory(flag=repo_flag, test=test)
         _ = DailyTestRollupFactory(
             test=test,
             created_at=datetime.datetime.now(),

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -12,7 +12,12 @@ from core.tests.factories import (
     RepositoryFactory,
     RepositoryTokenFactory,
 )
-from reports.tests.factories import DailyTestRollupFactory, TestFactory
+from reports.tests.factories import (
+    DailyTestRollupFactory,
+    RepositoryFlagFactory,
+    TestFactory,
+    TestFlagBridgeFactory,
+)
 from services.profiling import CriticalFile
 
 from .helper import GraphQLTestHelper
@@ -1017,6 +1022,59 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             """testResults(filters: { parameter: SLOWEST_TESTS }) { edges { node { name } } }""",
         )
         assert res["testResults"] == {"edges": [{"node": {"name": test2.name}}]}
+
+    def test_flags_filter_on_test_results(self) -> None:
+        repo = RepositoryFactory(author=self.owner, active=True, private=True)
+        test = TestFactory(repository=repo)
+        test2 = TestFactory(repository=repo)
+
+        repo_flag = RepositoryFlagFactory(repository=repo, flag_name="hello_world")
+
+        bridge = TestFlagBridgeFactory(flag=repo_flag, test=test)
+        _ = DailyTestRollupFactory(
+            test=test,
+            created_at=datetime.datetime.now(),
+            repoid=repo.repoid,
+            branch="main",
+            avg_duration_seconds=0.1,
+        )
+        _ = DailyTestRollupFactory(
+            test=test2,
+            created_at=datetime.datetime.now(),
+            repoid=repo.repoid,
+            branch="main",
+            avg_duration_seconds=20.0,
+        )
+        res = self.fetch_repository(
+            repo.name,
+            """testResults(filters: { flags: ["hello_world"] }) { edges { node { name } } }""",
+        )
+        assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
+
+    def test_testsuites_filter_on_test_results(self) -> None:
+        repo = RepositoryFactory(author=self.owner, active=True, private=True)
+        test = TestFactory(repository=repo, testsuite="hello")
+        test2 = TestFactory(repository=repo, testsuite="world")
+
+        _ = DailyTestRollupFactory(
+            test=test,
+            created_at=datetime.datetime.now(),
+            repoid=repo.repoid,
+            branch="main",
+            avg_duration_seconds=0.1,
+        )
+        _ = DailyTestRollupFactory(
+            test=test2,
+            created_at=datetime.datetime.now(),
+            repoid=repo.repoid,
+            branch="main",
+            avg_duration_seconds=20.0,
+        )
+        res = self.fetch_repository(
+            repo.name,
+            """testResults(filters: { testsuites: ["hello"] }) { edges { node { name } } }""",
+        )
+        assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
 
     def test_commits_failed_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -7,9 +7,7 @@ from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import RepositoryFactory
 from reports.tests.factories import (
     DailyTestRollupFactory,
-    RepositoryFlagFactory,
     TestFactory,
-    TestFlagBridgeFactory,
 )
 
 from .helper import GraphQLTestHelper
@@ -49,7 +47,6 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             avg_duration_seconds=3,
             latest_run=datetime.now(),
         )
-
 
     def test_fetch_test_result_name(self) -> None:
         query = """

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -7,6 +7,7 @@ from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import RepositoryFactory
 from reports.tests.factories import (
     DailyTestRollupFactory,
+    RepositoryFlagFactory,
     TestFactory,
     TestFlagBridgeFactory,
 )
@@ -35,7 +36,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             repository=self.repository, flag_name="test_flag_name"
         )
 
-        bridge = TestFlagBridgeFactory(repository=self.repository, flag=flag)
+        _ = TestFlagBridgeFactory(repository=self.repository, flag=flag)
 
         _ = DailyTestRollupFactory(
             test=self.test,

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -5,7 +5,11 @@ from freezegun import freeze_time
 
 from codecov_auth.tests.factories import OwnerFactory
 from core.tests.factories import RepositoryFactory
-from reports.tests.factories import DailyTestRollupFactory, TestFactory
+from reports.tests.factories import (
+    DailyTestRollupFactory,
+    TestFactory,
+    TestFlagBridgeFactory,
+)
 
 from .helper import GraphQLTestHelper
 
@@ -21,6 +25,17 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             name="Test\x1fName",
             repository=self.repository,
         )
+
+        self.test_with_flag = TestFactory(
+            name="Other Test",
+            repository=self.repository,
+        )
+
+        flag = RepositoryFlagFactory(
+            repository=self.repository, flag_name="test_flag_name"
+        )
+
+        bridge = TestFlagBridgeFactory(repository=self.repository, flag=flag)
 
         _ = DailyTestRollupFactory(
             test=self.test,
@@ -42,6 +57,14 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             date=date.today(),
             last_duration_seconds=5.0,
             avg_duration_seconds=3,
+            latest_run=datetime.now(),
+        )
+        _ = DailyTestRollupFactory(
+            test=self.test_with_flag,
+            commits_where_fail=["456"],
+            date=date.today(),
+            last_duration_seconds=10.0,
+            avg_duration_seconds=5,
             latest_run=datetime.now(),
         )
 

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -27,17 +27,6 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             repository=self.repository,
         )
 
-        self.test_with_flag = TestFactory(
-            name="Other Test",
-            repository=self.repository,
-        )
-
-        flag = RepositoryFlagFactory(
-            repository=self.repository, flag_name="test_flag_name"
-        )
-
-        _ = TestFlagBridgeFactory(repository=self.repository, flag=flag)
-
         _ = DailyTestRollupFactory(
             test=self.test,
             commits_where_fail=["123"],
@@ -60,14 +49,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             avg_duration_seconds=3,
             latest_run=datetime.now(),
         )
-        _ = DailyTestRollupFactory(
-            test=self.test_with_flag,
-            commits_where_fail=["456"],
-            date=date.today(),
-            last_duration_seconds=10.0,
-            avg_duration_seconds=5,
-            latest_run=datetime.now(),
-        )
+
 
     def test_fetch_test_result_name(self) -> None:
         query = """

--- a/graphql_api/types/inputs/test_results_filters.graphql
+++ b/graphql_api/types/inputs/test_results_filters.graphql
@@ -1,7 +1,7 @@
 input TestResultsFilters {
   branch: String
   parameter: TestResultsFilterParameter
-  testsuites: [String!]
+  test_suites: [String!]
   flags: [String!]
 }
 

--- a/graphql_api/types/inputs/test_results_filters.graphql
+++ b/graphql_api/types/inputs/test_results_filters.graphql
@@ -1,6 +1,8 @@
 input TestResultsFilters {
   branch: String
   parameter: TestResultsFilterParameter
+  testsuites: [String!]
+  flags: [String!]
 }
 
 input TestResultsOrdering {

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -554,6 +554,8 @@ async def resolve_test_results(
         repoid=repository.repoid,
         branch=filters.get("branch") if filters else None,
         parameter=generate_test_results_param,
+        testsuites=filters.get("testsuites") if filters else None,
+        flags=filters.get("flags") if filters else None,
     )
 
     return await queryset_to_connection(

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -554,7 +554,7 @@ async def resolve_test_results(
         repoid=repository.repoid,
         branch=filters.get("branch") if filters else None,
         parameter=generate_test_results_param,
-        testsuites=filters.get("testsuites") if filters else None,
+        testsuites=filters.get("test_suites") if filters else None,
         flags=filters.get("flags") if filters else None,
     )
 

--- a/reports/tests/factories.py
+++ b/reports/tests/factories.py
@@ -143,3 +143,11 @@ class DailyTestRollupFactory(factory.django.DjangoModelFactory):
     date = date.today()
 
     commits_where_fail = ["123", "456", "789"]
+
+
+class TestFlagBridgeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.TestFlagBridge
+
+    test = factory.SubFactory(TestFactory)
+    flag = factory.SubFactory(RepositoryFlagFactory)

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -72,8 +72,14 @@ def generate_test_results(
     The fields it calculates are: the test failure rate, commits where this test failed, last duration and average duration of the test.
 
     :param repoid: repoid of the repository we want to calculate aggregates for
-    :param branch: optional name of the branch we want to filter on, if this is provided the aggregates calculated will only take into account test instances generated on that branch. By default branches will not be filtered and test instances on all branches wil be taken into account.
-    :param history: optional timedelta field for filtering test instances used to calculated the aggregates by time, the test instances used will be those with a created at larger than now - history.
+    :param branch: optional name of the branch we want to filter on, if this is provided the aggregates calculated will only take into account
+        test instances generated on that branch. By default branches will not be filtered and test instances on all branches wil be taken into
+        account.
+    :param history: optional timedelta field for filtering test instances used to calculated the aggregates by time, the test instances used will be
+        those with a created at larger than now - history.
+    :param testsuites: optional list of testsuite names to filter by
+    :param flags: optional list of flag names to filter by, this is done via a union so if a user specifies multiple flags, we get all tests with any
+        of the flags, not tests that have all of the flags
     :returns: queryset object containing list of dictionaries of results
 
     """


### PR DESCRIPTION
we want to be able to filter test results by a list of flags and by a
list of testsuite names so this adds that functionality.

this is done by adding testsuites and flags fields to the
TestResultsFilteringParameter GQL model

to filter by flags this uses the TestFlagBridge database model