### PR TITLE
bundle analysis: sentry->prometheus metrics for upload view

### DIFF
--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -18,8 +18,8 @@ from timeseries.models import Dataset, MeasurementName
 @pytest.mark.django_db(databases={"default", "timeseries"})
 def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
     upload = mocker.patch.object(TaskService, "upload")
-    mock_sentry_metrics = mocker.patch(
-        "upload.views.bundle_analysis.sentry_metrics.incr"
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
     create_presigned_put = mocker.patch(
         "services.archive.StorageService.create_presigned_put",
@@ -89,9 +89,8 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
         report_code=None,
         report_type="bundle_analysis",
     )
-    mock_sentry_metrics.assert_called_with(
-        "upload",
-        tags={
+    mock_metrics.assert_called_with(
+        **{
             "agent": "cli",
             "version": "0.4.7",
             "action": "bundle_analysis",
@@ -110,6 +109,9 @@ def test_upload_bundle_analysis_org_token(db, client, mocker, mock_redis):
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
     )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
+    )
 
     repository = RepositoryFactory.create()
     org_token = OrganizationLevelTokenFactory.create(owner=repository.author)
@@ -126,6 +128,17 @@ def test_upload_bundle_analysis_org_token(db, client, mocker, mock_redis):
         format="json",
     )
     assert res.status_code == 201
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "unknown-user-agent",
+            "version": "unknown-user-agent",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "repo_visibility": "private",
+            "is_using_shelter": "no",
+            "position": "end",
+        },
+    )
 
 
 @pytest.mark.django_db(databases={"default", "timeseries"})
@@ -134,6 +147,9 @@ def test_upload_bundle_analysis_existing_commit(db, client, mocker, mock_redis):
     mocker.patch(
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
+    )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
 
     repository = RepositoryFactory.create()
@@ -159,6 +175,17 @@ def test_upload_bundle_analysis_existing_commit(db, client, mocker, mock_redis):
         report_code=None,
         report_type="bundle_analysis",
     )
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "unknown-user-agent",
+            "version": "unknown-user-agent",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "repo_visibility": "private",
+            "is_using_shelter": "no",
+            "position": "end",
+        },
+    )
 
 
 def test_upload_bundle_analysis_missing_args(db, client, mocker, mock_redis):
@@ -166,6 +193,9 @@ def test_upload_bundle_analysis_missing_args(db, client, mocker, mock_redis):
     mocker.patch(
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
+    )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
 
     repository = RepositoryFactory.create()
@@ -195,6 +225,16 @@ def test_upload_bundle_analysis_missing_args(db, client, mocker, mock_redis):
     assert res.status_code == 400
     assert res.json() == {"commit": ["This field is required."]}
     assert not upload.called
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "unknown-user-agent",
+            "version": "unknown-user-agent",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "is_using_shelter": "no",
+            "position": "start",
+        },
+    )
 
 
 def test_upload_bundle_analysis_invalid_token(db, client, mocker, mock_redis):
@@ -233,6 +273,9 @@ def test_upload_bundle_analysis_github_oidc_auth(
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
     )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
+    )
     repository = RepositoryFactory()
     mock_jwt_decode.return_value = {
         "repository": f"url/{repository.name}",
@@ -253,6 +296,17 @@ def test_upload_bundle_analysis_github_oidc_auth(
         format="json",
     )
     assert res.status_code == 201
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "unknown-user-agent",
+            "version": "unknown-user-agent",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "repo_visibility": "private",
+            "is_using_shelter": "no",
+            "position": "end",
+        },
+    )
 
 
 @pytest.mark.django_db(databases={"default", "timeseries"})
@@ -260,10 +314,12 @@ def test_upload_bundle_analysis_measurement_datasets_created(
     db, client, mocker, mock_redis
 ):
     mocker.patch.object(TaskService, "upload")
-    mocker.patch("upload.views.bundle_analysis.sentry_metrics.incr")
     mocker.patch(
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
+    )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
 
     repository = RepositoryFactory.create()
@@ -301,6 +357,18 @@ def test_upload_bundle_analysis_measurement_datasets_created(
             repository_id=repository.pk,
         ).exists()
 
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "cli",
+            "version": "0.4.7",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "repo_visibility": "private",
+            "is_using_shelter": "no",
+            "position": "end",
+        },
+    )
+
 
 @override_settings(TIMESERIES_ENABLED=False)
 @pytest.mark.django_db(databases={"default", "timeseries"})
@@ -308,10 +376,12 @@ def test_upload_bundle_analysis_measurement_timeseries_disabled(
     db, client, mocker, mock_redis
 ):
     mocker.patch.object(TaskService, "upload")
-    mocker.patch("upload.views.bundle_analysis.sentry_metrics.incr")
     mocker.patch(
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
+    )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
 
     repository = RepositoryFactory.create()
@@ -349,6 +419,18 @@ def test_upload_bundle_analysis_measurement_timeseries_disabled(
             repository_id=repository.pk,
         ).exists()
 
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "cli",
+            "version": "0.4.7",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "repo_visibility": "private",
+            "is_using_shelter": "no",
+            "position": "end",
+        },
+    )
+
 
 @pytest.mark.django_db(databases={"default", "timeseries"})
 def test_upload_bundle_analysis_no_repo(db, client, mocker, mock_redis):
@@ -357,6 +439,9 @@ def test_upload_bundle_analysis_no_repo(db, client, mocker, mock_redis):
     mocker.patch(
         "services.archive.StorageService.create_presigned_put",
         return_value="test-presigned-put",
+    )
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
 
     repository = RepositoryFactory.create()
@@ -377,10 +462,24 @@ def test_upload_bundle_analysis_no_repo(db, client, mocker, mock_redis):
     assert res.json() == {"detail": "Repository not found."}
     assert not upload.called
 
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "unknown-user-agent",
+            "version": "unknown-user-agent",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "is_using_shelter": "no",
+            "position": "start",
+        },
+    )
+
 
 @pytest.mark.django_db(databases={"default", "timeseries"})
 def test_upload_bundle_analysis_tokenless_success(db, client, mocker, mock_redis):
     upload = mocker.patch.object(TaskService, "upload")
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
+    )
 
     create_presigned_put = mocker.patch(
         "services.archive.StorageService.create_presigned_put",
@@ -416,6 +515,18 @@ def test_upload_bundle_analysis_tokenless_success(db, client, mocker, mock_redis
 
     assert upload.called
     create_presigned_put.assert_called_once_with("bundle-analysis", ANY, 30)
+
+    mock_metrics.assert_called_with(
+        **{
+            "agent": "cli",
+            "version": "0.4.7",
+            "action": "bundle_analysis",
+            "endpoint": "bundle_analysis",
+            "repo_visibility": "public",
+            "is_using_shelter": "no",
+            "position": "end",
+        },
+    )
 
 
 @pytest.mark.django_db(databases={"default", "timeseries"})

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -106,8 +106,8 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
 @override_settings(SHELTER_SHARED_SECRET="shelter-shared-secret")
 def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
     upload = mocker.patch.object(TaskService, "upload")
-    mock_sentry_metrics = mocker.patch(
-        "upload.views.bundle_analysis.sentry_metrics.incr"
+    mock_metrics = mocker.patch(
+        "upload.views.bundle_analysis.BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels"
     )
     create_presigned_put = mocker.patch(
         "services.archive.StorageService.create_presigned_put",
@@ -179,9 +179,8 @@ def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
         report_code=None,
         report_type="bundle_analysis",
     )
-    mock_sentry_metrics.assert_called_with(
-        "upload",
-        tags={
+    mock_metrics.assert_called_with(
+        **{
             "agent": "cli",
             "version": "0.4.7",
             "action": "bundle_analysis",

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -9,8 +9,8 @@ from rest_framework.exceptions import NotAuthenticated, NotFound
 from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from sentry_sdk import metrics as sentry_metrics
 from shared.bundle_analysis.storage import StoragePaths, get_bucket_name
+from shared.metrics import Counter
 
 from codecov_auth.authentication.repo_auth import (
     BundleAnalysisTokenlessAuthentication,
@@ -31,6 +31,21 @@ from upload.views.base import ShelterMixin
 from upload.views.helpers import get_repository_from_string
 
 log = logging.getLogger(__name__)
+
+
+BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER = Counter(
+    "bundle_analysis_upload_views_runs",
+    "Number of times a raw report processor was run and with what result",
+    [
+        "agent",
+        "version",
+        "action",
+        "endpoint",
+        "is_using_shelter",
+        "repo_visibility",
+        "position",
+    ],
+)
 
 
 class UploadBundleAnalysisPermission(BasePermission):
@@ -64,16 +79,15 @@ class BundleAnalysisView(APIView, ShelterMixin):
         return repo_auth_custom_exception_handler
 
     def post(self, request: HttpRequest) -> Response:
-        sentry_metrics.incr(
-            "upload",
-            tags=generate_upload_sentry_metrics_tags(
+        BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels(
+            **generate_upload_sentry_metrics_tags(
                 action="bundle_analysis",
                 endpoint="bundle_analysis",
                 request=self.request,
                 is_shelter_request=self.is_shelter_request(),
                 position="start",
-            ),
-        )
+            )
+        ).inc()
         serializer = UploadSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -148,18 +162,16 @@ class BundleAnalysisView(APIView, ShelterMixin):
                 task_arguments=task_arguments,
             ),
         )
-
-        sentry_metrics.incr(
-            "upload",
-            tags=generate_upload_sentry_metrics_tags(
+        BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER.labels(
+            **generate_upload_sentry_metrics_tags(
                 action="bundle_analysis",
                 endpoint="bundle_analysis",
                 request=self.request,
                 repository=repo,
                 is_shelter_request=self.is_shelter_request(),
                 position="end",
-            ),
-        )
+            )
+        ).inc()
 
         dispatch_upload_task(
             task_arguments,


### PR DESCRIPTION
closes https://github.com/codecov/engineering-team/issues/2654

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
