### PR TITLE
chore: Dedupe kwargs snake case decorator

### DIFF
--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Dict, List, Mapping, Optional, Union
 
 import sentry_sdk
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
 from codecov.commands.exceptions import ValidationError
@@ -139,7 +139,6 @@ def resolve_modules(
 
 @sentry_sdk.trace
 @bundle_asset_bindable.field("measurements")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_asset_report_measurements(
     bundle_asset: AssetReport,
@@ -277,7 +276,6 @@ def resolve_bundle_report_filtered(
 
 @sentry_sdk.trace
 @bundle_report_bindable.field("measurements")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_bundle_report_measurements(
     bundle_report: BundleReport,

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Union
 import sentry_sdk
 import shared.reports.api_report_service as report_service
 import yaml
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 from shared.reports.api_report_service import ReadOnlyReport
 from shared.reports.filtered import FilteredReportFile
@@ -84,7 +84,6 @@ async def resolve_yaml(commit: Commit, info) -> dict:
 
 
 @commit_bindable.field("yamlState")
-@convert_kwargs_to_snake_case
 async def resolve_yaml_state(commit: Commit, info) -> YamlStates:
     command = info.context["executor"].get_command("commit")
     final_yaml = await command.get_final_yaml(commit)
@@ -149,7 +148,6 @@ def resolve_critical_files(commit: Commit, info, **kwargs) -> List[CriticalFile]
 
 @sentry_sdk.trace
 @commit_bindable.field("pathContents")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
     """

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -2,7 +2,7 @@ from asyncio import gather
 from typing import List, Optional
 
 import sentry_sdk
-from ariadne import ObjectType, UnionType, convert_kwargs_to_snake_case
+from ariadne import ObjectType, UnionType
 from graphql.type.definition import GraphQLResolveInfo
 
 import services.components as components_service
@@ -36,7 +36,6 @@ def resolve_state(comparison: ComparisonReport, info: GraphQLResolveInfo) -> str
 
 
 @comparison_bindable.field("impactedFiles")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_impacted_files(
     comparison_report: ComparisonReport, info: GraphQLResolveInfo, filters=None

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -2,7 +2,7 @@ import hashlib
 from typing import List, Union
 
 import sentry_sdk
-from ariadne import ObjectType, UnionType, convert_kwargs_to_snake_case
+from ariadne import ObjectType, UnionType
 from shared.reports.types import ReportTotals
 from shared.torngit.exceptions import TorngitClientError
 
@@ -67,7 +67,6 @@ def resolve_hashed_path(impacted_file: ImpactedFile, info) -> str:
 @sentry_sdk.trace
 @impacted_file_bindable.field("segments")
 @sync_to_async
-@convert_kwargs_to_snake_case
 def resolve_segments(
     impacted_file: ImpactedFile, info, filters=None
 ) -> Union[UnknownPath, ProviderError, SegmentComparisons]:

--- a/graphql_api/types/line_comparison/line_comparison.py
+++ b/graphql_api/types/line_comparison/line_comparison.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 from typing import List, Optional
 
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from shared.utils.merge import LineType
 
 from graphql_api.types.enums import CoverageLine
@@ -72,7 +72,6 @@ def resolve_content(line_comparison: LineComparison, info) -> str:
 
 
 @line_comparison_bindable.field("coverageInfo")
-@convert_kwargs_to_snake_case
 def resolve_coverage_info(
     line_comparison: LineComparison,
     info,

--- a/graphql_api/types/me/me.py
+++ b/graphql_api/types/me/me.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
 from codecov.db import sync_to_async
@@ -41,7 +41,6 @@ def resolve_owner(user, _):
 
 
 @me_bindable.field("viewableRepositories")
-@convert_kwargs_to_snake_case
 def resolve_viewable_repositories(
     current_user,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/mutation/delete_component_measurements/delete_component_measurements.py
+++ b/graphql_api/types/mutation/delete_component_measurements/delete_component_measurements.py
@@ -1,4 +1,4 @@
-from ariadne import UnionType, convert_kwargs_to_snake_case
+from ariadne import UnionType
 
 from codecov.db import sync_to_async
 from core.commands.component import ComponentCommands
@@ -9,7 +9,6 @@ from graphql_api.helpers.mutation import (
 
 
 @wrap_error_handling_mutation
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_delete_component_measurements(_, info, input):
     command: ComponentCommands = info.context["executor"].get_command("component")

--- a/graphql_api/types/mutation/delete_flag/delete_flag.py
+++ b/graphql_api/types/mutation/delete_flag/delete_flag.py
@@ -1,4 +1,4 @@
-from ariadne import UnionType, convert_kwargs_to_snake_case
+from ariadne import UnionType
 
 from codecov.db import sync_to_async
 from core.commands.flag import FlagCommands
@@ -9,7 +9,6 @@ from graphql_api.helpers.mutation import (
 
 
 @wrap_error_handling_mutation
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_delete_flag(_, info, input):
     command: FlagCommands = info.context["executor"].get_command("flag")

--- a/graphql_api/types/mutation/onboard_user/onboard_user.py
+++ b/graphql_api/types/mutation/onboard_user/onboard_user.py
@@ -1,4 +1,4 @@
-from ariadne import UnionType, convert_kwargs_to_snake_case
+from ariadne import UnionType
 
 from graphql_api.helpers.mutation import (
     resolve_union_error_type,
@@ -7,7 +7,6 @@ from graphql_api.helpers.mutation import (
 
 
 @wrap_error_handling_mutation
-@convert_kwargs_to_snake_case
 async def resolve_onboard_user(_, info, input):
     command = info.context["executor"].get_command("owner")
     input["goals"] = [goal.value for goal in input.get("goals", [])]

--- a/graphql_api/types/mutation/regenerate_repository_token/regenerate_repository_token.py
+++ b/graphql_api/types/mutation/regenerate_repository_token/regenerate_repository_token.py
@@ -1,4 +1,4 @@
-from ariadne import UnionType, convert_kwargs_to_snake_case
+from ariadne import UnionType
 
 from graphql_api.helpers.mutation import (
     require_authenticated,
@@ -9,7 +9,6 @@ from graphql_api.helpers.mutation import (
 
 @wrap_error_handling_mutation
 @require_authenticated
-@convert_kwargs_to_snake_case
 async def resolve_regenerate_repository_token(_, info, input):
     command = info.context["executor"].get_command("repository")
 

--- a/graphql_api/types/mutation/save_okta_config/save_okta_config.py
+++ b/graphql_api/types/mutation/save_okta_config/save_okta_config.py
@@ -1,4 +1,4 @@
-from ariadne import UnionType, convert_kwargs_to_snake_case
+from ariadne import UnionType
 
 from graphql_api.helpers.mutation import (
     require_authenticated,
@@ -9,7 +9,6 @@ from graphql_api.helpers.mutation import (
 
 @wrap_error_handling_mutation
 @require_authenticated
-@convert_kwargs_to_snake_case
 async def resolve_save_okta_config(_, info, input):
     command = info.context["executor"].get_command("owner")
     return await command.save_okta_config(input)

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, List, Optional
 import shared.rate_limits as rate_limits
 import stripe
 import yaml
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
 
 import services.activation as activation
@@ -53,7 +53,6 @@ AI_FEATURES_GH_APP_ID = get_config("github", "ai_features_app_id")
 
 
 @owner_bindable.field("repositories")
-@convert_kwargs_to_snake_case
 def resolve_repositories(
     owner: Owner,
     info: GraphQLResolveInfo,
@@ -108,7 +107,6 @@ def resolve_plan(owner: Owner, info: GraphQLResolveInfo) -> PlanService:
 
 
 @owner_bindable.field("pretrialPlan")
-@convert_kwargs_to_snake_case
 @require_part_of_org
 def resolve_plan_representation(owner: Owner, info: GraphQLResolveInfo) -> PlanData:
     info.context["plan_service"] = PlanService(current_org=owner)
@@ -116,7 +114,6 @@ def resolve_plan_representation(owner: Owner, info: GraphQLResolveInfo) -> PlanD
 
 
 @owner_bindable.field("availablePlans")
-@convert_kwargs_to_snake_case
 @require_part_of_org
 def resolve_available_plans(owner: Owner, info: GraphQLResolveInfo) -> List[PlanData]:
     plan_service = PlanService(current_org=owner)
@@ -223,7 +220,6 @@ def resolve_org_default_org_username(
 
 @owner_bindable.field("measurements")
 @sync_to_async
-@convert_kwargs_to_snake_case
 def resolve_measurements(
     owner: Owner,
     info: GraphQLResolveInfo,
@@ -313,7 +309,6 @@ def resolve_is_github_rate_limited(
 
 @owner_bindable.field("invoice")
 @require_part_of_org
-@convert_kwargs_to_snake_case
 def resolve_owner_invoice(
     owner: Owner,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/plan/plan.py
+++ b/graphql_api/types/plan/plan.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 
 from codecov.db import sync_to_async
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
@@ -15,39 +15,33 @@ plan_bindable = ObjectType("Plan")
 
 
 @plan_bindable.field("trialStartDate")
-@convert_kwargs_to_snake_case
 def resolve_trial_start_date(plan_service: PlanService, info) -> Optional[datetime]:
     return plan_service.trial_start_date
 
 
 @plan_bindable.field("trialTotalDays")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_trial_total_days(plan_service: PlanService, info) -> Optional[int]:
     return plan_service.trial_total_days
 
 
 @plan_bindable.field("trialEndDate")
-@convert_kwargs_to_snake_case
 def resolve_trial_end_date(plan_service: PlanService, info) -> Optional[datetime]:
     return plan_service.trial_end_date
 
 
 @plan_bindable.field("trialStatus")
-@convert_kwargs_to_snake_case
 def resolve_trial_status(plan_service: PlanService, info) -> TrialStatus:
     return TrialStatus(plan_service.trial_status)
 
 
 @plan_bindable.field("marketingName")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_marketing_name(plan_service: PlanService, info) -> str:
     return plan_service.marketing_name
 
 
 @plan_bindable.field("planName")
-@convert_kwargs_to_snake_case
 def resolve_plan_name(plan_service: PlanService, info) -> str:
     return plan_service.plan_name
 
@@ -58,21 +52,18 @@ def resolve_plan_name_as_value(plan_service: PlanService, info) -> str:
 
 
 @plan_bindable.field("tierName")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_tier_name(plan_service: PlanService, info) -> str:
     return plan_service.tier_name
 
 
 @plan_bindable.field("billingRate")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_billing_rate(plan_service: PlanService, info) -> Optional[str]:
     return plan_service.billing_rate
 
 
 @plan_bindable.field("baseUnitPrice")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_base_unit_price(plan_service: PlanService, info) -> int:
     return plan_service.base_unit_price
@@ -85,7 +76,6 @@ def resolve_benefits(plan_service: PlanService, info) -> List[str]:
 
 
 @plan_bindable.field("pretrialUsersCount")
-@convert_kwargs_to_snake_case
 def resolve_pretrial_users_count(plan_service: PlanService, info) -> Optional[int]:
     if plan_service.is_org_trialing:
         return plan_service.pretrial_users_count
@@ -93,21 +83,18 @@ def resolve_pretrial_users_count(plan_service: PlanService, info) -> Optional[in
 
 
 @plan_bindable.field("monthlyUploadLimit")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_monthly_uploads_limit(plan_service: PlanService, info) -> Optional[int]:
     return plan_service.monthly_uploads_limit
 
 
 @plan_bindable.field("planUserCount")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_plan_user_count(plan_service: PlanService, info) -> int:
     return plan_service.plan_user_count
 
 
 @plan_bindable.field("hasSeatsLeft")
-@convert_kwargs_to_snake_case
 @sync_to_async
 def resolve_has_seats_left(plan_service: PlanService, info) -> bool:
     return plan_service.has_seats_left

--- a/graphql_api/types/plan_representation/plan_representation.py
+++ b/graphql_api/types/plan_representation/plan_representation.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from ariadne import ObjectType, convert_kwargs_to_snake_case
+from ariadne import ObjectType
 
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 from plan.constants import PlanData
@@ -13,13 +13,11 @@ plan_representation_bindable = ObjectType("PlanRepresentation")
 
 
 @plan_representation_bindable.field("marketingName")
-@convert_kwargs_to_snake_case
 def resolve_marketing_name(plan_data: PlanData, info) -> str:
     return plan_data.marketing_name
 
 
 @plan_representation_bindable.field("planName")
-@convert_kwargs_to_snake_case
 def resolve_plan_name(plan_data: PlanData, info) -> str:
     return plan_data.value
 
@@ -30,13 +28,11 @@ def resolve_plan_value(plan_data: PlanData, info) -> str:
 
 
 @plan_representation_bindable.field("billingRate")
-@convert_kwargs_to_snake_case
 def resolve_billing_rate(plan_data: PlanData, info) -> Optional[str]:
     return plan_data.billing_rate
 
 
 @plan_representation_bindable.field("baseUnitPrice")
-@convert_kwargs_to_snake_case
 def resolve_base_unit_price(plan_data: PlanData, info) -> int:
     return plan_data.base_unit_price
 
@@ -58,6 +54,5 @@ def resolve_benefits(plan_data: PlanData, info) -> List[str]:
 
 
 @plan_representation_bindable.field("monthlyUploadLimit")
-@convert_kwargs_to_snake_case
 def resolve_monthly_uploads_limit(plan_data: PlanData, info) -> Optional[int]:
     return plan_data.monthly_uploads_limit

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import shared.rate_limits as rate_limits
 import yaml
-from ariadne import ObjectType, UnionType, convert_kwargs_to_snake_case
+from ariadne import ObjectType, UnionType
 from graphql.type.definition import GraphQLResolveInfo
 
 from codecov.db import sync_to_async
@@ -79,7 +79,6 @@ def resolve_pull(repository: Repository, info: GraphQLResolveInfo, id):
 
 
 @repository_bindable.field("pulls")
-@convert_kwargs_to_snake_case
 async def resolve_pulls(
     repository: Repository,
     info: GraphQLResolveInfo,
@@ -98,7 +97,6 @@ async def resolve_pulls(
 
 
 @repository_bindable.field("commits")
-@convert_kwargs_to_snake_case
 async def resolve_commits(
     repository: Repository, info: GraphQLResolveInfo, filters=None, **kwargs
 ):
@@ -120,7 +118,6 @@ async def resolve_commits(
 
 
 @repository_bindable.field("branches")
-@convert_kwargs_to_snake_case
 async def resolve_branches(
     repository: Repository, info: GraphQLResolveInfo, filters=None, **kwargs
 ):


### PR DESCRIPTION
This other [PR](https://github.com/codecov/codecov-api/pull/610) deprecated the snake case fallback resolver in favor of ariadne's `convert_names_case` option. 

> The default object case behavior is deprecated: [snake case fallback resolver](https://ariadnegraphql.org/docs/api-reference#snake_case_fallback_resolvers)
Ariadne calls out [convert_names_case](https://ariadnegraphql.org/docs/api-reference#make_executable_schema) as the new correct way to convert case names

This PR is a follow-up clean-up to remove the since-duplicated instances of the snake case decorator.

Tested by smoke testing on staging and confirming no regression in these graphql queries

Closes https://github.com/codecov/engineering-team/issues/1879
Closes https://github.com/codecov/engineering-team/issues/2757 (duplicate)