### PR TITLE
chore: Remove GQL playground access from prod

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -350,7 +350,11 @@ CORS_ALLOWED_ORIGIN_REGEXES = get_config(
 )
 CORS_ALLOWED_ORIGINS: list[str] = []
 
-GRAPHQL_PLAYGROUND = True
+GRAPHQL_PLAYGROUND = get_settings_module() in [
+    SettingsModule.DEV.value,
+    SettingsModule.STAGING.value,
+    SettingsModule.TESTING.value,
+]
 
 UPLOAD_THROTTLING_ENABLED = get_config(
     "setup", "upload_throttling_enabled", default=True


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Closes https://github.com/codecov/internal-issues/issues/916

Turning the setting off for `SettingsModule.PRODUCTION.value` and `SettingsModule.ENTERPRISE.value`

Tested locally by setting the line to `get_settings_module() != SettingsModule.DEV.value` and tried accessing at http://localhost:8000/graphql/ and the page was inaccessible.
