### PR TITLE
Removing commit update for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,9 @@ push.self-hosted-rolling:
 	docker push ${DOCKERHUB_REPO}:rolling_no_dependencies
 	docker push ${DOCKERHUB_REPO}:rolling
 
+shell:
+	docker-compose exec api bash
+	
 test_env.up:
 	env | grep GITHUB > .testenv; true
 	TIMESERIES_ENABLED=${TIMESERIES_ENABLED} docker-compose up -d

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -495,6 +495,17 @@ def insert_commit(commitid, branch, pr, repository, owner, parent_commit_id=None
             "state": "pending",
         },
     )
+
+    edited = False
+    if parent_commit_id and commit.parent_commit_id is None:
+        commit.parent_commit_id = parent_commit_id
+        edited = True
+    if branch and commit.branch != branch:
+        # A branch head may have been moved; this allows commits to be "moved"
+        commit.branch = branch
+        edited = True
+    if edited:
+        commit.save(update_fields=["parent_commit_id", "state", "branch"])
     return commit
 
 

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -505,7 +505,7 @@ def insert_commit(commitid, branch, pr, repository, owner, parent_commit_id=None
         commit.branch = branch
         edited = True
     if edited:
-        commit.save(update_fields=["parent_commit_id", "state", "branch"])
+        commit.save(update_fields=["parent_commit_id", "branch"])
     return commit
 
 

--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -495,20 +495,6 @@ def insert_commit(commitid, branch, pr, repository, owner, parent_commit_id=None
             "state": "pending",
         },
     )
-
-    edited = False
-    if commit.state != "pending":
-        commit.state = "pending"
-        edited = True
-    if parent_commit_id and commit.parent_commit_id is None:
-        commit.parent_commit_id = parent_commit_id
-        edited = True
-    if branch and commit.branch != branch:
-        # A branch head may have been moved; this allows commits to be "moved"
-        commit.branch = branch
-        edited = True
-    if edited:
-        commit.save(update_fields=["parent_commit_id", "state", "branch"])
     return commit
 
 

--- a/upload/tests/test_upload.py
+++ b/upload/tests/test_upload.py
@@ -627,56 +627,6 @@ class UploadHandlerHelpersTest(TestCase):
             assert commit.merged == False
             assert commit.parent_commit_id is None
 
-        with self.subTest("commit already in database"):
-            G(
-                Commit,
-                commitid="1c78206f1a46dc6db8412a491fc770eb7d0f8a47",
-                branch="apples",
-                pullid="456",
-                repository=repo,
-                parent_commit_id=None,
-            )
-            # parent_commit_id, state, and branch should be updated
-            insert_commit(
-                "1c78206f1a46dc6db8412a491fc770eb7d0f8a47",
-                "oranges",
-                "123",
-                repo,
-                org,
-                parent_commit_id="different_parent_commit",
-            )
-
-            commit = Commit.objects.get(
-                commitid="1c78206f1a46dc6db8412a491fc770eb7d0f8a47"
-            )
-            assert commit.repository == repo
-            assert commit.state == "pending"
-            assert commit.branch == "oranges"
-            assert commit.pullid == 456
-            assert commit.merged is None
-            assert commit.parent_commit_id == "different_parent_commit"
-
-        with self.subTest("parent provided"):
-            parent = G(Commit)
-            insert_commit(
-                "8458a8c72aafb5fb4c5cd58f467a2f71298f1b61",
-                "test",
-                None,
-                repo,
-                org,
-                parent_commit_id=parent.commitid,
-            )
-
-            commit = Commit.objects.get(
-                commitid="8458a8c72aafb5fb4c5cd58f467a2f71298f1b61"
-            )
-            assert commit.repository == repo
-            assert commit.state == "pending"
-            assert commit.branch == "test"
-            assert commit.pullid is None
-            assert commit.merged is None
-            assert commit.parent_commit_id == parent.commitid
-
     def test_parse_request_headers(self):
         with self.subTest("Invalid content disposition"):
             with self.assertRaises(ValidationError):


### PR DESCRIPTION
### Purpose/Motivation
Removing commit update for consistency. This is not done in the new upload endpoint. The upload process takes care of this.

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
