### PR TITLE
feat: Create Django Command for Deleting Rate Limit Redis Keys

### DIFF
--- a/core/management/commands/delete_rate_limit_keys.py
+++ b/core/management/commands/delete_rate_limit_keys.py
@@ -19,8 +19,10 @@ class Command(BaseCommand):
 
         try:
             for key in redis.scan_iter(path):
-                print(f"Deleting key: {key.decode('utf-8')}")
-                redis.delete(key)
+                # -1 means the key has no expiry
+                if redis.ttl(key) == -1:
+                    print(f"Deleting key: {key.decode('utf-8')}")
+                    redis.delete(key)
         except Exception as e:
             print("Error occurred when deleting redis keys")
             print(e)

--- a/core/management/commands/delete_rate_limit_keys.py
+++ b/core/management/commands/delete_rate_limit_keys.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand, CommandParser
+
+from services.redis_configuration import get_redis_connection
+
+
+class Command(BaseCommand):
+    help = "This command is meant to delete all rate limit redis keys for either userId or ip."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        # This argument switches the command to "anonymous mode" deleting all the ip based keys
+        parser.add_argument("--ip", type=bool)
+
+    def handle(self, *args, **options):
+        redis = get_redis_connection()
+
+        path = "rl-user:*"
+        if options["ip"]:
+            path = "rl-ip:*"
+
+        try:
+            for key in redis.scan_iter(path):
+                print(f"Deleting key: {key.decode('utf-8')}")
+                redis.delete(key)
+        except Exception as e:
+            print("Error occurred when deleting redis keys")
+            print(e)

--- a/core/tests/test_management_commands.py
+++ b/core/tests/test_management_commands.py
@@ -85,7 +85,7 @@ def test_update_gitlab_webhook_command(mocker):
 def test_delete_rate_limit_keys_user_id():
     redis = get_redis_connection()
     redis.set("rl-user:1", 1)
-    redis.set("rl-user:2", 1)
+    redis.set("rl-user:2", 1, ex=5000)
     redis.set("rl-ip:1", 1)
 
     call_command(
@@ -95,18 +95,19 @@ def test_delete_rate_limit_keys_user_id():
     )
 
     assert redis.get("rl-user:1") is None
-    assert redis.get("rl-user:2") is None
+    assert redis.get("rl-user:2") is not None
     assert redis.get("rl-ip:1") is not None
 
-    # Get rid of lingering key
+    # Get rid of lingering keys
     redis.delete("rl-ip:1")
+    redis.delete("rl-user:2")
 
 
 @pytest.mark.django_db
 def test_delete_rate_limit_keys_ip_option():
     redis = get_redis_connection()
     redis.set("rl-ip:1", 1)
-    redis.set("rl-ip:2", 1)
+    redis.set("rl-ip:2", 1, ex=5000)
     redis.set("rl-user:1", 1)
 
     call_command(
@@ -114,8 +115,9 @@ def test_delete_rate_limit_keys_ip_option():
     )
 
     assert redis.get("rl-ip:1") is None
-    assert redis.get("rl-ip:2") is None
+    assert redis.get("rl-ip:2") is not None
     assert redis.get("rl-user:1") is not None
 
-    # Get rid of lingering key
+    # Get rid of lingering keys
     redis.delete("rl-user:1")
+    redis.delete("rl-ip:2")


### PR DESCRIPTION
### Purpose/Motivation

This PR adds a new django command to be run on CRON clearing any lingering users who may have had a redis key for their rate limit failing to expire.

The command runs only on user's (non-anon) by default, but an option can be passed in to run the deletion on anon users instead as well. We utilize the scan_iter function on redis because it's capable of having a regex path passed in, from which we go through and delete each of the keys. We only delete keys which have no TTL (comes back as -1 when you call the ttl function)

Redis Scan Docs - https://redis.io/docs/latest/commands/scan/

Redis TTL Docs - https://redis.io/docs/latest/commands/ttl/

Closes [#2527](https://github.com/codecov/engineering-team/issues/2527)

Will need the second half to be completed by https://github.com/codecov/engineering-team/issues/2588


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
