### PR TITLE
Remove unused logs in github webhook controller

### DIFF
--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -95,10 +95,6 @@ class GithubWebhookHandler(APIView):
             or len(computed_sig) != len(expected_sig)
             or not constant_time_compare(computed_sig, expected_sig)
         ):
-            log.info(
-                f"Error validating signature {request}, Headers: {list(request.META.keys())}, "
-                f"Failed to validate signature for request"
-            )
             _incr("invalid_signature")
             raise PermissionDenied()
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Not needed for debugging anymore. Revert https://github.com/codecov/codecov-api/pull/864

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
