### PR TITLE
perf: Fix TestResults SQL query to not take as long

### DIFF
--- a/graphql_api/tests/test_test_analytics.py
+++ b/graphql_api/tests/test_test_analytics.py
@@ -167,6 +167,7 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         assert res["testResults"] == {"edges": [{"node": {"name": test2.name}}]}
 
     def test_skipped_filter_on_test_results(self) -> None:
+        # note - this test guards against division by zero errors for the failure/flake rate
         repo = RepositoryFactory(author=self.owner, active=True, private=True)
         test = TestFactory(repository=repo)
         test2 = TestFactory(repository=repo)
@@ -367,8 +368,8 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         assert res["testResults"] == {
             "edges": [
-                {"node": {"name": test.name, "lastDuration": 0.0}},
-                {"node": {"name": test_2.name, "lastDuration": 0.0}},
+                {"node": {"name": test.name, "lastDuration": 2.0}},
+                {"node": {"name": test_2.name, "lastDuration": 3.0}},
             ]
         }
 
@@ -402,8 +403,8 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
         assert res["testResults"] == {
             "edges": [
-                {"node": {"name": test_2.name, "lastDuration": 0.0}},
-                {"node": {"name": test.name, "lastDuration": 0.0}},
+                {"node": {"name": test_2.name, "lastDuration": 3.0}},
+                {"node": {"name": test.name, "lastDuration": 2.0}},
             ]
         }
 
@@ -924,7 +925,7 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
 
         res = self.fetch_test_analytics(
             repo.name,
-            """flakeAggregates(history: INTERVAL_7_DAY) { flakeCount, flakeRate, flakeCountPercentChange, flakeRatePercentChange }""",
+            """flakeAggregates(interval: INTERVAL_7_DAY) { flakeCount, flakeRate, flakeCountPercentChange, flakeRatePercentChange }""",
         )
 
         assert res["flakeAggregates"] == {

--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -197,7 +197,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
                 "node"
             ]["lastDuration"]
-            == 0.0
+            == 1.0
         )
 
     def test_fetch_test_result_avg_duration(self) -> None:

--- a/graphql_api/types/inputs/test_results_filters.graphql
+++ b/graphql_api/types/inputs/test_results_filters.graphql
@@ -3,7 +3,7 @@ input TestResultsFilters {
   parameter: TestResultsFilterParameter
   test_suites: [String!]
   flags: [String!]
-  history: MeasurementInterval
+  interval: MeasurementInterval
   term: String
 }
 

--- a/graphql_api/types/test_analytics/test_analytics.graphql
+++ b/graphql_api/types/test_analytics/test_analytics.graphql
@@ -13,10 +13,10 @@ type TestAnalytics {
   ): TestResultConnection! @cost(complexity: 10, multipliers: ["first", "last"])
 
   "Test results aggregates are analytics data totals across all tests"
-  testResultsAggregates(history: MeasurementInterval): TestResultsAggregates
+  testResultsAggregates(interval: MeasurementInterval): TestResultsAggregates
 
   "Flake aggregates are flake totals across all tests"
-  flakeAggregates(history: MeasurementInterval): FlakeAggregates
+  flakeAggregates(interval: MeasurementInterval): FlakeAggregates
 }
 
 type TestResultConnection {

--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -44,13 +44,9 @@ async def resolve_test_results(
     )
 
     queryset = await sync_to_async(generate_test_results)(
-        ordering=(
-            (ordering.get("parameter").value, "name")
-            if ordering
-            else ("avg_duration", "name")
-        ),
+        ordering=ordering.get("parameter").value if ordering else "avg_duration",
         ordering_direction=(
-            ordering.get("direction") if ordering else OrderingDirection.DESC
+            ordering.get("direction").name if ordering else OrderingDirection.DESC.name
         ),
         repoid=repository.repoid,
         interval=interval,

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -1,71 +1,58 @@
 from datetime import datetime
-from typing import TypedDict
 
 from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
-
-class TestDict(TypedDict):
-    name: str
-    updated_at: datetime
-    commits_where_fail: int
-    failure_rate: float
-    avg_duration: float
-    last_duration: float
-    flake_rate: float
-    total_fail_count: int
-    total_skip_count: int
-    total_pass_count: int
-
+from utils.test_results import TestResultsRow
 
 test_result_bindable = ObjectType("TestResult")
 
 
 @test_result_bindable.field("name")
-def resolve_name(test: TestDict, _: GraphQLResolveInfo) -> str:
-    return test["name"].replace("\x1f", " ")
+def resolve_name(test: TestResultsRow, _: GraphQLResolveInfo) -> str:
+    return test.name.replace("\x1f", " ")
 
 
 @test_result_bindable.field("updatedAt")
-def resolve_updated_at(test: TestDict, _: GraphQLResolveInfo) -> datetime:
-    return test["updated_at"]
+def resolve_updated_at(test: TestResultsRow, _: GraphQLResolveInfo) -> datetime:
+    return test.updated_at
 
 
 @test_result_bindable.field("commitsFailed")
-def resolve_commits_failed(test: TestDict, _: GraphQLResolveInfo) -> int:
-    return test["commits_where_fail"]
+def resolve_commits_failed(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+    return test.commits_where_fail
 
 
 @test_result_bindable.field("failureRate")
-def resolve_failure_rate(test: TestDict, _: GraphQLResolveInfo) -> float:
-    return test["failure_rate"]
+def resolve_failure_rate(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+    return test.failure_rate
 
 
 @test_result_bindable.field("flakeRate")
-def resolve_flake_rate(test: TestDict, _: GraphQLResolveInfo) -> float:
-    return test["flake_rate"]
+def resolve_flake_rate(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+    return test.flake_rate
 
 
 @test_result_bindable.field("avgDuration")
-def resolve_avg_duration(test: TestDict, _: GraphQLResolveInfo) -> float:
-    return test["avg_duration"]
+def resolve_avg_duration(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+    return test.avg_duration
 
 
 @test_result_bindable.field("lastDuration")
-def resolve_last_duration(test: TestDict, _: GraphQLResolveInfo) -> float:
-    return test["last_duration"]
+def resolve_last_duration(test: TestResultsRow, _: GraphQLResolveInfo) -> float:
+    return test.last_duration
 
 
 @test_result_bindable.field("totalFailCount")
-def resolve_total_fail_count(test: TestDict, _: GraphQLResolveInfo) -> int:
-    return test["total_fail_count"]
+def resolve_total_fail_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+    return test.total_fail_count
 
 
 @test_result_bindable.field("totalSkipCount")
-def resolve_total_skip_count(test: TestDict, _: GraphQLResolveInfo) -> int:
-    return test["total_skip_count"]
+def resolve_total_skip_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+    return test.total_skip_count
 
 
 @test_result_bindable.field("totalPassCount")
-def resolve_total_pass_count(test: TestDict, _: GraphQLResolveInfo) -> int:
-    return test["total_pass_count"]
+def resolve_total_pass_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+    return test.total_pass_count

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -49,8 +49,8 @@ def resolve_total_fail_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int
 
 
 @test_result_bindable.field("totalFlakyFailCount")
-def resolve_total_flaky_fail_count(test: TestDict, _: GraphQLResolveInfo) -> int:
-    return test["total_flaky_fail_count"]
+def resolve_total_flaky_fail_count(test: TestResultsRow, _: GraphQLResolveInfo) -> int:
+    return test.total_flaky_fail_count
 
 
 @test_result_bindable.field("totalSkipCount")

--- a/graphql_api/types/test_results/test_results.py
+++ b/graphql_api/types/test_results/test_results.py
@@ -10,7 +10,7 @@ test_result_bindable = ObjectType("TestResult")
 
 @test_result_bindable.field("name")
 def resolve_name(test: TestResultsRow, _: GraphQLResolveInfo) -> str:
-    return test.computed_name or test.name.replace("\x1f", " ")
+    return test.name.replace("\x1f", " ")
 
 
 @test_result_bindable.field("updatedAt")

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -221,7 +221,7 @@ last_duration_cte as (
 
 select * from (
     select
-    COALESCE(rt.name, rt.computed_name) as name,
+    COALESCE(rt.computed_name, rt.name) as name,
     results.*
     from
     (

--- a/utils/tests/unit/test_cursor.py
+++ b/utils/tests/unit/test_cursor.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from utils.test_results import CursorValue, TestResultsRow, decode_cursor, encode_cursor
+
+
+def test_cursor():
+    row = TestResultsRow(
+        test_id="test",
+        name="test",
+        computed_name="test",
+        updated_at=datetime.fromisoformat("2024-01-01T00:00:00Z"),
+        commits_where_fail=1,
+        failure_rate=0.5,
+        avg_duration=100,
+        last_duration=100,
+        flake_rate=0.1,
+        total_fail_count=1,
+        total_flaky_fail_count=1,
+        total_skip_count=1,
+        total_pass_count=1,
+    )
+    cursor = encode_cursor(row, "updated_at")
+    assert cursor == "MjAyNC0wMS0wMSAwMDowMDowMCswMDowMHx0ZXN0"
+    decoded_cursor = decode_cursor(cursor)
+    assert decoded_cursor == CursorValue(str(row.updated_at), "test")

--- a/utils/tests/unit/test_cursor.py
+++ b/utils/tests/unit/test_cursor.py
@@ -7,7 +7,6 @@ def test_cursor():
     row = TestResultsRow(
         test_id="test",
         name="test",
-        computed_name="test",
         updated_at=datetime.fromisoformat("2024-01-01T00:00:00Z"),
         commits_where_fail=1,
         failure_rate=0.5,

--- a/utils/tests/unit/test_search_base_query.py
+++ b/utils/tests/unit/test_search_base_query.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+
+from utils.test_results import CursorValue, TestResultsRow, search_base_query
+
+
+def row_factory(name: str, failure_rate: float):
+    return TestResultsRow(
+        test_id=name,
+        name=name,
+        computed_name=name,
+        failure_rate=failure_rate,
+        flake_rate=0.0,
+        updated_at=datetime.now(),
+        avg_duration=0.0,
+        total_fail_count=0,
+        total_flaky_fail_count=0,
+        total_pass_count=0,
+        total_skip_count=0,
+        commits_where_fail=0,
+        last_duration=0.0,
+    )
+
+
+def test_search_base_query_cursor_val_none():
+    rows = [row_factory(str(i), float(i) * 0.1) for i in range(10)]
+    res = search_base_query(rows, "failure_rate", None)
+    assert res == rows
+
+
+def test_search_base_query_with_existing_cursor():
+    rows = [row_factory(str(i), float(i) * 0.1) for i in range(10)]
+    cursor = CursorValue(name="5", ordered_value="0.5")
+    res = search_base_query(rows, "failure_rate", cursor)
+    assert res == rows[6:]
+
+
+def test_search_base_query_with_missing_cursor_high_name_low_failure_rate():
+    # [(0, "0.0"), (1, "0.1"), (2, "0.2")]
+    #            ^
+    #          here's where the cursor is pointing at
+    rows = [row_factory(str(i), float(i) * 0.1) for i in range(3)]
+    cursor = CursorValue(name="111111", ordered_value="0.05")
+    res = search_base_query(rows, "failure_rate", cursor)
+    assert res == rows[1:]
+
+
+def test_search_base_query_with_missing_cursor_low_name_high_failure_rate():
+    # [(0, "0.0"), (1, "0.1"), (2, "0.2")]
+    #                         ^
+    #                        here's where the cursor is pointing at
+    rows = [row_factory(str(i), float(i) * 0.1) for i in range(3)]
+    cursor = CursorValue(name="0", ordered_value="0.15")
+    res = search_base_query(rows, "failure_rate", cursor)
+    assert res == rows[-1:]

--- a/utils/tests/unit/test_search_base_query.py
+++ b/utils/tests/unit/test_search_base_query.py
@@ -7,7 +7,6 @@ def row_factory(name: str, failure_rate: float):
     return TestResultsRow(
         test_id=name,
         name=name,
-        computed_name=name,
         failure_rate=failure_rate,
         flake_rate=0.0,
         updated_at=datetime.now(),


### PR DESCRIPTION
this commit replaces the previous django orm code with an invocation
to do a raw sql query that performs much better for repos with a large
amount of data.

one worry with this approach is the risk for sql injection

in this specific case, we're passing most of the dynamic user provided
values used in the sql through the parameters which the django docs say
are sanitized and should be used to protect against sql injection

for the user provided values that are not passed through the sql parameters
they're checked to be in a strict set of values, so we shouldn't be substituting
any unexpected strings into the query
