### PR TITLE
remove payment_behavior - it's breaking subscription.modify

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -237,7 +237,9 @@ class StripeService(AbstractPaymentService):
                 ],
                 metadata=self._get_checkout_session_and_subscription_metadata(owner),
                 proration_behavior=proration_behavior,
-                payment_behavior="pending_if_incomplete",
+                # TODO: we need to include this arg, but it means we need to remove some of the existing args
+                # on the .modify() call https://docs.stripe.com/billing/subscriptions/pending-updates-reference
+                # payment_behavior="pending_if_incomplete",
             )
             log.info(
                 f"Stripe subscription upgrade attempted for owner {owner.ownerid} by user #{self.requesting_user.ownerid}"

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -189,7 +189,7 @@ class StripeServiceTests(TestCase):
                 "obo": self.user.ownerid,
             },
             proration_behavior="always_invoice",
-            payment_behavior="pending_if_incomplete",
+            # payment_behavior="pending_if_incomplete",
         )
 
     def _assert_schedule_modify(


### PR DESCRIPTION
### Purpose/Motivation
Stripe errors are popping up in logs with this message `StripeError raised: When `payment_behavior` is set to `pending_if_incomplete`, you can only pass supported params. `metadata` is not supported. See https://stripe.com/docs/billing/subscriptions/pending-updates-reference#supported-attributes for more details.`

There are several conflicting params, I'll have to sort them out later, for now removing this param from the .modify() call should fix the problem

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/2407
https://docs.stripe.com/billing/subscriptions/pending-updates-reference
