### PR TITLE
fix: Make Int non-nullable in totalSeatCount on Account

### DIFF
--- a/graphql_api/types/account/account.graphql
+++ b/graphql_api/types/account/account.graphql
@@ -1,5 +1,5 @@
 type Account {
   name: String!
   oktaConfig: OktaConfig
-  totalSeatCount: Int
+  totalSeatCount: Int!
 }


### PR DESCRIPTION
Converts type of Account's totalSeatCount Int! instead of Int.
