### PR TITLE
feat: Send email to admins on failed payment

### DIFF
--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -194,6 +194,7 @@ class StripeWebhookHandlerTests(APITestCase):
         admin_2 = OwnerFactory(email="admin2@codecov.io")
         self.owner.admins = [admin_1.ownerid, admin_2.ownerid]
         self.owner.plan_activated_users = [non_admin.ownerid]
+        self.owner.email = "owner@codecov.io"
         self.owner.save()
 
         response = self._send_event(
@@ -218,6 +219,17 @@ class StripeWebhookHandlerTests(APITestCase):
         assert self.owner.delinquent is True
 
         expected_calls = [
+            call(
+                to_addr=self.owner.email,
+                subject="Your Codecov payment failed",
+                template_name="failed-payment",
+                name=self.owner.username,
+                amount=240,
+                card_type="visa",
+                last_four=1234,
+                cta_link="https://stripe.com",
+                date=datetime.now().strftime("%B %-d, %Y"),
+            ),
             call(
                 to_addr=admin_1.email,
                 subject="Your Codecov payment failed",
@@ -252,6 +264,7 @@ class StripeWebhookHandlerTests(APITestCase):
         admin_2 = OwnerFactory(email="admin2@codecov.io")
         self.owner.admins = [admin_1.ownerid, admin_2.ownerid]
         self.owner.plan_activated_users = [non_admin.ownerid]
+        self.owner.email = "owner@codecov.io"
         self.owner.save()
 
         response = self._send_event(
@@ -274,6 +287,17 @@ class StripeWebhookHandlerTests(APITestCase):
         assert self.owner.delinquent is True
 
         expected_calls = [
+            call(
+                to_addr=self.owner.email,
+                subject="Your Codecov payment failed",
+                template_name="failed-payment",
+                name=self.owner.username,
+                amount=240,
+                card_type=None,
+                last_four=None,
+                cta_link="https://stripe.com",
+                date=datetime.now().strftime("%B %-d, %Y"),
+            ),
             call(
                 to_addr=admin_1.email,
                 subject="Your Codecov payment failed",

--- a/billing/views.py
+++ b/billing/views.py
@@ -71,6 +71,10 @@ class StripeWebhookHandler(APIView):
         for owner in owners:
             admin_ids.update(owner.admins)
 
+            # Add the owner's email as well - for user owners, admins is empty.
+            if owner.email:
+                admin_ids.add(owner)
+
         admins: QuerySet[Owner] = Owner.objects.filter(pk__in=admin_ids)
 
         task_service = TaskService()

--- a/billing/views.py
+++ b/billing/views.py
@@ -73,7 +73,7 @@ class StripeWebhookHandler(APIView):
 
             # Add the owner's email as well - for user owners, admins is empty.
             if owner.email:
-                admin_ids.add(owner)
+                admin_ids.add(owner.ownerid)
 
         admins: QuerySet[Owner] = Owner.objects.filter(pk__in=admin_ids)
 

--- a/billing/views.py
+++ b/billing/views.py
@@ -69,7 +69,8 @@ class StripeWebhookHandler(APIView):
 
         admin_ids = set()
         for owner in owners:
-            admin_ids.update(owner.admins)
+            if owner.admins:
+                admin_ids.update(owner.admins)
 
             # Add the owner's email as well - for user owners, admins is empty.
             if owner.email:

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -391,15 +391,21 @@ class TaskService(object):
         ).apply_async()
 
     def send_email(
-        self, ownerid, template_name: str, from_addr: str, subject: str, **kwargs
+        self,
+        to_addr: str,
+        subject: str,
+        template_name: str,
+        from_addr: str | None = None,
+        **kwargs,
     ):
+        # Templates can be found in worker/templates
         self._create_signature(
             "app.tasks.send_email.SendEmail",
             kwargs=dict(
-                ownerid=ownerid,
+                to_addr=to_addr,
+                subject=subject,
                 template_name=template_name,
                 from_addr=from_addr,
-                subject=subject,
                 **kwargs,
             ),
         ).apply_async()


### PR DESCRIPTION
This PR adds code to send emails (through the send email worker task) to all owner admins when an invoice payment fails. We are doing this because the current stripe behavior only sends the notification email to the address associated with the stripe customer.

Depends on https://github.com/codecov/worker/pull/835

Closes https://github.com/codecov/engineering-team/issues/2483
Closes https://github.com/codecov/engineering-team/issues/2484
Closes https://github.com/codecov/engineering-team/issues/2485
