### PR TITLE
 Add tests for handling anon users for token GQL resolvers 

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -729,6 +729,42 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
         assert data["owner"]["repository"]["uploadToken"] == TOKEN_UNAVAILABLE
 
     @override_settings(HIDE_ALL_CODECOV_TOKENS=True)
+    def test_repo_upload_token_not_available_config_setting_owner_is_anonymous(self):
+        owner = OwnerFactory(service="gitlab")
+
+        repo = RepositoryFactory(
+            author=owner,
+            author__service="gitlab",
+            service_id=12345,
+            active=True,
+            private=False
+        )
+
+        query = """
+            query {
+                owner(username: "%s") {
+                    repository(name: "%s") {
+                                ... on Repository {
+                            uploadToken
+                        }
+                    }
+                }
+            }
+        """ % (
+            owner.username,
+            repo.name,
+        )
+
+        data = self.gql_request(
+            query,
+            variables={"name": repo.name},
+            provider="gitlab",
+        )
+
+        assert data["owner"]["repository"]["uploadToken"] == TOKEN_UNAVAILABLE
+
+
+    @override_settings(HIDE_ALL_CODECOV_TOKENS=True)
     def test_repo_upload_token_not_available_config_setting_owner_is_admin(self):
         owner = OwnerFactory(service="gitlab")
         repo = RepositoryFactory(

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -210,10 +210,7 @@ def resolve_org_upload_token(
     should_hide_tokens = settings.HIDE_ALL_CODECOV_TOKENS
     current_owner = info.context["request"].current_owner
     command = info.context["executor"].get_command("owner")
-    if not current_owner:
-        is_owner_admin = False
-    else:
-        is_owner_admin = current_owner.is_admin(owner)
+    is_owner_admin = current_owner.is_admin(owner)
     if should_hide_tokens and not is_owner_admin:
         return TOKEN_UNAVAILABLE
 


### PR DESCRIPTION
Following up from 
https://github.com/codecov/codecov-api/pull/930

The check on the owner type is not required since the resolver already has an `require_part_of_org` decorator 