### PR TITLE
[temp] Add logs to incoming github webhook events 

### DIFF
--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -94,7 +94,11 @@ class GithubWebhookHandler(APIView):
             or expected_sig is None
             or len(computed_sig) != len(expected_sig)
             or not constant_time_compare(computed_sig, expected_sig)
-        ):
+        ):  
+            log.info(
+                f"Error validating signature {request}, {request.META}, "
+                f"Failed to validate signature for request" 
+            )
             _incr("invalid_signature")
             raise PermissionDenied()
 

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -94,10 +94,10 @@ class GithubWebhookHandler(APIView):
             or expected_sig is None
             or len(computed_sig) != len(expected_sig)
             or not constant_time_compare(computed_sig, expected_sig)
-        ):  
+        ):
             log.info(
                 f"Error validating signature {request}, {request.META}, "
-                f"Failed to validate signature for request" 
+                f"Failed to validate signature for request"
             )
             _incr("invalid_signature")
             raise PermissionDenied()

--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -96,7 +96,7 @@ class GithubWebhookHandler(APIView):
             or not constant_time_compare(computed_sig, expected_sig)
         ):
             log.info(
-                f"Error validating signature {request}, {request.META}, "
+                f"Error validating signature {request}, Headers: {list(request.META.keys())}, "
                 f"Failed to validate signature for request"
             )
             _incr("invalid_signature")


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Testing signature validation on forwarding webhook requests from AI reviewer. We want to ensure we log the same headers. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
