### PR TITLE
ref: Replace setex with set in gql rate limit code

### DIFF
--- a/graphql_api/views.py
+++ b/graphql_api/views.py
@@ -329,7 +329,7 @@ class AsyncGraphqlView(GraphQLAsyncView):
                 "[GQL Rate Limit] - Setting new key",
                 extra=dict(key=key, user_id=user_id),
             )
-            redis.setex(key, window, 1)
+            redis.set(name=key, ex=window, value=1)
         elif int(current_count) >= limit:
             log.warning(
                 "[GQL Rate Limit] - Rate limit reached for key",


### PR DESCRIPTION
### Purpose/Motivation

https://redis.io/docs/latest/commands/setex/

Setex looks to be deprecated in favor of set, thanks @nora-codecov for letting me know! This PR just updates the GQL rate limit code from setex to set and defines the function params explicitly

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
