### PR TITLE
fix: Rename graphql testResults

### DIFF
--- a/graphql_api/tests/test_test_analytics.py
+++ b/graphql_api/tests/test_test_analytics.py
@@ -85,17 +85,17 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
 
         _ = DailyTestRollupFactory(test=test)
         res = self.fetch_test_analytics(
-            repo.name, """results { edges { node { name } } }"""
+            repo.name, """testResults { edges { node { name } } }"""
         )
 
-        assert res["results"] == {"edges": [{"node": {"name": test.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
 
     def test_test_results_no_tests(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         res = self.fetch_test_analytics(
-            repo.name, """results { edges { node { name } } }"""
+            repo.name, """testResults { edges { node { name } } }"""
         )
-        assert res["results"] == {"edges": []}
+        assert res["testResults"] == {"edges": []}
 
     def test_branch_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -115,9 +115,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { branch: "main"}) { edges { node { name } } }""",
+            """testResults(filters: { branch: "main"}) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
 
     def test_flaky_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -138,9 +138,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { parameter: FLAKY_TESTS }) { edges { node { name } } }""",
+            """testResults(filters: { parameter: FLAKY_TESTS }) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test2.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test2.name}}]}
 
     def test_failed_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -162,9 +162,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { parameter: FAILED_TESTS }) { edges { node { name } } }""",
+            """testResults(filters: { parameter: FAILED_TESTS }) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test2.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test2.name}}]}
 
     def test_skipped_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -190,9 +190,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { parameter: SKIPPED_TESTS }) { edges { node { name } } }""",
+            """testResults(filters: { parameter: SKIPPED_TESTS }) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test2.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test2.name}}]}
 
     def test_slowest_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -214,9 +214,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { parameter: SLOWEST_TESTS }) { edges { node { name } } }""",
+            """testResults(filters: { parameter: SLOWEST_TESTS }) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test2.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test2.name}}]}
 
     def test_flags_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -242,9 +242,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { flags: ["hello_world"] }) { edges { node { name } } }""",
+            """testResults(filters: { flags: ["hello_world"] }) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
 
     def test_testsuites_filter_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -267,9 +267,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(filters: { test_suites: ["hello"] }) { edges { node { name } } }""",
+            """testResults(filters: { test_suites: ["hello"] }) { edges { node { name } } }""",
         )
-        assert res["results"] == {"edges": [{"node": {"name": test.name}}]}
+        assert res["testResults"] == {"edges": [{"node": {"name": test.name}}]}
 
     def test_commits_failed_ordering_on_test_results(self) -> None:
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
@@ -295,9 +295,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: COMMITS_WHERE_FAIL, direction: ASC }) { edges { node { name commitsFailed } } }""",
+            """testResults(ordering: { parameter: COMMITS_WHERE_FAIL, direction: ASC }) { edges { node { name commitsFailed } } }""",
         )
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test_2.name, "commitsFailed": 1}},
                 {"node": {"name": test.name, "commitsFailed": 2}},
@@ -328,9 +328,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: COMMITS_WHERE_FAIL, direction: DESC }) { edges { node { name commitsFailed } } }""",
+            """testResults(ordering: { parameter: COMMITS_WHERE_FAIL, direction: DESC }) { edges { node { name commitsFailed } } }""",
         )
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test.name, "commitsFailed": 2}},
                 {"node": {"name": test_2.name, "commitsFailed": 1}},
@@ -363,9 +363,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: LAST_DURATION, direction: ASC }) { edges { node { name lastDuration } } }""",
+            """testResults(ordering: { parameter: LAST_DURATION, direction: ASC }) { edges { node { name lastDuration } } }""",
         )
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test.name, "lastDuration": 2.0}},
                 {"node": {"name": test_2.name, "lastDuration": 3.0}},
@@ -398,9 +398,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: LAST_DURATION, direction: DESC }) { edges { node { name lastDuration } } }""",
+            """testResults(ordering: { parameter: LAST_DURATION, direction: DESC }) { edges { node { name lastDuration } } }""",
         )
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test_2.name, "lastDuration": 3}},
                 {"node": {"name": test.name, "lastDuration": 2}},
@@ -432,9 +432,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: AVG_DURATION, direction: ASC }) { edges { node { name avgDuration } } }""",
+            """testResults(ordering: { parameter: AVG_DURATION, direction: ASC }) { edges { node { name avgDuration } } }""",
         )
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test.name, "avgDuration": 1.5}},
                 {"node": {"name": test_2.name, "avgDuration": 3}},
@@ -465,9 +465,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: AVG_DURATION, direction: DESC }) { edges { node { name avgDuration } } }""",
+            """testResults(ordering: { parameter: AVG_DURATION, direction: DESC }) { edges { node { name avgDuration } } }""",
         )
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test_2.name, "avgDuration": 3}},
                 {"node": {"name": test.name, "avgDuration": 1.5}},
@@ -501,10 +501,10 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: FAILURE_RATE, direction: ASC }) { edges { node { name failureRate } } }""",
+            """testResults(ordering: { parameter: FAILURE_RATE, direction: ASC }) { edges { node { name failureRate } } }""",
         )
 
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test.name, "failureRate": 0.2}},
                 {"node": {"name": test_2.name, "failureRate": 0.6}},
@@ -538,10 +538,10 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: FAILURE_RATE, direction: DESC }) { edges { node { name failureRate } } }""",
+            """testResults(ordering: { parameter: FAILURE_RATE, direction: DESC }) { edges { node { name failureRate } } }""",
         )
 
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test_2.name, "failureRate": 0.6}},
                 {"node": {"name": test.name, "failureRate": 0.2}},
@@ -578,10 +578,10 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: FAILURE_RATE, direction: ASC }) { edges { node { name flakeRate } } }""",
+            """testResults(ordering: { parameter: FAILURE_RATE, direction: ASC }) { edges { node { name flakeRate } } }""",
         )
 
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test.name, "flakeRate": 0.2}},
                 {"node": {"name": test_2.name, "flakeRate": 0.2}},
@@ -618,10 +618,10 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         res = self.fetch_test_analytics(
             repo.name,
-            """results(ordering: { parameter: FAILURE_RATE, direction: DESC }) { edges { node { name flakeRate } } }""",
+            """testResults(ordering: { parameter: FAILURE_RATE, direction: DESC }) { edges { node { name flakeRate } } }""",
         )
 
-        assert res["results"] == {
+        assert res["testResults"] == {
             "edges": [
                 {"node": {"name": test_2.name, "flakeRate": 0.2}},
                 {"node": {"name": test.name, "flakeRate": 0.2}},
@@ -662,9 +662,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
             )
         res = self.fetch_test_analytics(
             repo.name,
-            """resultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
+            """testResultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
-        assert res["resultsAggregates"] == {
+        assert res["testResultsAggregates"] == {
             "totalDuration": 570.0,
             "slowestTestsDuration": 29.0,
             "totalFails": 10,
@@ -696,10 +696,10 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
 
         res = self.fetch_test_analytics(
             repo.name,
-            """resultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
+            """testResultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange }""",
         )
 
-        assert res["resultsAggregates"] == {
+        assert res["testResultsAggregates"] == {
             "totalDuration": 570.0,
             "slowestTestsDuration": 29.0,
             "totalFails": 10,

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -55,7 +55,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             name
@@ -72,9 +72,9 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
         result = self.gql_request(query, owner=self.owner)
 
         assert "errors" not in result
-        assert result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
-            "node"
-        ]["name"] == self.test.name.replace("\x1f", " ")
+        assert result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][
+            0
+        ]["node"]["name"] == self.test.name.replace("\x1f", " ")
 
     def test_fetch_test_result_updated_at(self) -> None:
         query = """
@@ -83,7 +83,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             updatedAt
@@ -101,7 +101,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
                 "node"
             ]["updatedAt"]
             == datetime.now(UTC).isoformat()
@@ -114,7 +114,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             commitsFailed
@@ -132,7 +132,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
                 "node"
             ]["commitsFailed"]
             == 3
@@ -145,7 +145,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             failureRate
@@ -163,7 +163,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
                 "node"
             ]["failureRate"]
             == 0.75
@@ -176,7 +176,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             lastDuration
@@ -194,7 +194,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
+            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
                 "node"
             ]["lastDuration"]
             == 5.0
@@ -207,7 +207,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                results {
+                                testResults {
                                     edges {
                                         node {
                                             avgDuration
@@ -224,6 +224,6 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
         result = self.gql_request(query, owner=self.owner)
 
         assert "errors" not in result
-        assert result["owner"]["repository"]["testAnalytics"]["results"]["edges"][0][
-            "node"
-        ]["avgDuration"] == (5.6 / 3)
+        assert result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][
+            0
+        ]["node"]["avgDuration"] == (5.6 / 3)

--- a/graphql_api/tests/test_test_results_headers.py
+++ b/graphql_api/tests/test_test_results_headers.py
@@ -37,7 +37,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                resultsAggregates {
+                                testResultsAggregates {
                                     totalDuration
                                 }
                             }
@@ -51,7 +51,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["resultsAggregates"][
+            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "totalDuration"
             ]
             == 435.0
@@ -64,7 +64,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                resultsAggregates {
+                                testResultsAggregates {
                                     slowestTestsDuration
                                 }
                             }
@@ -78,7 +78,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["resultsAggregates"][
+            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "slowestTestsDuration"
             ]
             == 29.0
@@ -91,7 +91,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                resultsAggregates {
+                                testResultsAggregates {
                                     totalFails
                                 }
                             }
@@ -105,7 +105,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["resultsAggregates"][
+            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "totalFails"
             ]
             == 29
@@ -118,7 +118,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                     repository(name: "%s") {
                         ... on Repository {
                             testAnalytics {
-                                resultsAggregates {
+                                testResultsAggregates {
                                     totalSkips
                                 }
                             }
@@ -132,7 +132,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["resultsAggregates"][
+            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "totalSkips"
             ]
             == 29

--- a/graphql_api/types/test_analytics/test_analytics.graphql
+++ b/graphql_api/types/test_analytics/test_analytics.graphql
@@ -2,8 +2,8 @@
 TestAnalytics are fields related to Codecov's Test Analytics product offering
 """
 type TestAnalytics {
-  "Results are analytics data per test"
-  results(
+  "Test results are analytics data per test"
+  testResults(
     filters: TestResultsFilters
     ordering: TestResultsOrdering
     first: Int
@@ -12,8 +12,8 @@ type TestAnalytics {
     before: String
   ): TestResultConnection! @cost(complexity: 10, multipliers: ["first", "last"])
 
-  "Results aggregates are analytics data totals across all tests"
-  resultsAggregates: TestResultsAggregates
+  "Test results aggregates are analytics data totals across all tests"
+  testResultsAggregates: TestResultsAggregates
 
   "Flake aggregates are flake totals across all tests"
   flakeAggregates: FlakeAggregates

--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 test_analytics_bindable: ObjectType = ObjectType("TestAnalytics")
 
 
-@test_analytics_bindable.field("results")
+@test_analytics_bindable.field("testResults")
 async def resolve_results(
     repository: Repository,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -1,6 +1,6 @@
 import logging
 
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from graphql.type.definition import GraphQLResolveInfo
 
 from codecov.db import sync_to_async
@@ -64,9 +64,8 @@ async def resolve_results(
     )
 
 
-@test_analytics_bindable.field("resultsAggregates")
-@convert_kwargs_to_snake_case
-async def resolve_results_aggregates(
+@test_analytics_bindable.field("testResultsAggregates")
+async def resolve_test_results_aggregates(
     repository: Repository,
     info: GraphQLResolveInfo,
 ):
@@ -76,6 +75,5 @@ async def resolve_results_aggregates(
 
 
 @test_analytics_bindable.field("flakeAggregates")
-@convert_kwargs_to_snake_case
 async def resolve_flake_aggregates(repository: Repository, info: GraphQLResolveInfo):
     return await sync_to_async(generate_flake_aggregates)(repoid=repository.repoid)


### PR DESCRIPTION
Chatted with @ajay-sentry  - Rename fields in the new testAnalytics type introduced in this [PR](https://github.com/codecov/codecov-api/pull/852) to be more explicit
Before
```graphql
{
   testAnalytics {
     results
     resultsAggregates
  }
}
```

After
```graphql
{
   testAnalytics {
     testResults
     testResultsAggregates
  }
}
```
No frontend clients are hooked up to any of this yet so okay to make breaking change here