### PR TITLE
chore: Bump Django version to 4.2.16

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ ariadne_django
 celery>=5.3.6
 cerberus
 ddtrace
-Django>=4.2.15
+Django>=4.2.16
 django-cors-headers
 django-csp
 django-dynamic-fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ deprecated==1.2.12
     # via opentelemetry-api
 distlib==0.3.1
     # via virtualenv
-django==4.2.15
+django==4.2.16
     # via
     #   -r requirements.in
     #   ariadne-django
@@ -205,8 +205,6 @@ googleapis-common-protos[grpc]==1.59.1
     #   grpcio-status
 graphql-core==3.2.3
     # via ariadne
-greenlet==3.1.1
-    # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
 grpcio==1.62.1


### PR DESCRIPTION
### Purpose/Motivation

This PR bumps our django version from 4.2.15 -> 4.2.16.[ Changlog here](https://docs.djangoproject.com/en/5.1/releases/4.2.16/)

No breaking changes with this update.

Closes https://github.com/codecov/internal-issues/issues/906

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
