### PR TITLE
update okta cloud views

### DIFF
--- a/codecov_auth/views/okta_cloud.py
+++ b/codecov_auth/views/okta_cloud.py
@@ -50,7 +50,7 @@ class OktaCloudLoginView(OktaLoginMixin, View):
         self, request: HttpRequest, service: str, org_username: str
     ) -> HttpResponse:
         log_context: dict = {"service": service, "username": org_username}
-        if not request.session.get("current_owner_id"):
+        if not request.user or request.user.is_anonymous:
             log.warning(
                 "User needs to be signed in before authenticating organization with Okta.",
                 extra=log_context,
@@ -114,7 +114,7 @@ class OktaCloudCallbackView(OktaLoginMixin, View):
             "username": org_owner.username,
         }
 
-        if not request.session.get("current_owner_id"):
+        if not request.user or request.user.is_anonymous:
             log.warning(
                 "User not logged in for Okta callback.",
                 extra=log_context,


### PR DESCRIPTION
### Purpose/Motivation
Okta redirect wasn't working when users signed in through Sentry (instead of their git provider).

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/2349

### What does this PR do?
Changes the way we check whether the user is logged in.
