### PR TITLE
bundle analysis: fix unknown asset size compute

### DIFF
--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -295,9 +295,17 @@ def resolve_bundle_report_measurements(
     )
 
     # All measureable names we need to fetch to compute the requested asset types
-    if not asset_types or ASSET_TYPE_UNKNOWN in asset_types:
+    if not asset_types:
         measurables_to_fetch = [
             item for item in list(BundleAnalysisMeasurementsAssetType)
+        ]
+    elif ASSET_TYPE_UNKNOWN in asset_types:
+        measurables_to_fetch = [
+            BundleAnalysisMeasurementsAssetType.REPORT_SIZE,
+            BundleAnalysisMeasurementsAssetType.JAVASCRIPT_SIZE,
+            BundleAnalysisMeasurementsAssetType.STYLESHEET_SIZE,
+            BundleAnalysisMeasurementsAssetType.FONT_SIZE,
+            BundleAnalysisMeasurementsAssetType.IMAGE_SIZE,
         ]
     else:
         measurables_to_fetch = [


### PR DESCRIPTION
If looking to get unknown asset type in the filters only retrieve the necessary known asset types to compute it
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
