### PR TITLE
feat: add use of computed_name in API

### DIFF
--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -86,7 +86,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             name

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -104,7 +104,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
                 "node"
             ]["name"]
             == self.test.computed_name

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -76,6 +76,37 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             0
         ]["node"]["name"] == self.test.name.replace("\x1f", " ")
 
+    def test_fetch_test_result_name_with_computed_name(self) -> None:
+        self.test.computed_name = "Computed Name"
+        self.test.save()
+
+        query = """
+            query {
+               owner(username: "%s") {
+                    repository(name: "%s") {
+                        ... on Repository {
+                            testAnalytics {
+                                results {
+                                    edges {
+                                        node {
+                                            name
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                 }
+            }
+        """ % (self.owner.username, self.repository.name)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+        assert result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+            "node"
+        ]["name"] == self.test.computed_name
+
     def test_fetch_test_result_updated_at(self) -> None:
         query = """
             query {

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -103,9 +103,12 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
         result = self.gql_request(query, owner=self.owner)
 
         assert "errors" not in result
-        assert result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
-            "node"
-        ]["name"] == self.test.computed_name
+        assert (
+            result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+                "node"
+            ]["name"]
+            == self.test.computed_name
+        )
 
     def test_fetch_test_result_updated_at(self) -> None:
         query = """

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -16,6 +16,7 @@ class TestDict(TypedDict):
     total_fail_count: int
     total_skip_count: int
     total_pass_count: int
+    computed_name: str | None
 
 
 test_result_bindable = ObjectType("TestResult")

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -23,7 +23,7 @@ test_result_bindable = ObjectType("TestResult")
 
 @test_result_bindable.field("name")
 def resolve_name(test: TestDict, _: GraphQLResolveInfo) -> str:
-    return test["name"].replace("\x1f", " ")
+    return test.get("computed_name") or test["name"].replace("\x1f", " ")
 
 
 @test_result_bindable.field("updatedAt")

--- a/reports/tests/factories.py
+++ b/reports/tests/factories.py
@@ -107,6 +107,7 @@ class TestFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"{n}")
     repository = factory.SubFactory(RepositoryFactory)
     commits_where_fail = []
+    computed_name = None
 
 
 class TestInstanceFactory(factory.django.DjangoModelFactory):

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -197,6 +197,7 @@ def generate_test_results(
         last_duration=Value(0.0),
         avg_duration=Avg("avg_duration_seconds"),
         name=F("test__name"),
+        computed_name=F("test__computed_name"),
     )
 
     return aggregation_of_test_results


### PR DESCRIPTION
if a test has a computed name we want to return that as the test name in the GQL Test Result object instead of its uncomputed name otherwise just return its uncomputed name with the special separation character escaped