### PR TITLE
Remove usage of `ReportDetails`/`files_array`

### DIFF
--- a/graphql_api/actions/commits.py
+++ b/graphql_api/actions/commits.py
@@ -80,13 +80,12 @@ def commit_status(
 def repo_commits(
     repository: Repository, filters: Optional[dict] = None
 ) -> QuerySet[Commit]:
-    # prefetch the CommitReport with the ReportLevelTotals and ReportDetails
+    # prefetch the CommitReport with the ReportLevelTotals
     prefetch = Prefetch(
         "reports",
         queryset=CommitReport.objects.coverage_reports()
         .filter(code=None)
-        .select_related("reportleveltotals", "reportdetails")
-        .defer("reportdetails___files_array"),
+        .select_related("reportleveltotals"),
     )
 
     # We don't select the `report` column here b/c it can be many MBs of JSON

--- a/graphql_api/dataloader/commit.py
+++ b/graphql_api/dataloader/commit.py
@@ -16,16 +16,15 @@ class CommitLoader(BaseLoader):
         super().__init__(info, *args, **kwargs)
 
     def batch_queryset(self, keys):
-        # We don't select the `report` or `files_array` columns here b/c then can be
+        # We don't select the `report` column here b/c then can be
         # very large JSON blobs and cause performance issues
 
-        # prefetch the CommitReport with the ReportLevelTotals and ReportDetails
+        # prefetch the CommitReport with the ReportLevelTotals
         prefetch = Prefetch(
             "reports",
             queryset=CommitReport.objects.coverage_reports()
             .filter(code=None)
-            .select_related("reportleveltotals", "reportdetails")
-            .defer("reportdetails___files_array"),
+            .select_related("reportleveltotals"),
         )
 
         return (

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -21,7 +21,7 @@ from shared.utils.merge import LineType, line_type
 
 from compare.models import CommitComparison
 from core.models import Commit
-from reports.models import CommitReport, ReportDetails
+from reports.models import CommitReport
 from services import ServiceException
 from services.redis_configuration import get_redis_connection
 from services.repo_providers import RepoProviderService
@@ -1208,18 +1208,6 @@ class CommitComparisonService:
         if self._last_updated_before(self.base_commit.updatestamp):
             return True
 
-        compare_commit_details = self._commit_report_details(self.compare_commit)
-        if compare_commit_details is not None and self._last_updated_before(
-            compare_commit_details.updated_at
-        ):
-            return True
-
-        base_commit_details = self._commit_report_details(self.base_commit)
-        if base_commit_details is not None and self._last_updated_before(
-            base_commit_details.updated_at
-        ):
-            return True
-
         return False
 
     def _last_updated_before(self, timestamp: datetime) -> bool:
@@ -1237,22 +1225,10 @@ class CommitComparisonService:
 
         return timezone.normalize(self.commit_comparison.updated_at) < timestamp
 
-    def _commit_report_details(self, commit: Commit) -> Optional[ReportDetails]:
-        # CommitDetails records are updated by the worker every time a new upload is processed.
-        # We can use the `updated_at` timestamp as a proxy for when a report was last updated.
-        # These are expected to have been preloaded.
-        if hasattr(commit, "commitreport") and hasattr(
-            commit.commitreport, "reportdetails"
-        ):
-            return commit.commitreport.reportdetails
-
     def _load_commit(self, commit_id: int) -> Optional[Commit]:
         prefetch = Prefetch(
             "reports",
-            queryset=CommitReport.objects.coverage_reports()
-            .filter(code=None)
-            .select_related("reportdetails")
-            .defer("reportdetails___files_array"),
+            queryset=CommitReport.objects.coverage_reports().filter(code=None),
         )
         return (
             Commit.objects.filter(pk=commit_id)

--- a/services/tests/test_comparison.py
+++ b/services/tests/test_comparison.py
@@ -23,7 +23,6 @@ from shared.utils.merge import LineType
 from compare.models import CommitComparison
 from compare.tests.factories import CommitComparisonFactory
 from core.models import Commit
-from reports.models import ReportDetails
 from reports.tests.factories import CommitReportFactory
 from services.comparison import (
     CommitComparisonService,
@@ -1792,14 +1791,6 @@ class CommitComparisonTests(TestCase):
         self.compare_commit = CommitFactory(updatestamp=datetime(2023, 1, 1))
         self.base_commit_report = CommitReportFactory(commit=self.base_commit)
         self.compare_commit_report = CommitReportFactory(commit=self.compare_commit)
-        self.base_report_details = ReportDetails.objects.create(
-            report_id=self.base_commit_report.id,
-            _files_array=[],
-        )
-        self.compare_report_details = ReportDetails.objects.create(
-            report_id=self.compare_commit_report.id,
-            _files_array=[],
-        )
         self.commit_comparison = CommitComparisonFactory(
             base_commit=self.base_commit,
             compare_commit=self.compare_commit,
@@ -1836,30 +1827,6 @@ class CommitComparisonTests(TestCase):
 
         self.compare_commit.updatestamp = datetime(2023, 1, 2)
         self.compare_commit.save()
-
-        commit_comparison = CommitComparison.objects.get(pk=self.commit_comparison.pk)
-        service = CommitComparisonService(commit_comparison)
-
-        assert service.needs_recompute() == True
-
-    def test_stale_base_report_details(self):
-        # base report details were updated after comparison was made
-        self.commit_comparison.updated_at = datetime(2021, 1, 1, tzinfo=pytz.utc)
-        self.commit_comparison.save()
-        self.base_report_details.updated_at = datetime(2023, 1, 2, tzinfo=pytz.utc)
-        self.base_report_details.save()
-
-        commit_comparison = CommitComparison.objects.get(pk=self.commit_comparison.pk)
-        service = CommitComparisonService(commit_comparison)
-
-        assert service.needs_recompute() == True
-
-    def test_stale_compare_report_details(self):
-        # compare report details were updated after comparison was made
-        self.commit_comparison.updated_at = datetime(2021, 1, 1, tzinfo=pytz.utc)
-        self.commit_comparison.save()
-        self.compare_report_details.updated_at = datetime(2023, 1, 2, tzinfo=pytz.utc)
-        self.compare_report_details.save()
 
         commit_comparison = CommitComparison.objects.get(pk=self.commit_comparison.pk)
         service = CommitComparisonService(commit_comparison)


### PR DESCRIPTION
This removes all usage of `ReportDetails`. The base definitions still exist.