### PR TITLE
Stripe Auto-refund cancellation within Grace Period

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -182,7 +182,7 @@ class StripeService(AbstractPaymentService):
 
         # we only want to refund the invoices PAID recently for the latest, current period. "invoices_list" gives us any invoice
         # created over the last month/year based on what period length they are on but the customer could have possibly
-        # switched from monthly to yearly recently. 
+        # switched from monthly to yearly recently.
         recently_paid_invoices_list = [
             invoice
             for invoice in invoices_list["data"]

--- a/services/billing.py
+++ b/services/billing.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 
 import stripe
 from dateutil.relativedelta import relativedelta
@@ -167,10 +167,10 @@ class StripeService(AbstractPaymentService):
 
         # we give an auto-refund grace period of 24 hours for a monthly subscription or 72 hours for a yearly subscription
         current_subscription_datetime = datetime.fromtimestamp(
-            subscription["current_period_start"], tz=datetime.timezone.utc
+            subscription["current_period_start"], tz=timezone.utc
         )
         difference_from_now = (
-            datetime.now(datetime.timezone.utc) - current_subscription_datetime
+            datetime.now(timezone.utc) - current_subscription_datetime
         )
 
         subscription_plan_interval = getattr(
@@ -200,8 +200,8 @@ class StripeService(AbstractPaymentService):
                     subscription=owner.stripe_subscription_id,
                     status="paid",
                     created={
-                        "created.gte": start_of_last_period.timestamp(),
-                        "created.lt": current_subscription_datetime.timestamp(),
+                        "created.gte": int(start_of_last_period.timestamp()),
+                        "created.lt": int(current_subscription_datetime.timestamp()),
                     },
                 )
                 created_refund = False

--- a/services/billing.py
+++ b/services/billing.py
@@ -159,11 +159,17 @@ class StripeService(AbstractPaymentService):
         stripe.Subscription.cancel(owner.stripe_subscription_id)
 
         start_of_last_period = current_subscription_datetime - relativedelta(months=1)
-        invoice_grace_period_start = current_subscription_datetime - relativedelta(days=1)
+        invoice_grace_period_start = current_subscription_datetime - relativedelta(
+            days=1
+        )
 
         if subscription_plan_interval == "year":
-            start_of_last_period = current_subscription_datetime - relativedelta(years=1)
-            invoice_grace_period_start = current_subscription_datetime - relativedelta(days=3)
+            start_of_last_period = current_subscription_datetime - relativedelta(
+                years=1
+            )
+            invoice_grace_period_start = current_subscription_datetime - relativedelta(
+                days=3
+            )
 
         invoices_list = stripe.Invoice.list(
             subscription=owner.stripe_subscription_id,

--- a/services/billing.py
+++ b/services/billing.py
@@ -185,7 +185,7 @@ class StripeService(AbstractPaymentService):
             invoice
             for invoice in invoices_list["data"]
             if invoice["status_transitions"]["paid_at"] is not None
-            and invoice["status_transitions"]["paid_at"] >= invoice_grace_period_start
+            and invoice["status_transitions"]["paid_at"] >= int(invoice_grace_period_start.timestamp())
         ]
 
         created_refund = False

--- a/services/billing.py
+++ b/services/billing.py
@@ -2,9 +2,9 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from datetime import datetime
-from dateutil.relativedelta import relativedelta
 
 import stripe
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 
 from billing.constants import REMOVED_INVOICE_STATUSES

--- a/services/billing.py
+++ b/services/billing.py
@@ -167,23 +167,40 @@ class StripeService(AbstractPaymentService):
 
         # we give an auto-refund grace period of 24 hours for a monthly subscription or 72 hours for a yearly subscription
         # current_subscription_timestamp = subscription["current_period_start"]
-        current_subscription_datetime = datetime.fromtimestamp(subscription["current_period_start"])
+        current_subscription_datetime = datetime.fromtimestamp(
+            subscription["current_period_start"]
+        )
         differenceFromNow = datetime.now() - current_subscription_datetime
 
-        subscription_plan_interval = subscription.plan.interval if subscription.plan is not None else None
-        within_refund_grace_period = (subscription_plan_interval == "month" and differenceFromNow.days < 1) or (subscription_plan_interval == "year" and differenceFromNow.days < 3)
+        subscription_plan_interval = (
+            subscription.plan.interval if subscription.plan is not None else None
+        )
+        within_refund_grace_period = (
+            subscription_plan_interval == "month" and differenceFromNow.days < 1
+        ) or (subscription_plan_interval == "year" and differenceFromNow.days < 3)
         if within_refund_grace_period:
             stripe.Subscription.cancel(owner.stripe_subscription_id)
 
-            invoices_list = stripe.Invoice.list(subscription=owner.stripe_subscription_id, status="paid")
+            invoices_list = stripe.Invoice.list(
+                subscription=owner.stripe_subscription_id, status="paid"
+            )
             created_refund = False
             # there could be multiple invoices that need to be refunded such as if the user increased seats within the grace period
             for invoice in invoices_list["data"]:
-                start_of_last_period = current_subscription_datetime - relativedelta(months=1) if subscription_plan_interval == "month" else current_subscription_datetime - relativedelta(years=1)
+                start_of_last_period = (
+                    current_subscription_datetime - relativedelta(months=1)
+                    if subscription_plan_interval == "month"
+                    else current_subscription_datetime - relativedelta(years=1)
+                )
 
                 # refund if the invoice has a charge, it has been fully paid, the creation time was before the start of the current subscription's start and the creation time was after the start of the last period
                 invoice_created_datetime = datetime.fromtimestamp(invoice["created"])
-                if invoice["charge"] is not None and invoice["amount_remaining"] == 0 and invoice_created_datetime < current_subscription_datetime and invoice_created_datetime >= start_of_last_period:
+                if (
+                    invoice["charge"] is not None
+                    and invoice["amount_remaining"] == 0
+                    and invoice_created_datetime < current_subscription_datetime
+                    and invoice_created_datetime >= start_of_last_period
+                ):
                     stripe.Refund.create(invoice["charge"])
                     created_refund = True
             if created_refund == True:

--- a/services/tests/samples/stripe_invoice.json
+++ b/services/tests/samples/stripe_invoice.json
@@ -120,7 +120,7 @@
       "total_tax_amounts": [],
       "webhooks_delivered_at": 1489789437
     },
-      {
+    {
       "id": "in_19yTU92eZvKYlo2C7uDjvu69",
       "object": "invoice",
       "account_country": "US",

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1,11 +1,11 @@
 import json
 from unittest.mock import MagicMock, patch
-from freezegun import freeze_time
 
 import requests
 from django.conf import settings
 from django.test import TestCase
 from shared.django_apps.core.tests.factories import OwnerFactory
+from freezegun import freeze_time
 from stripe import InvalidRequestError
 
 from codecov_auth.models import Service
@@ -291,8 +291,8 @@ class StripeServiceTests(TestCase):
         )
         subscription_params = {
             "schedule_id": stripe_schedule_id,
-            "start_date": 1639628096,
-            "end_date": 1644107871,
+            "start_date": 1489799420,
+            "end_date": 1492477820,
             "quantity": 10,
             "name": plan,
             "id": 215,
@@ -311,7 +311,7 @@ class StripeServiceTests(TestCase):
         assert owner.plan_activated_users == [4, 6, 3]
         assert owner.plan_user_count == 9
 
-    @freeze_time("2021-12-22T00:00:00")
+    @freeze_time("2017-03-22T00:00:00")
     @patch("services.billing.stripe.Refund.create")
     @patch("services.billing.stripe.Subscription.modify")
     @patch("services.billing.stripe.Subscription.retrieve")
@@ -330,8 +330,8 @@ class StripeServiceTests(TestCase):
         )
         subscription_params = {
             "schedule_id": stripe_schedule_id,
-            "start_date": 1639628096,
-            "end_date": 1644107871,
+            "start_date": 1489799420,
+            "end_date": 1492477820,
             "quantity": 10,
             "name": plan,
             "id": 215,
@@ -352,7 +352,7 @@ class StripeServiceTests(TestCase):
         assert owner.plan_activated_users == [4, 6, 3]
         assert owner.plan_user_count == 9
 
-    @freeze_time("2021-12-17T00:00:00")
+    @freeze_time("2017-03-18T00:00:00")
     @patch("services.billing.stripe.Subscription.modify")
     @patch("services.billing.stripe.Customer.modify")
     @patch("services.billing.stripe.Refund.create")
@@ -377,8 +377,8 @@ class StripeServiceTests(TestCase):
         )
         subscription_params = {
             "schedule_id": stripe_schedule_id,
-            "start_date": 1639628096,
-            "end_date": 1644107871,
+            "start_date": 1489799420,
+            "end_date": 1492477820,
             "quantity": 10,
             "name": plan,
             "id": 215,
@@ -405,7 +405,7 @@ class StripeServiceTests(TestCase):
         assert owner.plan_activated_users == [4, 6, 3]
         assert owner.plan_user_count == 9
 
-    @freeze_time("2021-12-19T00:00:00")
+    @freeze_time("2017-03-19T00:00:00")
     @patch("services.billing.stripe.Subscription.modify")
     @patch("services.billing.stripe.Customer.modify")
     @patch("services.billing.stripe.Refund.create")
@@ -430,8 +430,8 @@ class StripeServiceTests(TestCase):
         )
         subscription_params = {
             "schedule_id": stripe_schedule_id,
-            "start_date": 1639628096,
-            "end_date": 1644107871,
+            "start_date": 1489799420,
+            "end_date": 1492477820,
             "quantity": 10,
             "name": plan,
             "id": 215,

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -365,12 +365,10 @@ class StripeServiceTests(TestCase):
     ):
         with open("./services/tests/samples/stripe_invoice.json") as f:
             stripe_invoice_response = json.load(f)
-        stripe_invoice_response["data"] = stripe_invoice_response["data"] * 2
         list_invoice_mock.return_value = stripe_invoice_response
         plan = PlanName.CODECOV_PRO_YEARLY.value
         stripe_subscription_id = "sub_1K77Y5GlVGuVgOrkJrLjRnne"
         stripe_schedule_id = "sub_sched_sch1K77Y5GlVGuVgOrkJrLjRnne"
-        charge = "ch_19yUQN2eZvKYlo2CQf7aWpSX"
         owner = OwnerFactory(
             stripe_subscription_id=stripe_subscription_id,
             plan=plan,
@@ -397,7 +395,7 @@ class StripeServiceTests(TestCase):
         schedule_release_mock.assert_called_once_with(stripe_schedule_id)
         cancel_sub_mock.assert_called_once_with(stripe_subscription_id)
         list_invoice_mock.assert_called_once_with(subscription=stripe_subscription_id, status="paid")
-        create_refund_mock.assert_called_once_with(charge=charge)
+        self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(owner.stripe_customer_id, balance=0)
         modify_sub_mock.assert_not_called()
 
@@ -420,12 +418,10 @@ class StripeServiceTests(TestCase):
     ):
         with open("./services/tests/samples/stripe_invoice.json") as f:
             stripe_invoice_response = json.load(f)
-        stripe_invoice_response["data"] = stripe_invoice_response["data"] * 2
         list_invoice_mock.return_value = stripe_invoice_response
         plan = PlanName.CODECOV_PRO_YEARLY.value
         stripe_subscription_id = "sub_1K77Y5GlVGuVgOrkJrLjRnne"
         stripe_schedule_id = "sub_sched_sch1K77Y5GlVGuVgOrkJrLjRnne"
-        charge = "ch_19yUQN2eZvKYlo2CQf7aWpSX"
         owner = OwnerFactory(
             stripe_subscription_id=stripe_subscription_id,
             plan=plan,
@@ -452,7 +448,7 @@ class StripeServiceTests(TestCase):
         schedule_release_mock.assert_called_once_with(stripe_schedule_id)
         cancel_sub_mock.assert_called_once_with(stripe_subscription_id)
         list_invoice_mock.assert_called_once_with(subscription=stripe_subscription_id, status="paid")
-        create_refund_mock.assert_called_once_with(charge=charge)
+        self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(owner.stripe_customer_id, balance=0)
         modify_sub_mock.assert_not_called()
 

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -446,7 +446,9 @@ class StripeServiceTests(TestCase):
         retrieve_customer_mock.assert_called_once_with(owner.stripe_customer_id)
         cancel_sub_mock.assert_called_once_with(stripe_subscription_id)
         list_invoice_mock.assert_called_once_with(
-            subscription=stripe_subscription_id, status="paid", created={'created.gte': 1458263420, 'created.lt': 1489799420}
+            subscription=stripe_subscription_id,
+            status="paid",
+            created={"created.gte": 1458263420, "created.lt": 1489799420},
         )
         self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(
@@ -519,7 +521,9 @@ class StripeServiceTests(TestCase):
         retrieve_customer_mock.assert_called_once_with(owner.stripe_customer_id)
         cancel_sub_mock.assert_called_once_with(stripe_subscription_id)
         list_invoice_mock.assert_called_once_with(
-            subscription=stripe_subscription_id, status="paid", created={'created.gte': 1458263420, 'created.lt': 1489799420}
+            subscription=stripe_subscription_id,
+            status="paid",
+            created={"created.gte": 1458263420, "created.lt": 1489799420},
         )
         self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -446,7 +446,7 @@ class StripeServiceTests(TestCase):
         retrieve_customer_mock.assert_called_once_with(owner.stripe_customer_id)
         cancel_sub_mock.assert_called_once_with(stripe_subscription_id)
         list_invoice_mock.assert_called_once_with(
-            subscription=stripe_subscription_id, status="paid"
+            subscription=stripe_subscription_id, status="paid", created={'created.gte': 1458263420, 'created.lt': 1489799420}
         )
         self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(
@@ -519,7 +519,7 @@ class StripeServiceTests(TestCase):
         retrieve_customer_mock.assert_called_once_with(owner.stripe_customer_id)
         cancel_sub_mock.assert_called_once_with(stripe_subscription_id)
         list_invoice_mock.assert_called_once_with(
-            subscription=stripe_subscription_id, status="paid"
+            subscription=stripe_subscription_id, status="paid", created={'created.gte': 1458263420, 'created.lt': 1489799420}
         )
         self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Adding auto-refund logic for when a user cancels their subscription within 24 hours (monthly charge) or 72 hours (yearly charge) of the period starting and being charged.

Open to any and all feedback including styling and syntax recommendations as this is one of my first python/codecov-api PRs. Should I wrap Stripe API calls in a try/catch?

### Links to relevant tickets
Closes https://github.com/codecov/engineering-team/issues/2508
- Follows ideas at https://github.com/codecov/engineering-team/issues/1813#issuecomment-2290200974
- Follows https://docs.stripe.com/billing/subscriptions/cancel with https://docs.stripe.com/api/subscriptions/cancel
- Last line of https://docs.stripe.com/billing/subscriptions/cancel#prorate-for-usage-based-billing
  - To [refund your customer](https://support.stripe.com/questions/refunding-credit-balance-to-customer-after-subscription-downgrade-or-cancellation), issue [refunds](https://docs.stripe.com/refunds#issuing) and then [adjust their account balance](https://docs.stripe.com/billing/customer/balance#modifying) back to zero.
- https://support.stripe.com/questions/refunding-credit-balance-to-customer-after-subscription-downgrade-or-cancellation

### What does this PR do?
Our current logic is that when someone cancels, since they have already paid for their current period (either a month or a year), we just "modify" there subscription to cancel at period end. We will still keep this logic for when they cancel out of the grace period but within the grace period, we will cancel immediately and refund them their money.

Doing now:
- grabs the current period's start timestamp and compares it to current time
- checks to see if it is within 1 day if monthly or 3 days if yearly
- if it is, check if they have exceeded their limit of 2 autorefund instances
    - we cancel the current subscription instead of modifying it
- look through the invoices on the subscription from within the last period and create refunds for each that is paid and has a created date before the start of the period
- modify the customer to have a balance of 0
- if not within the grace period or they've exceeded their limit, we modify the subscription to end at period end like we currently do

### Notable change ###
- we are managing the limit of autorefunds through stripe Customer object's metadata field `{"autorefunds_remaining: int"}` as opposed to making a new column in the DB `Owners` table
- this allows anyone with Stripe access to modify for a customer if needed
- Drawback: a bad actor could theoretically keep making new Stripe accounts to get around this and get free Codecov if they cancelled every 3 days as this limit is imposed on a stripe Customer as opposed to a Codecov owner. We will be logging each time an autorefund is fired to get a sense of how often it is happened and if users are dropping down to 0 to decide if this is a problem.