### PR TITLE
fix: add UTC time to API logs

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -197,7 +197,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "standard": {
-            "format": "%(message)s %(utctime)s %(name)s %(levelname)s %(lineno)s %(pathname)s %(funcName)s %(threadName)s",
+            "format": "%(message)s %(asctime)s %(name)s %(levelname)s %(lineno)s %(pathname)s %(funcName)s %(threadName)s",
             "class": "utils.logging_configuration.CustomLocalJsonFormatter",
         },
         "json": {

--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -197,7 +197,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "standard": {
-            "format": "%(message)s %(asctime)s %(name)s %(levelname)s %(lineno)s %(pathname)s %(funcName)s %(threadName)s",
+            "format": "%(message)s %(utctime)s %(name)s %(levelname)s %(lineno)s %(pathname)s %(funcName)s %(threadName)s",
             "class": "utils.logging_configuration.CustomLocalJsonFormatter",
         },
         "json": {

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -9,6 +9,9 @@ class BaseLogger(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
+        log_record.get("asctime")
+        log_record['asctime'] = 'meow'
+
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string
         data = json.loads(json_str)

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -9,7 +9,8 @@ class BaseLogger(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
-        log_record["utctime"] = "meow"
+        log_record["asctime"] = "meowasc"
+        log_record["utctime"] = "meowutc"
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -9,8 +9,7 @@ class BaseLogger(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
-        log_record.get("asctime")
-        log_record["asctime"] = "meow"
+        log_record["utctime"] = "meow"
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -9,7 +9,10 @@ class BaseLogger(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
-        log_record["utctime"] = log_record.get('asctime')
+        asctime_format = '%Y-%m-%d %H:%M:%S,%f'
+        asctime = datetime.strptime(log_record.get('asctime'), asctime_format)
+
+        log_record["utctime"] = asctime.isoformat()
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -7,7 +7,7 @@ from sentry_sdk import get_current_span
 
 
 class BaseLogger(JsonFormatter):
-    def add_fields(self, log_record, record, message_dict): -> None
+    def add_fields(self, log_record, record, message_dict):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
         asctime_format = "%Y-%m-%d %H:%M:%S,%f"

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -9,8 +9,7 @@ class BaseLogger(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
-        log_record["asctime"] = "meowasc"
-        log_record["utctime"] = "meowutc"
+        log_record["utctime"] = log_record.get('asctime')
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from logging import Filter
 
 from pythonjsonlogger.jsonlogger import JsonFormatter
@@ -6,11 +7,11 @@ from sentry_sdk import get_current_span
 
 
 class BaseLogger(JsonFormatter):
-    def add_fields(self, log_record, record, message_dict):
+    def add_fields(self, log_record, record, message_dict): -> None
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
-        asctime_format = '%Y-%m-%d %H:%M:%S,%f'
-        asctime = datetime.strptime(log_record.get('asctime'), asctime_format)
+        asctime_format = "%Y-%m-%d %H:%M:%S,%f"
+        asctime = datetime.strptime(log_record.get("asctime"), asctime_format)
 
         log_record["utctime"] = asctime.isoformat()
 

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -10,7 +10,7 @@ class BaseLogger(JsonFormatter):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
         log_record.get("asctime")
-        log_record['asctime'] = 'meow'
+        log_record["asctime"] = "meow"
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -13,6 +13,7 @@ class BaseLogger(JsonFormatter):
         asctime = datetime.strptime(log_record.get('asctime'), asctime_format)
 
         log_record["utctime"] = asctime.isoformat()
+        log_record["utctime2"] = asctime.isoformat()
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/utils/logging_configuration.py
+++ b/utils/logging_configuration.py
@@ -13,7 +13,6 @@ class BaseLogger(JsonFormatter):
         asctime = datetime.strptime(log_record.get('asctime'), asctime_format)
 
         log_record["utctime"] = asctime.isoformat()
-        log_record["utctime2"] = asctime.isoformat()
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string


### PR DESCRIPTION
### Purpose/Motivation
For security, we need to add in RFC3339 timestamps to API logs

### Links to relevant tickets
https://github.com/codecov/infrastructure-team/issues/388

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
