### PR TITLE
fix(test_analytics): handle null ordering parameter

### DIFF
--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -15,6 +15,7 @@ from utils.test_results import (
     generate_test_results_aggregates,
     get_flags,
     get_test_suites,
+    OrderingParameter,
 )
 
 log = logging.getLogger(__name__)
@@ -46,10 +47,12 @@ async def resolve_test_results(
     )
 
     queryset = await sync_to_async(generate_test_results)(
-        ordering=ordering.get("parameter").value if ordering else "avg_duration",
-        ordering_direction=(
-            ordering.get("direction").name if ordering else OrderingDirection.DESC.name
-        ),
+        ordering_param=OrderingParameter(
+            ordering=ordering.get("parameter").value,
+            ordering_direction=ordering.get("direction").name,
+        )
+        if ordering
+        else None,
         repoid=repository.repoid,
         interval=interval,
         first=first,

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -274,9 +274,16 @@ def search_base_query(
         row_is_greater = row_value_str > cursor_value_str
         row_is_less = row_value_str < cursor_value_str
         if descending:
-            return row_is_less - row_is_greater
+            res = row_is_less - row_is_greater
         else:
-            return row_is_greater - row_is_less
+            res = row_is_greater - row_is_less
+
+        if res == 0:
+            row_is_greater = row.name > cursor.name
+            row_is_less = row.name < cursor.name
+            res = row_is_greater - row_is_less
+
+        return res
 
     left, right = 0, len(rows) - 1
     while left <= right:
@@ -284,12 +291,7 @@ def search_base_query(
         comparison = compare(rows[mid])
 
         if comparison == 0:
-            if rows[mid].name == cursor.name:
-                return rows[mid + 1 :]
-            elif rows[mid].name < cursor.name:
-                left = mid + 1
-            else:
-                right = mid - 1
+            return rows[mid + 1 :]
         elif comparison < 0:
             left = mid + 1
         else:


### PR DESCRIPTION
when we receive a testResults GQL request with no ordering parameter
we want the default to be ordered by name ascending
