### PR TITLE
Add logic for BA endpoint to accept storage_path

### DIFF
--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -104,6 +104,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
 
 
 @pytest.mark.django_db(databases={"default", "timeseries"})
+@override_settings(SHELTER_SHARED_SECRET="shelter-shared-secret")
 def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
     upload = mocker.patch.object(TaskService, "upload")
     mock_sentry_metrics = mocker.patch(
@@ -131,6 +132,7 @@ def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
             "service": "test-service",
             "compareSha": "6fd5b89357fc8cdf34d6197549ac7c6d7e5aaaaa",
             "storage_path": "shelter/test/path.txt",
+            "upload_external_id": "test-47078f85-2cee-4511-b38d-183c334ef43b",
         },
         format="json",
         headers={"User-Agent": "codecov-cli/0.4.7"},

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -116,12 +116,15 @@ class BundleAnalysisView(APIView, ShelterMixin):
             },
         )
 
-        upload_external_id = str(uuid.uuid4())
-        storage_path = StoragePaths.upload.path(upload_key=upload_external_id)
-        archive_service = ArchiveService(repo)
-        url = archive_service.storage.create_presigned_put(
-            get_bucket_name(), storage_path, 30
-        )
+        storage_path = data.get("storage_path", None)
+        url = None
+        if storage_path is None or not self.is_shelter_request():
+            upload_external_id = str(uuid.uuid4())
+            storage_path = StoragePaths.upload.path(upload_key=upload_external_id)
+            archive_service = ArchiveService(repo)
+            url = archive_service.storage.create_presigned_put(
+                get_bucket_name(), storage_path, 30
+            )
 
         task_arguments = {
             # these are used in the upload task when saving an upload record

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -50,6 +50,7 @@ class UploadSerializer(serializers.Serializer):
     compareSha = serializers.CharField(required=False, allow_null=True)
     git_service = serializers.CharField(required=False, allow_null=True)
     storage_path = serializers.CharField(required=False, allow_null=True)
+    upload_external_id = serializers.CharField(required=False, allow_null=True)
 
 
 class BundleAnalysisView(APIView, ShelterMixin):
@@ -118,8 +119,9 @@ class BundleAnalysisView(APIView, ShelterMixin):
         )
 
         storage_path = data.get("storage_path", None)
+        upload_external_id = data.get("upload_external_id", None)
         url = None
-        if storage_path is None or not self.is_shelter_request():
+        if not self.is_shelter_request():
             upload_external_id = str(uuid.uuid4())
             storage_path = StoragePaths.upload.path(upload_key=upload_external_id)
             archive_service = ArchiveService(repo)

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -49,6 +49,7 @@ class UploadSerializer(serializers.Serializer):
     branch = serializers.CharField(required=False, allow_null=True)
     compareSha = serializers.CharField(required=False, allow_null=True)
     git_service = serializers.CharField(required=False, allow_null=True)
+    storage_path = serializers.CharField(required=False, allow_null=True)
 
 
 class BundleAnalysisView(APIView, ShelterMixin):


### PR DESCRIPTION
Shelter will pass the storage_path variable that it creates on its end. We want to acknowledge if a request comes from shelter, and if so use it's storage_path

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
