### PR TITLE
fix: Remove ordering on account organizations list

### DIFF
--- a/graphql_api/helpers/mutation.py
+++ b/graphql_api/helpers/mutation.py
@@ -78,8 +78,6 @@ def require_part_of_org(resolver):
 def require_shared_account_or_part_of_org(resolver):
     def authenticated_resolver(queried_owner, info, *args, **kwargs):
         current_user = info.context["request"].user
-        current_owner = info.context["request"].current_owner
-
         if (
             current_user
             and current_user.is_authenticated
@@ -89,15 +87,7 @@ def require_shared_account_or_part_of_org(resolver):
         ):
             return resolver(queried_owner, info, *args, **kwargs)
 
-        if (
-            not current_user
-            or not current_user.is_authenticated
-            or not current_owner
-            or not current_user_part_of_org(current_owner, queried_owner)
-        ):
-            return None
-
-        return resolver(queried_owner, info, *args, **kwargs)
+        return require_part_of_org(resolver)(queried_owner, info, *args, **kwargs)
 
     return authenticated_resolver
 

--- a/graphql_api/helpers/mutation.py
+++ b/graphql_api/helpers/mutation.py
@@ -75,5 +75,32 @@ def require_part_of_org(resolver):
     return authenticated_resolver
 
 
+def require_shared_account_or_part_of_org(resolver):
+    def authenticated_resolver(queried_owner, info, *args, **kwargs):
+        current_user = info.context["request"].user
+        current_owner = info.context["request"].current_owner
+
+        if (
+            current_user
+            and current_user.is_authenticated
+            and queried_owner
+            and queried_owner.account
+            and current_user in queried_owner.account.users.all()
+        ):
+            return resolver(queried_owner, info, *args, **kwargs)
+
+        if (
+            not current_user
+            or not current_user.is_authenticated
+            or not current_owner
+            or not current_user_part_of_org(current_owner, queried_owner)
+        ):
+            return None
+
+        return resolver(queried_owner, info, *args, **kwargs)
+
+    return authenticated_resolver
+
+
 def resolve_union_error_type(error, *_):
     return error.get_graphql_type()

--- a/graphql_api/tests/test_account.py
+++ b/graphql_api/tests/test_account.py
@@ -126,55 +126,9 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             for node in result["owner"]["account"]["organizations"]["edges"]
         ]
 
-        assert orgs == ["owner-2", "owner-1", "owner-0"]
-
-    def test_fetch_organizations_order_by_activated_users_asc(self) -> None:
-        account = AccountFactory(name="account")
-        owner = OwnerFactory(
-            username="owner-0",
-            plan_activated_users=[],
-            account=account,
-        )
-        OwnerFactory(
-            username="owner-1",
-            plan_activated_users=[0],
-            account=account,
-        )
-        OwnerFactory(
-            username="owner-2",
-            plan_activated_users=[0, 1],
-            account=account,
-        )
-
-        query = """
-            query {
-                owner(username: "%s") {
-                    account {
-                        organizations(first: 20, ordering: ACTIVATED_USERS, orderingDirection: ASC) {
-                            edges {
-                                node {
-                                    username
-                                    activatedUserCount
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        """ % (owner.username)
-
-        result = self.gql_request(query, owner=owner)
-
-        assert "errors" not in result
-
-        orgs = [
-            node["node"]["username"]
-            for node in result["owner"]["account"]["organizations"]["edges"]
-        ]
-
         assert orgs == ["owner-0", "owner-1", "owner-2"]
 
-    def test_fetch_organizations_order_by_name(self) -> None:
+    def test_fetch_organizations_desc(self) -> None:
         account = AccountFactory(name="account")
         owner = OwnerFactory(
             username="owner-0",
@@ -196,7 +150,7 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             query {
                 owner(username: "%s") {
                     account {
-                        organizations(first: 20, ordering: NAME) {
+                        organizations(first: 20, orderingDirection: DESC) {
                             edges {
                                 node {
                                     username
@@ -219,52 +173,6 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
         ]
 
         assert orgs == ["owner-2", "owner-1", "owner-0"]
-
-    def test_fetch_organizations_order_by_name_asc(self) -> None:
-        account = AccountFactory(name="account")
-        owner = OwnerFactory(
-            username="owner-0",
-            plan_activated_users=[],
-            account=account,
-        )
-        OwnerFactory(
-            username="owner-1",
-            plan_activated_users=[0],
-            account=account,
-        )
-        OwnerFactory(
-            username="owner-2",
-            plan_activated_users=[0, 1],
-            account=account,
-        )
-
-        query = """
-            query {
-                owner(username: "%s") {
-                    account {
-                        organizations(first: 20, ordering: NAME, orderingDirection: ASC) {
-                            edges {
-                                node {
-                                    username
-                                    activatedUserCount
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        """ % (owner.username)
-
-        result = self.gql_request(query, owner=owner)
-
-        assert "errors" not in result
-
-        orgs = [
-            node["node"]["username"]
-            for node in result["owner"]["account"]["organizations"]["edges"]
-        ]
-
-        assert orgs == ["owner-0", "owner-1", "owner-2"]
 
     def test_fetch_organizations_pagination(self) -> None:
         account = AccountFactory(name="account")
@@ -318,7 +226,7 @@ class AccountTestCase(GraphQLTestHelper, TransactionTestCase):
             for node in result["owner"]["account"]["organizations"]["edges"]
         ]
 
-        assert orgs == ["owner-2", "owner-1"]
+        assert orgs == ["owner-0", "owner-1"]
 
         hasNextPage = result["owner"]["account"]["organizations"]["pageInfo"][
             "hasNextPage"

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -7,7 +7,10 @@ from django.utils import timezone
 from freezegun import freeze_time
 from graphql import GraphQLError
 from prometheus_client import REGISTRY
-from shared.django_apps.codecov_auth.tests.factories import OktaSettingsFactory
+from shared.django_apps.codecov_auth.tests.factories import (
+    AccountsUsersFactory,
+    OktaSettingsFactory,
+)
 from shared.django_apps.reports.models import ReportType
 from shared.upload.utils import UploaderType, insert_coverage_measurement
 
@@ -1027,3 +1030,23 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         """ % (owner.username)
         data = self.gql_request(query, owner=user)
         assert data["owner"]["activatedUserCount"] is None
+
+    def test_fetch_activated_user_count_when_not_in_org_but_has_shared_account(self):
+        owner = OwnerFactory(username="sample-user")
+        AccountsUsersFactory(user=owner.user, account=self.account)
+        user2 = OwnerFactory(username="sample-user-2")
+        user3 = OwnerFactory(username="sample-user-3")
+        owner = OwnerFactory(
+            username="sample-org",
+            plan_activated_users=[user2.ownerid, user3.ownerid],
+            account=self.account,
+        )
+
+        query = """{
+            owner(username: "%s") {
+                activatedUserCount
+            }
+        }
+        """ % (owner.username)
+        data = self.gql_request(query, owner=owner)
+        assert data["owner"]["activatedUserCount"] == 2

--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -1036,7 +1036,7 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         AccountsUsersFactory(user=owner.user, account=self.account)
         user2 = OwnerFactory(username="sample-user-2")
         user3 = OwnerFactory(username="sample-user-3")
-        owner = OwnerFactory(
+        other_owner = OwnerFactory(
             username="sample-org",
             plan_activated_users=[user2.ownerid, user3.ownerid],
             account=self.account,
@@ -1047,6 +1047,6 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
                 activatedUserCount
             }
         }
-        """ % (owner.username)
+        """ % (other_owner.username)
         data = self.gql_request(query, owner=owner)
         assert data["owner"]["activatedUserCount"] == 2

--- a/graphql_api/types/account/account.graphql
+++ b/graphql_api/types/account/account.graphql
@@ -4,7 +4,6 @@ type Account {
   totalSeatCount: Int!
   activatedUserCount: Int!
   organizations(
-    ordering: AccountOrganizationOrdering
     orderingDirection: OrderingDirection
     first: Int
     after: String

--- a/graphql_api/types/account/account.py
+++ b/graphql_api/types/account/account.py
@@ -8,7 +8,7 @@ from graphql_api.helpers.connection import (
     build_connection_graphql,
     queryset_to_connection,
 )
-from graphql_api.types.enums.enums import AccountOrganizationOrdering, OrderingDirection
+from graphql_api.types.enums.enums import OrderingDirection
 
 account = ariadne_load_local_graphql(__file__, "account.graphql")
 account = account + build_connection_graphql("AccountOrganizationConnection", "Owner")
@@ -43,13 +43,12 @@ def resolve_activated_user_count(account: Account, info: GraphQLResolveInfo) -> 
 def resolve_organizations(
     account: Account,
     info: GraphQLResolveInfo,
-    ordering=AccountOrganizationOrdering.ACTIVATED_USERS,
-    ordering_direction=OrderingDirection.DESC,
+    ordering_direction=OrderingDirection.ASC,
     **kwargs,
 ):
     return queryset_to_connection(
         account.organizations,
-        ordering=(ordering,),
+        ordering=("username",),
         ordering_direction=ordering_direction,
         **kwargs,
     )

--- a/graphql_api/types/enums/account_organization_ordering.graphql
+++ b/graphql_api/types/enums/account_organization_ordering.graphql
@@ -1,4 +1,0 @@
-enum AccountOrganizationOrdering {
-  NAME
-  ACTIVATED_USERS
-}

--- a/graphql_api/types/enums/enum_types.py
+++ b/graphql_api/types/enums/enum_types.py
@@ -11,7 +11,6 @@ from timeseries.models import Interval as MeasurementInterval
 from timeseries.models import MeasurementName
 
 from .enums import (
-    AccountOrganizationOrdering,
     AssetOrdering,
     BundleLoadTypes,
     CoverageLine,
@@ -57,5 +56,4 @@ enum_types = [
     EnumType("TestResultsOrderingParameter", TestResultsOrderingParameter),
     EnumType("TestResultsFilterParameter", TestResultsFilterParameter),
     EnumType("AssetOrdering", AssetOrdering),
-    EnumType("AccountOrganizationOrdering", AccountOrganizationOrdering),
 ]

--- a/graphql_api/types/enums/enums.py
+++ b/graphql_api/types/enums/enums.py
@@ -41,11 +41,6 @@ class RepositoryOrdering(enum.Enum):
     NAME = "name"
 
 
-class AccountOrganizationOrdering(enum.Enum):
-    NAME = "username"
-    ACTIVATED_USERS = "plan_activated_users"
-
-
 class OrderingDirection(enum.Enum):
     ASC = "ascending"
     DESC = "descending"

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -29,7 +29,10 @@ from graphql_api.helpers.connection import (
     build_connection_graphql,
     queryset_to_connection,
 )
-from graphql_api.helpers.mutation import require_part_of_org
+from graphql_api.helpers.mutation import (
+    require_part_of_org,
+    require_shared_account_or_part_of_org,
+)
 from graphql_api.types.enums import OrderingDirection, RepositoryOrdering
 from graphql_api.types.errors.errors import NotFoundError, OwnerNotActivatedError
 from plan.constants import FREE_PLAN_REPRESENTATIONS, PlanData, PlanName
@@ -377,6 +380,6 @@ def resolve_upload_token_required(owner: Owner, info) -> bool | None:
 
 @owner_bindable.field("activatedUserCount")
 @sync_to_async
-@require_part_of_org
+@require_shared_account_or_part_of_org
 def resolve_activated_user_count(owner: Owner, info: GraphQLResolveInfo) -> int:
     return owner.activated_user_count


### PR DESCRIPTION
Removes the ordering argument on the account organizations list because it turns out that the paginator can't handle/isn't intended to do sorting by count of a field. Was throwing errors.

Additionally, adds a new resolver decorator to allow users of an account to see the activatedUserCount of orgs in that same account. This was a necessary change to support the desired UI, otherwise we'd only show activated user counts for orgs that the user is a member of.
