### PR TITLE
chore: Skip tests when deploying to staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
   test:
     name: Test
     needs: [build]
+    # Skip the ~10min test step when deploying to staging
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/staging' && github.repository_owner == 'codecov') }}
     uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.23
     secrets: inherit
     with:


### PR DESCRIPTION
The staging deploy takes a while, mostly due to the ~10min test runner (which can sometimes fail due to flaky tests, so maybe more than that including retries). This PR considers skipping that step for the staging deploy only so testing cycles on staging can be faster.
