### PR TITLE
fix: Add history to TestResultsAggregates key

### DIFF
--- a/graphql_api/types/test_analytics/test_analytics.graphql
+++ b/graphql_api/types/test_analytics/test_analytics.graphql
@@ -13,7 +13,7 @@ type TestAnalytics {
   ): TestResultConnection! @cost(complexity: 10, multipliers: ["first", "last"])
 
   "Test results aggregates are analytics data totals across all tests"
-  testResultsAggregates: TestResultsAggregates
+  testResultsAggregates(history: MeasurementInterval): TestResultsAggregates
 
   "Flake aggregates are flake totals across all tests"
   flakeAggregates(history: MeasurementInterval): FlakeAggregates


### PR DESCRIPTION
### Purpose/Motivation

Test Results Aggregates was missing history param but is needed for filtering on Gazebo

We can see its already on the resolver here: https://github.com/codecov/codecov-api/blob/f4a178c73f3e679feecc0a0315008472915d7fe0/graphql_api/types/test_analytics/test_analytics.py#L71

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
