### PR TITLE
feat: Add total slowest test + percent change resolvers in API

### DIFF
--- a/graphql_api/tests/test_test_results_headers.py
+++ b/graphql_api/tests/test_test_results_headers.py
@@ -137,3 +137,30 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             ]
             == 29
         )
+
+    def test_fetch_test_result_slow_tests(self) -> None:
+        query = """
+            query {
+            owner(username: "%s") {
+                    repository(name: "%s") {
+                        ... on Repository {
+                            testAnalytics {
+                                testResultsAggregates {
+                                    totalSlowTests
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username, self.repository.name)
+
+        result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+        assert (
+            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
+                "totalSlowTests"
+            ]
+            == 1
+        )

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -11,6 +11,8 @@ class TestResultsAggregates(TypedDict):
     total_duration_percent_change: float | None
     slowest_tests_duration: float
     slowest_tests_duration_percent_change: float | None
+    total_slow_tests: int
+    total_slow_tests_percent_change: float | None
     fails: int
     fails_percent_change: float | None
     skips: int
@@ -41,6 +43,18 @@ def resolve_slowest_tests_duration_percent_change(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float | None:
     return obj.get("slowest_tests_duration_percent_change")
+
+
+@test_results_aggregates_bindable.field("totalSlowTests")
+def resolve_total_slow_tests(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
+    return obj["total_slow_tests"]
+
+
+@test_results_aggregates_bindable.field("totalSlowTestsPercentChange")
+def resolve_total_slow_tests_percent_change(
+    obj: TestResultsAggregates, _: GraphQLResolveInfo
+) -> float | None:
+    return obj.get("total_slow_tests_percent_change")
 
 
 @test_results_aggregates_bindable.field("totalFails")


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to add resolvers for total_slowest_tests and similar percent change so we can link them up to the failed tests table

Also added related UT

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
