### PR TITLE
Add generous amounts of tracing throughout the repo

### DIFF
--- a/api/shared/repo/repository_accessors.py
+++ b/api/shared/repo/repository_accessors.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from asgiref.sync import async_to_sync
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
@@ -30,6 +31,7 @@ class RepoAccessors:
             RepoProviderService().get_adapter(owner=user, repo=repo).get_authenticated
         )()
 
+    @sentry_sdk.trace
     def get_repo_details(
         self, user, repo_name, repo_owner_username, repo_owner_service
     ):

--- a/graphql_api/actions/repository.py
+++ b/graphql_api/actions/repository.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+import sentry_sdk
 from django.db.models import QuerySet
 from shared.django_apps.codecov_auth.models import Owner
 from shared.django_apps.core.models import Repository
@@ -30,6 +31,7 @@ def apply_filters_to_queryset(queryset, filters: dict[str, Any]) -> QuerySet:
     return queryset
 
 
+@sentry_sdk.trace
 def list_repository_for_owner(
     current_owner: Owner,
     owner: Owner,
@@ -50,6 +52,7 @@ def list_repository_for_owner(
     return queryset
 
 
+@sentry_sdk.trace
 def search_repos(
     current_owner: Owner,
     filters: dict[str, Any] | None,

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Dict, List, Mapping, Optional, Union
 
+import sentry_sdk
 from ariadne import ObjectType, convert_kwargs_to_snake_case
 from graphql import GraphQLResolveInfo
 
@@ -136,6 +137,7 @@ def resolve_modules(
     return bundle_asset.modules
 
 
+@sentry_sdk.trace
 @bundle_asset_bindable.field("measurements")
 @convert_kwargs_to_snake_case
 @sync_to_async
@@ -178,6 +180,7 @@ def resolve_assets(
     return list(bundle_report.assets())
 
 
+@sentry_sdk.trace
 @bundle_report_bindable.field("assetsPaginated")
 def resolve_assets_paginated(
     bundle_report: BundleReport,
@@ -272,6 +275,7 @@ def resolve_bundle_report_filtered(
     )
 
 
+@sentry_sdk.trace
 @bundle_report_bindable.field("measurements")
 @convert_kwargs_to_snake_case
 @sync_to_async

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -104,6 +104,7 @@ def resolve_list_uploads(commit: Commit, info, **kwargs):
     )
 
 
+@sentry_sdk.trace
 @commit_bindable.field("compareWithParent")
 async def resolve_compare_with_parent(commit: Commit, info, **kwargs):
     if not commit.parent_commit_id:
@@ -273,6 +274,7 @@ def resolve_commit_bundle_analysis(commit, info):
 ### Commit Coverage Bindable ###
 
 
+@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("totals")
 def resolve_coverage_totals(
     commit: Commit, info: GraphQLResolveInfo
@@ -281,12 +283,14 @@ def resolve_coverage_totals(
     return command.fetch_totals(commit)
 
 
+@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("flagNames")
 @sync_to_async
 def resolve_coverage_flags(commit: Commit, info: GraphQLResolveInfo) -> List[str]:
     return commit.full_report.flags.keys()
 
 
+@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("coverageFile")
 @sync_to_async
 def resolve_coverage_file(commit, info, path, flags=None, components=None):
@@ -315,6 +319,7 @@ def resolve_coverage_file(commit, info, path, flags=None, components=None):
     }
 
 
+@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("components")
 @sync_to_async
 def resolve_coverage_components(commit: Commit, info, filters=None) -> List[Component]:
@@ -333,6 +338,7 @@ def resolve_coverage_components(commit: Commit, info, filters=None) -> List[Comp
 ### Commit Bundle Analysis Bindable ###
 
 
+@sentry_sdk.trace
 @commit_bundle_analysis_bindable.field("bundleAnalysisCompareWithParent")
 @sync_to_async
 def resolve_commit_bundle_analysis_compare_with_parent(
@@ -361,6 +367,7 @@ def resolve_commit_bundle_analysis_compare_with_parent(
     return bundle_analysis_comparison
 
 
+@sentry_sdk.trace
 @commit_bundle_analysis_bindable.field("bundleAnalysisReport")
 @sync_to_async
 def resolve_commit_bundle_analysis_report(commit: Commit, info) -> BundleAnalysisReport:

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -155,6 +155,7 @@ async def resolve_head_totals(
         return head_commit.commitreport.reportleveltotals
 
 
+@sentry_sdk.trace
 @comparison_bindable.field("patchTotals")
 def resolve_patch_totals(
     comparison: ComparisonReport, info: GraphQLResolveInfo
@@ -172,6 +173,7 @@ def resolve_patch_totals(
     return {**totals, "coverage": coverage}
 
 
+@sentry_sdk.trace
 @comparison_bindable.field("flagComparisons")
 @sync_to_async
 def resolve_flag_comparisons(
@@ -190,6 +192,7 @@ def resolve_flag_comparisons(
     return list(all_flags)
 
 
+@sentry_sdk.trace
 @comparison_bindable.field("componentComparisons")
 @sync_to_async
 def resolve_component_comparisons(

--- a/graphql_api/types/coverage_analytics/coverage_analytics.py
+++ b/graphql_api/types/coverage_analytics/coverage_analytics.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Iterable, List, Mapping, Optional, Union
 
+import sentry_sdk
 from ariadne import ObjectType, UnionType
 from django.conf import settings
 from django.forms.utils import from_current_timezone
@@ -52,6 +53,7 @@ def resolve_coverage_analytics_result_type(
     return None
 
 
+@sentry_sdk.trace
 @coverage_analytics_bindable.field("percentCovered")
 def resolve_percent_covered(
     parent: CoverageAnalyticsProps, info: GraphQLResolveInfo
@@ -116,6 +118,7 @@ async def resolve_measurements(
     return measurements
 
 
+@sentry_sdk.trace
 @coverage_analytics_bindable.field("components")
 @sync_to_async
 def resolve_components_measurements(
@@ -250,6 +253,7 @@ def resolve_components_count(
     return len(repo_yaml_components)
 
 
+@sentry_sdk.trace
 @coverage_analytics_bindable.field("flags")
 @sync_to_async
 def resolve_flags(

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -131,6 +131,7 @@ def resolve_misses_count(impacted_file: ImpactedFile, info) -> int:
     return impacted_file.misses_count
 
 
+@sentry_sdk.trace
 @impacted_file_bindable.field("isCriticalFile")
 @sync_to_async
 def resolve_is_critical_file(impacted_file: ImpactedFile, info) -> bool:

--- a/graphql_api/types/pull/pull.py
+++ b/graphql_api/types/pull/pull.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional, Union
 
+import sentry_sdk
 from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
@@ -58,6 +59,7 @@ def is_first_pull_request(pull: Pull) -> bool:
     return pull.repository.pull_requests.order_by("id").first() == pull
 
 
+@sentry_sdk.trace
 @pull_bindable.field("compareWithBase")
 async def resolve_compare_with_base(
     pull: Pull, info: GraphQLResolveInfo, **kwargs: Any
@@ -88,6 +90,7 @@ async def resolve_compare_with_base(
         return ComparisonReport(commit_comparison)
 
 
+@sentry_sdk.trace
 @pull_bindable.field("bundleAnalysisCompareWithBase")
 @sync_to_async
 def resolve_bundle_analysis_compare_with_base(

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+import sentry_sdk
 from django.utils.functional import cached_property
 from shared.bundle_analysis import AssetReport as SharedAssetReport
 from shared.bundle_analysis import (
@@ -29,6 +30,7 @@ from timeseries.helpers import fill_sparse_measurements
 from timeseries.models import Interval, MeasurementName
 
 
+@sentry_sdk.trace
 def load_report(
     commit: Commit, report_code: Optional[str] = None
 ) -> Optional[SharedBundleAnalysisReport]:
@@ -397,6 +399,7 @@ class BundleAnalysisMeasurementsService(object):
         self.before = before
         self.branch = branch
 
+    @sentry_sdk.trace
     def _compute_measurements(
         self, measurable_name: str, measurable_ids: List[str]
     ) -> Dict[int, List[Dict[str, Any]]]:
@@ -437,6 +440,7 @@ class BundleAnalysisMeasurementsService(object):
 
         return all_measurements
 
+    @sentry_sdk.trace
     def compute_asset(
         self, asset_report: AssetReport
     ) -> Optional[BundleAnalysisMeasurementData]:
@@ -458,6 +462,7 @@ class BundleAnalysisMeasurementsService(object):
             before=self.before,
         )
 
+    @sentry_sdk.trace
     def compute_report(
         self,
         bundle_report: BundleReport,

--- a/timeseries/helpers.py
+++ b/timeseries/helpers.py
@@ -2,6 +2,7 @@ import math
 from datetime import datetime, timedelta
 from typing import Iterable, List, Optional
 
+import sentry_sdk
 from django.conf import settings
 from django.db import connections
 from django.db.models import (
@@ -38,6 +39,7 @@ interval_deltas = {
 }
 
 
+@sentry_sdk.trace
 def refresh_measurement_summaries(start_date: datetime, end_date: datetime) -> None:
     """
     Refresh the measurement summaries for the given time range.
@@ -55,6 +57,7 @@ def refresh_measurement_summaries(start_date: datetime, end_date: datetime) -> N
             cursor.execute(sql)
 
 
+@sentry_sdk.trace
 def aggregate_measurements(
     queryset: QuerySet, group_by: Iterable[str] = None
 ) -> QuerySet:
@@ -99,6 +102,7 @@ def _filter_repos(
     return queryset
 
 
+@sentry_sdk.trace
 def coverage_measurements(
     interval: Interval,
     start_date: Optional[datetime] = None,
@@ -190,6 +194,7 @@ def aligned_start_date(interval: Interval, date: datetime) -> datetime:
     return aligning_date + (intervals_before * delta)
 
 
+@sentry_sdk.trace
 def fill_sparse_measurements(
     measurements: Iterable[dict],
     interval: Interval,
@@ -254,6 +259,7 @@ def fill_sparse_measurements(
     return intervals
 
 
+@sentry_sdk.trace
 def coverage_fallback_query(
     interval: Interval,
     start_date: Optional[datetime] = None,
@@ -321,6 +327,7 @@ def _commits_coverage(
     )
 
 
+@sentry_sdk.trace
 def repository_coverage_measurements_with_fallback(
     repository: Repository,
     interval: Interval,
@@ -371,6 +378,7 @@ def repository_coverage_measurements_with_fallback(
         )
 
 
+@sentry_sdk.trace
 def owner_coverage_measurements_with_fallback(
     owner: Owner,
     repo_ids: Iterable[str],


### PR DESCRIPTION
Preemptively add Sentry traces at likely/possible chokepoints so that when we have an issue to debug why things are slow it would increase the chances that we already have traces for it.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
