### PR TITLE
fix: Safely access schedule metadata to avoid error

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -230,12 +230,14 @@ class ScheduleDetailSerializer(serializers.Serializer):
             return StripeScheduledPhaseSerializer(schedule["phases"][-1]).data
         else:
             # This error represents the phases object not having 2 phases; we are interested in the 2nd entry within phases
-            # since it represents the scheduled phase
+            # since it represents the scheduled phase.
+            # It should not be possible for a schedule to have one phase, but we have seen certain cases where this is true
+            # after manual intervention on a subscription.
             log.error(
                 "Expecting schedule object to have 2 phases, returning None",
                 extra=dict(
-                    ownerid=schedule.metadata.obo_organization,
-                    requesting_user_id=schedule.metadata.obo,
+                    ownerid=schedule.metadata.get("obo_organization"),
+                    requesting_user_id=schedule.metadata.get("obo"),
                     phases=schedule.get("phases", "no phases"),
                 ),
             )

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -270,6 +270,9 @@ class StripeWebhookHandlerTests(APITestCase):
         RepositoryFactory(author=self.other_owner, activated=True, active=True)
         RepositoryFactory(author=self.other_owner, activated=True, active=True)
 
+        self.owner.refresh_from_db()
+        self.other_owner.refresh_from_db()
+
         assert (
             self.owner.repository_set.filter(activated=True, active=True).count() == 3
         )


### PR DESCRIPTION
Updates last instance of unsafely accessing a schedule/subscription's metadata. This was causing errors when the expected metadata doesn't exist.

Resolves https://codecov.sentry.io/issues/5332174795
