### PR TITLE
debug: Add phases to error log in owner serializer's get_scheduled_phases

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -236,7 +236,7 @@ class ScheduleDetailSerializer(serializers.Serializer):
                 extra=dict(
                     ownerid=schedule.metadata.obo_organization,
                     requesting_user_id=schedule.metadata.obo,
-                    phases=schedule["phases"],
+                    phases=schedule.get("phases", "no phases"),
                 ),
             )
             return None

--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -236,7 +236,7 @@ class ScheduleDetailSerializer(serializers.Serializer):
                 extra=dict(
                     ownerid=schedule.metadata.obo_organization,
                     requesting_user_id=schedule.metadata.obo,
-                    phases=schedule["phases"]
+                    phases=schedule["phases"],
                 ),
             )
             return None

--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -236,6 +236,7 @@ class ScheduleDetailSerializer(serializers.Serializer):
                 extra=dict(
                     ownerid=schedule.metadata.obo_organization,
                     requesting_user_id=schedule.metadata.obo,
+                    phases=schedule["phases"]
                 ),
             )
             return None


### PR DESCRIPTION
Logs out the phases leading to an error in owner serializer's get_scheduled_phases. To be used to assist in debugging a sentry issue I'm looking in to.
