### PR TITLE
feat: Use env var for GQL rate limit instead of hard code val

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -92,12 +92,19 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "codecov.wsgi.application"
 
-# Database
-# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
+
+# GraphQL
 
 GRAPHQL_QUERY_COST_THRESHOLD = get_config(
     "setup", "graphql", "query_cost_threshold", default=10000
 )
+
+GRAPHQL_RATE_LIMIT_VALUE = get_config(
+    "setup", "graphql", "rate_limit_value", default=300
+)
+
+# Database
+# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
 DATABASE_ROUTERS = ["codecov.db.DatabaseRouter"]
 

--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -99,9 +99,11 @@ GRAPHQL_QUERY_COST_THRESHOLD = get_config(
     "setup", "graphql", "query_cost_threshold", default=10000
 )
 
-GRAPHQL_RATE_LIMIT_VALUE = get_config(
-    "setup", "graphql", "rate_limit_value", default=300
+GRAPHQL_RATE_LIMIT_ENABLED = get_config(
+    "setup", "graphql", "rate_limit_enabled", default=True
 )
+
+GRAPHQL_RATE_LIMIT_RPM = get_config("setup", "graphql", "rate_limit_rpm", default=300)
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases

--- a/codecov/settings_staging.py
+++ b/codecov/settings_staging.py
@@ -65,6 +65,10 @@ CORS_ALLOWED_ORIGINS = [
 # 25MB in bytes
 DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
 
+GRAPHQL_RATE_LIMIT_VALUE = get_config(
+    "setup", "graphql", "rate_limit_value", default=1000
+)
+
 # Same site is set to none on Staging as we want to be able to call the API
 # From Netlify preview deploy
 COOKIE_SAME_SITE = "None"

--- a/codecov/settings_staging.py
+++ b/codecov/settings_staging.py
@@ -65,9 +65,7 @@ CORS_ALLOWED_ORIGINS = [
 # 25MB in bytes
 DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
 
-GRAPHQL_RATE_LIMIT_VALUE = get_config(
-    "setup", "graphql", "rate_limit_value", default=1000
-)
+GRAPHQL_RATE_LIMIT_RPM = get_config("setup", "graphql", "rate_limit_rpm", default=1000)
 
 # Same site is set to none on Staging as we want to be able to call the API
 # From Netlify preview deploy

--- a/graphql_api/tests/test_views.py
+++ b/graphql_api/tests/test_views.py
@@ -203,6 +203,7 @@ class AriadneViewTestCase(GraphQLTestHelper, TestCase):
 
     @patch("sentry_sdk.metrics.incr")
     @patch("graphql_api.views.AsyncGraphqlView._check_ratelimit")
+    @override_settings(DEBUG=False, GRAPHQL_RATE_LIMIT_VALUE=1000)
     async def test_when_rate_limit_reached(
         self, mocked_check_ratelimit, mocked_sentry_incr
     ):
@@ -213,7 +214,7 @@ class AriadneViewTestCase(GraphQLTestHelper, TestCase):
         assert response["status"] == 429
         assert (
             response["detail"]
-            == "It looks like you've hit the rate limit of 300 req/min. Try again later."
+            == "It looks like you've hit the rate limit of 1000 req/min. Try again later."
         )
 
         expected_calls = [

--- a/graphql_api/views.py
+++ b/graphql_api/views.py
@@ -233,7 +233,7 @@ class AsyncGraphqlView(GraphQLAsyncView):
             return JsonResponse(
                 data={
                     "status": 429,
-                    "detail": f"It looks like you've hit the rate limit of {settings.GRAPHQL_RATE_LIMIT_VALUE} req/min. Try again later.",
+                    "detail": f"It looks like you've hit the rate limit of {settings.GRAPHQL_RATE_LIMIT_RPM} req/min. Try again later.",
                 },
                 status=429,
             )
@@ -306,6 +306,9 @@ class AsyncGraphqlView(GraphQLAsyncView):
             request.user.pk
 
     def _check_ratelimit(self, request):
+        if not settings.GRAPHQL_RATE_LIMIT_ENABLED:
+            return False
+
         redis = get_redis_connection()
 
         try:
@@ -320,7 +323,7 @@ class AsyncGraphqlView(GraphQLAsyncView):
             user_ip = self.get_client_ip(request)
             key = f"rl-ip:{user_ip}"
 
-        limit = settings.GRAPHQL_RATE_LIMIT_VALUE
+        limit = settings.GRAPHQL_RATE_LIMIT_RPM
         window = 60  # in seconds
 
         current_count = redis.get(key)

--- a/graphql_api/views.py
+++ b/graphql_api/views.py
@@ -233,7 +233,7 @@ class AsyncGraphqlView(GraphQLAsyncView):
             return JsonResponse(
                 data={
                     "status": 429,
-                    "detail": "It looks like you've hit the rate limit of 300 req/min. Try again later.",
+                    "detail": f"It looks like you've hit the rate limit of {settings.GRAPHQL_RATE_LIMIT_VALUE} req/min. Try again later.",
                 },
                 status=429,
             )
@@ -320,7 +320,7 @@ class AsyncGraphqlView(GraphQLAsyncView):
             user_ip = self.get_client_ip(request)
             key = f"rl-ip:{user_ip}"
 
-        limit = 300
+        limit = settings.GRAPHQL_RATE_LIMIT_VALUE
         window = 60  # in seconds
 
         current_count = redis.get(key)


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to move the hard coded gql rate limit value to an env variable that can be set per environment

In the same PR I've updated the staging limit to be 1000 from 300

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
