### PR TITLE
test: fix TestFactory

### DIFF
--- a/reports/tests/factories.py
+++ b/reports/tests/factories.py
@@ -106,7 +106,6 @@ class TestFactory(factory.django.DjangoModelFactory):
     id = factory.Sequence(lambda n: f"{n}")
     name = factory.Sequence(lambda n: f"{n}")
     repository = factory.SubFactory(RepositoryFactory)
-    commits_where_fail = []
     computed_name = None
 
 


### PR DESCRIPTION
there is a shared change that will remove the commits_where_fail
field from the Test model so having the commits_where_fail field
be set in the TestFactory will cause tests to fail
