### PR TITLE
chore: Bump ariadne and starlette versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 aiodataloader
-ariadne
-ariadne_django
+ariadne==0.23
+ariadne_django==0.3.0
 celery>=5.3.6
 cerberus
 ddtrace
@@ -49,6 +49,7 @@ sentry-sdk>=2.13.0
 sentry-sdk[celery]
 setproctitle
 simplejson
+starlette==0.40.0
 stripe>=9.6.0
 urllib3>=1.26.19
 vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,11 +18,11 @@ anyio==3.6.1
     #   starlette
 appdirs==1.4.4
     # via virtualenv
-ariadne==0.19.1
+ariadne==0.23.0
     # via
     #   -r requirements.in
     #   ariadne-django
-ariadne-django==0.2.0
+ariadne-django==0.3.0
     # via -r requirements.in
 asgiref==3.6.0
     # via django
@@ -177,7 +177,6 @@ freezegun==1.1.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-storage
@@ -409,9 +408,7 @@ requests==2.32.3
     #   shared
     #   stripe
 rfc3986[idna2008]==1.4.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -450,8 +447,10 @@ sqlparse==0.5.0
     # via
     #   ddtrace
     #   django
-starlette==0.36.2
-    # via ariadne
+starlette==0.40.0
+    # via
+    #   -r requirements.in
+    #   ariadne
 stripe==9.6.0
     # via -r requirements.in
 text-unidecode==1.3


### PR DESCRIPTION
### Purpose/Motivation

Bumps starlette version from 0.36.2 -> 0.40.0  [Changelog](https://github.com/encode/starlette/releases)
Bumps ariadne from 0.19.1 -> 0.23.0 [Changelog](https://github.com/mirumee/ariadne/releases)
Bumps ariadne-django from 0.2.0 -> 0.3.0 [Changelog](https://github.com/mirumee/ariadne-django/releases)

None of these version bumps look to have any breaking changes, ran API locally and confirmed GQL requests are still coming in properly (Screenshot below)

### Links to relevant tickets

Closes https://github.com/codecov/internal-issues/issues/923

<img width="1078" alt="Screenshot 2024-10-28 at 12 10 05 PM" src="https://github.com/user-attachments/assets/f473e7f8-b0ae-485e-bc26-7b0787c6ed30">


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
