### PR TITLE
feat: Add activatedUserCount resolver to Owner

### DIFF
--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -39,4 +39,5 @@ type Owner {
   yaml: String
   aiFeaturesEnabled: Boolean!
   aiEnabledRepos: [String]
+  activatedUserCount: Int
 }

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -373,5 +373,4 @@ def resolve_ai_enabled_repos(
 @sync_to_async
 @require_part_of_org
 def resolve_activated_user_count(owner: Owner, info: GraphQLResolveInfo) -> int | None:
-    print(owner.activated_user_count)
     return owner.activated_user_count

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -372,5 +372,5 @@ def resolve_ai_enabled_repos(
 @owner_bindable.field("activatedUserCount")
 @sync_to_async
 @require_part_of_org
-def resolve_activated_user_count(owner: Owner, info: GraphQLResolveInfo) -> int | None:
+def resolve_activated_user_count(owner: Owner, info: GraphQLResolveInfo) -> int:
     return owner.activated_user_count


### PR DESCRIPTION
Adds activatedUserCount resolver on the Owner type. One small step towards removing the account details rest endpoint lol.

Closes https://github.com/codecov/engineering-team/issues/2555
