### PR TITLE
feat: Add organizations array resolver on Account type

### DIFF
--- a/graphql_api/tests/test_account.py
+++ b/graphql_api/tests/test_account.py
@@ -81,3 +81,196 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
         assert "errors" not in result
         activatedUserCount = result["owner"]["account"]["activatedUserCount"]
         assert activatedUserCount == 7
+
+    def test_fetch_organizations(self) -> None:
+        for i in range(3):
+            OwnerFactory(
+                username=f"owner-{i}",
+                plan_activated_users=[j for j in range(i)],
+                account=self.account,
+            )
+
+        query = """
+            query {
+                owner(username: "%s") {
+                    account {
+                        organizations(first: 20) {
+                            edges {
+                                node {
+                                    username
+                                    activatedUserCount
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+
+        orgs = [
+            node["node"]["username"]
+            for node in result["owner"]["account"]["organizations"]["edges"]
+        ]
+
+        assert orgs == ["owner-2", "owner-1", "randomOwner", "owner-0"]
+
+    def test_fetch_organizations_order_by_activated_users_asc(self) -> None:
+        for i in range(3):
+            OwnerFactory(
+                username=f"owner-{i}",
+                plan_activated_users=[j for j in range(i)],
+                account=self.account,
+            )
+
+        query = """
+            query {
+                owner(username: "%s") {
+                    account {
+                        organizations(first: 20, ordering: ACTIVATED_USERS, orderingDirection: ASC) {
+                            edges {
+                                node {
+                                    username
+                                    activatedUserCount
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+
+        orgs = [
+            node["node"]["username"]
+            for node in result["owner"]["account"]["organizations"]["edges"]
+        ]
+
+        assert orgs == ["randomOwner", "owner-0", "owner-1", "owner-2"]
+
+    def test_fetch_organizations_order_by_name(self) -> None:
+        for i in range(3):
+            OwnerFactory(
+                username=f"owner-{i}",
+                plan_activated_users=[j for j in range(i)],
+                account=self.account,
+            )
+
+        query = """
+            query {
+                owner(username: "%s") {
+                    account {
+                        organizations(first: 20, ordering: NAME) {
+                            edges {
+                                node {
+                                    username
+                                    activatedUserCount
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+
+        orgs = [
+            node["node"]["username"]
+            for node in result["owner"]["account"]["organizations"]["edges"]
+        ]
+
+        assert orgs == ["randomOwner", "owner-2", "owner-1", "owner-0"]
+
+    def test_fetch_organizations_order_by_name_asc(self) -> None:
+        for i in range(3):
+            OwnerFactory(
+                username=f"owner-{i}",
+                plan_activated_users=[j for j in range(i)],
+                account=self.account,
+            )
+
+        query = """
+            query {
+                owner(username: "%s") {
+                    account {
+                        organizations(first: 20, ordering: NAME, orderingDirection: ASC) {
+                            edges {
+                                node {
+                                    username
+                                    activatedUserCount
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+
+        orgs = [
+            node["node"]["username"]
+            for node in result["owner"]["account"]["organizations"]["edges"]
+        ]
+
+        assert orgs == ["owner-0", "owner-1", "owner-2", "randomOwner"]
+
+    def test_fetch_organizations_pagination(self) -> None:
+        for i in range(3):
+            OwnerFactory(
+                username=f"owner-{i}",
+                plan_activated_users=[j for j in range(i)],
+                account=self.account,
+            )
+
+        query = """
+            query {
+                owner(username: "%s") {
+                    account {
+                        organizations(first: 2) {
+                            edges {
+                                node {
+                                    username
+                                    activatedUserCount
+                                }
+                            }
+                            totalCount
+                            pageInfo {
+                                hasNextPage
+                            }
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+
+        totalCount = result["owner"]["account"]["organizations"]["totalCount"]
+
+        assert totalCount == 4
+
+        orgs = [
+            node["node"]["username"]
+            for node in result["owner"]["account"]["organizations"]["edges"]
+        ]
+
+        assert orgs == ["owner-2", "owner-1"]
+
+        hasNextPage = result["owner"]["account"]["organizations"]["pageInfo"][
+            "hasNextPage"
+        ]
+        assert hasNextPage

--- a/graphql_api/tests/test_account.py
+++ b/graphql_api/tests/test_account.py
@@ -83,12 +83,22 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
         assert activatedUserCount == 7
 
     def test_fetch_organizations(self) -> None:
-        for i in range(3):
-            OwnerFactory(
-                username=f"owner-{i}",
-                plan_activated_users=[j for j in range(i)],
-                account=self.account,
-            )
+        account = AccountFactory(name="account")
+        owner = OwnerFactory(
+            username="owner-0",
+            plan_activated_users=[],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-1",
+            plan_activated_users=[0],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-2",
+            plan_activated_users=[0, 1],
+            account=account,
+        )
 
         query = """
             query {
@@ -105,9 +115,9 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
                     }
                 }
             }
-        """ % (self.owner.username)
+        """ % (owner.username)
 
-        result = self.gql_request(query, owner=self.owner)
+        result = self.gql_request(query, owner=owner)
 
         assert "errors" not in result
 
@@ -116,15 +126,25 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             for node in result["owner"]["account"]["organizations"]["edges"]
         ]
 
-        assert orgs == ["owner-2", "owner-1", "randomOwner", "owner-0"]
+        assert orgs == ["owner-2", "owner-1", "owner-0"]
 
     def test_fetch_organizations_order_by_activated_users_asc(self) -> None:
-        for i in range(3):
-            OwnerFactory(
-                username=f"owner-{i}",
-                plan_activated_users=[j for j in range(i)],
-                account=self.account,
-            )
+        account = AccountFactory(name="account")
+        owner = OwnerFactory(
+            username="owner-0",
+            plan_activated_users=[],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-1",
+            plan_activated_users=[0],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-2",
+            plan_activated_users=[0, 1],
+            account=account,
+        )
 
         query = """
             query {
@@ -141,9 +161,9 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
                     }
                 }
             }
-        """ % (self.owner.username)
+        """ % (owner.username)
 
-        result = self.gql_request(query, owner=self.owner)
+        result = self.gql_request(query, owner=owner)
 
         assert "errors" not in result
 
@@ -152,15 +172,25 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             for node in result["owner"]["account"]["organizations"]["edges"]
         ]
 
-        assert orgs == ["randomOwner", "owner-0", "owner-1", "owner-2"]
+        assert orgs == ["owner-0", "owner-1", "owner-2"]
 
     def test_fetch_organizations_order_by_name(self) -> None:
-        for i in range(3):
-            OwnerFactory(
-                username=f"owner-{i}",
-                plan_activated_users=[j for j in range(i)],
-                account=self.account,
-            )
+        account = AccountFactory(name="account")
+        owner = OwnerFactory(
+            username="owner-0",
+            plan_activated_users=[],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-1",
+            plan_activated_users=[0],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-2",
+            plan_activated_users=[0, 1],
+            account=account,
+        )
 
         query = """
             query {
@@ -177,9 +207,9 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
                     }
                 }
             }
-        """ % (self.owner.username)
+        """ % (owner.username)
 
-        result = self.gql_request(query, owner=self.owner)
+        result = self.gql_request(query, owner=owner)
 
         assert "errors" not in result
 
@@ -188,15 +218,25 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             for node in result["owner"]["account"]["organizations"]["edges"]
         ]
 
-        assert orgs == ["randomOwner", "owner-2", "owner-1", "owner-0"]
+        assert orgs == ["owner-2", "owner-1", "owner-0"]
 
     def test_fetch_organizations_order_by_name_asc(self) -> None:
-        for i in range(3):
-            OwnerFactory(
-                username=f"owner-{i}",
-                plan_activated_users=[j for j in range(i)],
-                account=self.account,
-            )
+        account = AccountFactory(name="account")
+        owner = OwnerFactory(
+            username="owner-0",
+            plan_activated_users=[],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-1",
+            plan_activated_users=[0],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-2",
+            plan_activated_users=[0, 1],
+            account=account,
+        )
 
         query = """
             query {
@@ -213,9 +253,9 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
                     }
                 }
             }
-        """ % (self.owner.username)
+        """ % (owner.username)
 
-        result = self.gql_request(query, owner=self.owner)
+        result = self.gql_request(query, owner=owner)
 
         assert "errors" not in result
 
@@ -224,15 +264,25 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             for node in result["owner"]["account"]["organizations"]["edges"]
         ]
 
-        assert orgs == ["owner-0", "owner-1", "owner-2", "randomOwner"]
+        assert orgs == ["owner-0", "owner-1", "owner-2"]
 
     def test_fetch_organizations_pagination(self) -> None:
-        for i in range(3):
-            OwnerFactory(
-                username=f"owner-{i}",
-                plan_activated_users=[j for j in range(i)],
-                account=self.account,
-            )
+        account = AccountFactory(name="account")
+        owner = OwnerFactory(
+            username="owner-0",
+            plan_activated_users=[],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-1",
+            plan_activated_users=[0],
+            account=account,
+        )
+        OwnerFactory(
+            username="owner-2",
+            plan_activated_users=[0, 1],
+            account=account,
+        )
 
         query = """
             query {
@@ -253,15 +303,15 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
                     }
                 }
             }
-        """ % (self.owner.username)
+        """ % (owner.username)
 
-        result = self.gql_request(query, owner=self.owner)
+        result = self.gql_request(query, owner=owner)
 
         assert "errors" not in result
 
         totalCount = result["owner"]["account"]["organizations"]["totalCount"]
 
-        assert totalCount == 4
+        assert totalCount == 3
 
         orgs = [
             node["node"]["username"]

--- a/graphql_api/types/account/__init__.py
+++ b/graphql_api/types/account/__init__.py
@@ -1,10 +1,5 @@
 from shared.license import get_current_license
 
-from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+from .account import account, account_bindable
 
-from .account import account_bindable
-
-account = ariadne_load_local_graphql(__file__, "account.graphql")
-
-
-__all__ = ["get_current_license", "account_bindable"]
+__all__ = ["get_current_license", "account_bindable", "account"]

--- a/graphql_api/types/account/__init__.py
+++ b/graphql_api/types/account/__init__.py
@@ -1,5 +1,3 @@
-from shared.license import get_current_license
-
 from .account import account, account_bindable
 
-__all__ = ["get_current_license", "account_bindable", "account"]
+__all__ = ["account_bindable", "account"]

--- a/graphql_api/types/account/account.graphql
+++ b/graphql_api/types/account/account.graphql
@@ -3,4 +3,12 @@ type Account {
   oktaConfig: OktaConfig
   totalSeatCount: Int!
   activatedUserCount: Int!
+  organizations(
+    ordering: AccountOrganizationOrdering
+    orderingDirection: OrderingDirection
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): AccountOrganizationConnection! @cost(complexity: 25, multipliers: ["first", "last"])
 }

--- a/graphql_api/types/account/account.py
+++ b/graphql_api/types/account/account.py
@@ -1,4 +1,4 @@
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
 from codecov.db import sync_to_async
@@ -40,7 +40,6 @@ def resolve_activated_user_count(account: Account, info: GraphQLResolveInfo) -> 
 
 
 @account_bindable.field("organizations")
-@convert_kwargs_to_snake_case
 def resolve_organizations(
     account: Account,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/account/account.py
+++ b/graphql_api/types/account/account.py
@@ -1,9 +1,17 @@
-from ariadne import ObjectType
+from ariadne import ObjectType, convert_kwargs_to_snake_case
 from graphql import GraphQLResolveInfo
 
 from codecov.db import sync_to_async
 from codecov_auth.models import Account, OktaSettings
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+from graphql_api.helpers.connection import (
+    build_connection_graphql,
+    queryset_to_connection,
+)
+from graphql_api.types.enums.enums import AccountOrganizationOrdering, OrderingDirection
 
+account = ariadne_load_local_graphql(__file__, "account.graphql")
+account = account + build_connection_graphql("AccountOrganizationConnection", "Owner")
 account_bindable = ObjectType("Account")
 
 
@@ -29,3 +37,20 @@ def resolve_total_seat_count(account: Account, info: GraphQLResolveInfo) -> int:
 @sync_to_async
 def resolve_activated_user_count(account: Account, info: GraphQLResolveInfo) -> int:
     return account.activated_user_count
+
+
+@account_bindable.field("organizations")
+@convert_kwargs_to_snake_case
+def resolve_organizations(
+    account: Account,
+    info: GraphQLResolveInfo,
+    ordering=AccountOrganizationOrdering.ACTIVATED_USERS,
+    ordering_direction=OrderingDirection.DESC,
+    **kwargs,
+):
+    return queryset_to_connection(
+        account.organizations,
+        ordering=(ordering,),
+        ordering_direction=ordering_direction,
+        **kwargs,
+    )

--- a/graphql_api/types/config/__init__.py
+++ b/graphql_api/types/config/__init__.py
@@ -1,5 +1,3 @@
-from shared.license import get_current_license
-
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 
 from .config import config_bindable
@@ -7,4 +5,4 @@ from .config import config_bindable
 config = ariadne_load_local_graphql(__file__, "config.graphql")
 
 
-__all__ = ["get_current_license", "config_bindable"]
+__all__ = ["config_bindable"]

--- a/graphql_api/types/enums/account_organization_ordering.graphql
+++ b/graphql_api/types/enums/account_organization_ordering.graphql
@@ -1,0 +1,4 @@
+enum AccountOrganizationOrdering {
+  NAME
+  ACTIVATED_USERS
+}

--- a/graphql_api/types/enums/enum_types.py
+++ b/graphql_api/types/enums/enum_types.py
@@ -11,6 +11,7 @@ from timeseries.models import Interval as MeasurementInterval
 from timeseries.models import MeasurementName
 
 from .enums import (
+    AccountOrganizationOrdering,
     AssetOrdering,
     BundleLoadTypes,
     CoverageLine,
@@ -56,4 +57,5 @@ enum_types = [
     EnumType("TestResultsOrderingParameter", TestResultsOrderingParameter),
     EnumType("TestResultsFilterParameter", TestResultsFilterParameter),
     EnumType("AssetOrdering", AssetOrdering),
+    EnumType("AccountOrganizationOrdering", AccountOrganizationOrdering),
 ]

--- a/graphql_api/types/enums/enums.py
+++ b/graphql_api/types/enums/enums.py
@@ -41,6 +41,11 @@ class RepositoryOrdering(enum.Enum):
     NAME = "name"
 
 
+class AccountOrganizationOrdering(enum.Enum):
+    NAME = "username"
+    ACTIVATED_USERS = "plan_activated_users"
+
+
 class OrderingDirection(enum.Enum):
     ASC = "ascending"
     DESC = "descending"

--- a/graphql_api/types/okta_config/__init__.py
+++ b/graphql_api/types/okta_config/__init__.py
@@ -1,5 +1,3 @@
-from shared.license import get_current_license
-
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 
 from .okta_config import okta_config_bindable
@@ -7,4 +5,4 @@ from .okta_config import okta_config_bindable
 okta_config = ariadne_load_local_graphql(__file__, "okta_config.graphql")
 
 
-__all__ = ["get_current_license", "okta_config_bindable"]
+__all__ = ["okta_config_bindable"]


### PR DESCRIPTION
Adds the paginated organizations array resolver on the Account type in the graphql API.

Closes https://github.com/codecov/engineering-team/issues/2558
