### PR TITLE
fix: make test analytics GQL queries use gte

### DIFF
--- a/graphql_api/tests/test_flake_aggregates.py
+++ b/graphql_api/tests/test_flake_aggregates.py
@@ -79,8 +79,8 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert result["owner"]["repository"]["testAnalytics"]["flakeAggregates"] == {
-            "flakeRate": 0.1,
-            "flakeCount": 30,
-            "flakeRatePercentChange": -33.33333,
-            "flakeCountPercentChange": 100.0,
+            "flakeRate": 0.140625,
+            "flakeCount": 31,
+            "flakeRatePercentChange": 31.25,
+            "flakeCountPercentChange": 106.66667,
         }

--- a/graphql_api/tests/test_test_analytics.py
+++ b/graphql_api/tests/test_test_analytics.py
@@ -819,14 +819,14 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
             """testResultsAggregates { totalDuration, slowestTestsDuration, totalFails, totalSkips, totalSlowTests, totalDurationPercentChange, slowestTestsDurationPercentChange, totalFailsPercentChange, totalSkipsPercentChange, totalSlowTestsPercentChange }""",
         )
         assert res["testResultsAggregates"] == {
-            "totalDuration": 570.0,
-            "totalDurationPercentChange": -63.1068,
-            "slowestTestsDuration": 29.0,
-            "slowestTestsDurationPercentChange": -50.84746,
-            "totalFails": 10,
-            "totalFailsPercentChange": 100.0,
-            "totalSkips": 5,
-            "totalSkipsPercentChange": -50.0,
+            "totalDuration": 630.0,
+            "totalDurationPercentChange": -57.57576,
+            "slowestTestsDuration": 60.0,
+            "slowestTestsDurationPercentChange": 1.69492,
+            "totalFails": 11,
+            "totalFailsPercentChange": 175.0,
+            "totalSkips": 6,
+            "totalSkipsPercentChange": -33.33333,
             "totalSlowTests": 1,
             "totalSlowTestsPercentChange": 0.0,
         }
@@ -976,10 +976,10 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
         )
 
         assert res["flakeAggregates"] == {
-            "flakeCount": 2,
-            "flakeRate": 0.125,
-            "flakeCountPercentChange": -33.33333,
-            "flakeRatePercentChange": -50.0,
+            "flakeCount": 3,
+            "flakeRate": 0.2,
+            "flakeCountPercentChange": 0.0,
+            "flakeRatePercentChange": -15.55556,
         }
 
     def test_flake_aggregates_no_history(self) -> None:
@@ -1081,9 +1081,9 @@ class TestAnalyticsTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert res["flakeAggregates"] == {
             "flakeCount": 1,
-            "flakeRate": 0.125,
+            "flakeRate": 0.1111111111111111,
             "flakeCountPercentChange": -50.0,
-            "flakeRatePercentChange": -43.75,
+            "flakeRatePercentChange": -55.55556,
         }
 
     def test_test_suites(self) -> None:

--- a/graphql_api/tests/test_test_results_headers.py
+++ b/graphql_api/tests/test_test_results_headers.py
@@ -53,7 +53,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "totalDuration"
             ]
-            == 435.0
+            == 465.0
         )
 
     def test_fetch_test_result_slowest_tests_runtime(self) -> None:
@@ -80,7 +80,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "slowestTestsDuration"
             ]
-            == 29.0
+            == 30.0
         )
 
     def test_fetch_test_result_failed_tests(self) -> None:
@@ -107,7 +107,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "totalFails"
             ]
-            == 29
+            == 30
         )
 
     def test_fetch_test_result_skipped_tests(self) -> None:
@@ -134,7 +134,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
                 "totalSkips"
             ]
-            == 29
+            == 30
         )
 
     def test_fetch_test_result_slow_tests(self) -> None:


### PR DESCRIPTION
we want to include the last day of the interval when we fetch test results and calculate aggregates.

we also want to remove the interval
date from the calculation of the percent changes.
