### PR TITLE
refactor: test results GQL endpoints

### DIFF
--- a/graphql_api/tests/test_test_result.py
+++ b/graphql_api/tests/test_test_result.py
@@ -50,34 +50,6 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
             flaky_fail_count=1,
         )
 
-    def test_fetch_test_result_name(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
-                                            name
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][
-            0
-        ]["node"]["name"] == self.test.name.replace("\x1f", " ")
-
     def test_fetch_test_result_name_with_computed_name(self) -> None:
         self.test.computed_name = "Computed Name"
         self.test.save()
@@ -92,161 +64,15 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                                     edges {
                                         node {
                                             name
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["name"]
-            == self.test.computed_name
-        )
-
-    def test_fetch_test_result_updated_at(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
                                             updatedAt
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["updatedAt"]
-            == datetime.now(UTC).isoformat()
-        )
-
-    def test_fetch_test_result_commits_failed(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
                                             commitsFailed
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["commitsFailed"]
-            == 3
-        )
-
-    def test_fetch_test_result_failure_rate(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
                                             failureRate
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["failureRate"]
-            == 0.75
-        )
-
-    def test_fetch_test_result_last_duration(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
                                             lastDuration
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["lastDuration"]
-            == 1.0
-        )
-
-    def test_fetch_test_result_avg_duration(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
                                             avgDuration
+                                            totalFailCount
+                                            totalSkipCount
+                                            totalPassCount
+                                            totalFlakyFailCount
                                         }
                                     }
                                 }
@@ -262,128 +88,15 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
         assert "errors" not in result
         assert result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][
             0
-        ]["node"]["avgDuration"] == (5.6 / 3)
-
-    def test_fetch_test_result_total_fail_count(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
-                                            totalFailCount
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["totalFailCount"]
-            == 9
-        )
-
-    def test_fetch_test_result_total_skip_count(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
-                                            totalSkipCount
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["totalSkipCount"]
-            == 6
-        )
-
-    def test_fetch_test_result_total_pass_count(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
-                                            totalPassCount
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["totalPassCount"]
-            == 3
-        )
-
-    def test_fetch_test_result_total_flaky_fail_count(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResults {
-                                    edges {
-                                        node {
-                                            totalFlakyFailCount
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResults"]["edges"][0][
-                "node"
-            ]["totalFlakyFailCount"]
-            == 2
-        )
+        ]["node"] == {
+            "name": self.test.computed_name,
+            "updatedAt": datetime.now(UTC).isoformat(),
+            "commitsFailed": 3,
+            "failureRate": 0.75,
+            "lastDuration": 1.0,
+            "avgDuration": (5.6 / 3),
+            "totalFailCount": 9,
+            "totalSkipCount": 6,
+            "totalPassCount": 3,
+            "totalFlakyFailCount": 2,
+        }

--- a/graphql_api/tests/test_test_results_headers.py
+++ b/graphql_api/tests/test_test_results_headers.py
@@ -29,7 +29,7 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                 branch="main",
             )
 
-    def test_fetch_test_result_total_runtime(self) -> None:
+    def test_fetch_test_result_aggregates(self) -> None:
         query = """
             query {
                owner(username: "%s") {
@@ -38,119 +38,15 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
                             testAnalytics {
                                 testResultsAggregates {
                                     totalDuration
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
-                "totalDuration"
-            ]
-            == 465.0
-        )
-
-    def test_fetch_test_result_slowest_tests_runtime(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResultsAggregates {
                                     slowestTestsDuration
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
-                "slowestTestsDuration"
-            ]
-            == 30.0
-        )
-
-    def test_fetch_test_result_failed_tests(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResultsAggregates {
                                     totalFails
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
-                "totalFails"
-            ]
-            == 30
-        )
-
-    def test_fetch_test_result_skipped_tests(self) -> None:
-        query = """
-            query {
-               owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResultsAggregates {
                                     totalSkips
-                                }
-                            }
-                        }
-                    }
-                 }
-            }
-        """ % (self.owner.username, self.repository.name)
-
-        result = self.gql_request(query, owner=self.owner)
-
-        assert "errors" not in result
-        assert (
-            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
-                "totalSkips"
-            ]
-            == 30
-        )
-
-    def test_fetch_test_result_slow_tests(self) -> None:
-        query = """
-            query {
-            owner(username: "%s") {
-                    repository(name: "%s") {
-                        ... on Repository {
-                            testAnalytics {
-                                testResultsAggregates {
                                     totalSlowTests
                                 }
                             }
                         }
                     }
-                }
+                 }
             }
         """ % (self.owner.username, self.repository.name)
 
@@ -158,8 +54,16 @@ class TestResultTestCase(GraphQLTestHelper, TransactionTestCase):
 
         assert "errors" not in result
         assert (
-            result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"][
-                "totalSlowTests"
-            ]
-            == 1
+            result["owner"]["repository"]["testAnalytics"] is not None
+            and result["owner"]["repository"]["testAnalytics"]["testResultsAggregates"]
+            is not None
         )
+        assert result["owner"]["repository"]["testAnalytics"][
+            "testResultsAggregates"
+        ] == {
+            "totalDuration": 465.0,
+            "slowestTestsDuration": 30.0,
+            "totalFails": 30,
+            "totalSkips": 30,
+            "totalSlowTests": 1,
+        }

--- a/graphql_api/types/flake_aggregates/flake_aggregates.py
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.py
@@ -1,37 +1,30 @@
-from typing import TypedDict
-
 from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
+
+from utils.test_results import FlakeAggregates
 
 flake_aggregates_bindable = ObjectType("FlakeAggregates")
 
 
-class FlakeAggregate(TypedDict):
-    flake_count: int
-    flake_count_percent_change: float | None
-    flake_rate: float
-    flake_rate_percent_change: float | None
-
-
 @flake_aggregates_bindable.field("flakeCount")
-def resolve_flake_count(obj: FlakeAggregate, _: GraphQLResolveInfo) -> int:
-    return obj["flake_count"]
+def resolve_flake_count(obj: FlakeAggregates, _: GraphQLResolveInfo) -> int:
+    return obj.flake_count
 
 
 @flake_aggregates_bindable.field("flakeCountPercentChange")
 def resolve_flake_count_percent_change(
-    obj: FlakeAggregate, _: GraphQLResolveInfo
+    obj: FlakeAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("flake_count_percent_change")
+    return obj.flake_count_percent_change
 
 
 @flake_aggregates_bindable.field("flakeRate")
-def resolve_flake_rate(obj: FlakeAggregate, _: GraphQLResolveInfo) -> float:
-    return obj["flake_rate"]
+def resolve_flake_rate(obj: FlakeAggregates, _: GraphQLResolveInfo) -> float:
+    return obj.flake_rate
 
 
 @flake_aggregates_bindable.field("flakeRatePercentChange")
 def resolve_flake_rate_percent_change(
-    obj: FlakeAggregate, _: GraphQLResolveInfo
+    obj: FlakeAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("flake_rate_percent_change")
+    return obj.flake_rate_percent_change

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -1,81 +1,68 @@
-from typing import TypedDict
-
 from ariadne import ObjectType
 from graphql import GraphQLResolveInfo
+
+from utils.test_results import TestResultsAggregates
 
 test_results_aggregates_bindable = ObjectType("TestResultsAggregates")
 
 
-class TestResultsAggregates(TypedDict):
-    total_duration: float
-    total_duration_percent_change: float | None
-    slowest_tests_duration: float
-    slowest_tests_duration_percent_change: float | None
-    total_slow_tests: int
-    total_slow_tests_percent_change: float | None
-    fails: int
-    fails_percent_change: float | None
-    skips: int
-    skips_percent_change: float | None
-
-
 @test_results_aggregates_bindable.field("totalDuration")
 def resolve_total_duration(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> float:
-    return obj["total_duration"]
+    return obj.total_duration
 
 
 @test_results_aggregates_bindable.field("totalDurationPercentChange")
 def resolve_total_duration_percent_change(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("total_duration_percent_change")
+    return obj.total_duration_percent_change
 
 
 @test_results_aggregates_bindable.field("slowestTestsDuration")
 def resolve_slowest_tests_duration(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float:
-    return obj["slowest_tests_duration"]
+    return obj.slowest_tests_duration
 
 
 @test_results_aggregates_bindable.field("slowestTestsDurationPercentChange")
 def resolve_slowest_tests_duration_percent_change(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("slowest_tests_duration_percent_change")
+    return obj.slowest_tests_duration_percent_change
 
 
 @test_results_aggregates_bindable.field("totalSlowTests")
 def resolve_total_slow_tests(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
-    return obj["total_slow_tests"]
+    return obj.total_slow_tests
 
 
 @test_results_aggregates_bindable.field("totalSlowTestsPercentChange")
 def resolve_total_slow_tests_percent_change(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("total_slow_tests_percent_change")
+    return obj.total_slow_tests_percent_change
 
 
 @test_results_aggregates_bindable.field("totalFails")
 def resolve_total_fails(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
-    return obj["fails"]
+    return obj.fails
 
 
 @test_results_aggregates_bindable.field("totalFailsPercentChange")
 def resolve_total_fails_percent_change(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("fails_percent_change")
+    return obj.fails_percent_change
 
 
 @test_results_aggregates_bindable.field("totalSkips")
 def resolve_total_skips(obj: TestResultsAggregates, _: GraphQLResolveInfo) -> int:
-    return obj["skips"]
+    return obj.skips
 
 
 @test_results_aggregates_bindable.field("totalSkipsPercentChange")
 def resolve_total_skips_percent_change(
     obj: TestResultsAggregates, _: GraphQLResolveInfo
 ) -> float | None:
-    return obj.get("skips_percent_change")
+    return obj.skips_percent_change

--- a/utils/tests/unit/test_cursor.py
+++ b/utils/tests/unit/test_cursor.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from graphql_api.types.enums.enums import TestResultsOrderingParameter
 from utils.test_results import CursorValue, TestResultsRow, decode_cursor, encode_cursor
 
 
@@ -18,7 +19,7 @@ def test_cursor():
         total_skip_count=1,
         total_pass_count=1,
     )
-    cursor = encode_cursor(row, "updated_at")
+    cursor = encode_cursor(row, TestResultsOrderingParameter.UPDATED_AT)
     assert cursor == "MjAyNC0wMS0wMSAwMDowMDowMCswMDowMHx0ZXN0"
     decoded_cursor = decode_cursor(cursor)
     assert decoded_cursor == CursorValue(str(row.updated_at), "test")

--- a/utils/tests/unit/test_search_base_query.py
+++ b/utils/tests/unit/test_search_base_query.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from graphql_api.types.enums.enums import TestResultsOrderingParameter
 from utils.test_results import CursorValue, TestResultsRow, search_base_query
 
 
@@ -22,14 +23,14 @@ def row_factory(name: str, failure_rate: float):
 
 def test_search_base_query_cursor_val_none():
     rows = [row_factory(str(i), float(i) * 0.1) for i in range(10)]
-    res = search_base_query(rows, "failure_rate", None)
+    res = search_base_query(rows, TestResultsOrderingParameter.FAILURE_RATE, None)
     assert res == rows
 
 
 def test_search_base_query_with_existing_cursor():
     rows = [row_factory(str(i), float(i) * 0.1) for i in range(10)]
     cursor = CursorValue(name="5", ordered_value="0.5")
-    res = search_base_query(rows, "failure_rate", cursor)
+    res = search_base_query(rows, TestResultsOrderingParameter.FAILURE_RATE, cursor)
     assert res == rows[6:]
 
 
@@ -39,7 +40,7 @@ def test_search_base_query_with_missing_cursor_high_name_low_failure_rate():
     #          here's where the cursor is pointing at
     rows = [row_factory(str(i), float(i) * 0.1) for i in range(3)]
     cursor = CursorValue(name="111111", ordered_value="0.05")
-    res = search_base_query(rows, "failure_rate", cursor)
+    res = search_base_query(rows, TestResultsOrderingParameter.FAILURE_RATE, cursor)
     assert res == rows[1:]
 
 
@@ -49,7 +50,7 @@ def test_search_base_query_with_missing_cursor_low_name_high_failure_rate():
     #                        here's where the cursor is pointing at
     rows = [row_factory(str(i), float(i) * 0.1) for i in range(3)]
     cursor = CursorValue(name="0", ordered_value="0.15")
-    res = search_base_query(rows, "failure_rate", cursor)
+    res = search_base_query(rows, TestResultsOrderingParameter.FAILURE_RATE, cursor)
     assert res == rows[-1:]
 
 
@@ -59,5 +60,7 @@ def test_search_base_query_descending():
     #             here's where the cursor is pointing at
     rows = [row_factory(str(i), float(i) * 0.1) for i in range(2, -1, -1)]
     cursor = CursorValue(name="0", ordered_value="0.15")
-    res = search_base_query(rows, "failure_rate", cursor, descending=True)
+    res = search_base_query(
+        rows, TestResultsOrderingParameter.FAILURE_RATE, cursor, descending=True
+    )
     assert res == rows[1:]


### PR DESCRIPTION
this refactor simplifies the tests from test results aggregates and flake aggregates and adds some typing to the generate_test_results function. It also changes the arguments passed to the generate_test_results function so handling them is simpler and changes some things regarding error handling in that function.