### PR TITLE
fix: Don't show detailed errors for anonymous users

### DIFF
--- a/graphql_api/tests/test_views.py
+++ b/graphql_api/tests/test_views.py
@@ -113,7 +113,7 @@ class AriadneViewTestCase(GraphQLTestHelper, TestCase):
         assert data["errors"][0]["type"] == "Unauthorized"
         assert data["errors"][0].get("extensions") is None
 
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=True)
     async def test_when_bad_query(self):
         schema = generate_schema_that_raise_with(Unauthorized())
         data = await self.do_query(schema, " { fieldThatDoesntExist }")
@@ -122,6 +122,13 @@ class AriadneViewTestCase(GraphQLTestHelper, TestCase):
             data["errors"][0]["message"]
             == "Cannot query field 'fieldThatDoesntExist' on type 'Query'."
         )
+
+    @override_settings(DEBUG=False)
+    async def test_when_bad_query_and_anonymous(self):
+        schema = generate_schema_that_raise_with(Unauthorized())
+        data = await self.do_query(schema, " { fieldThatDoesntExist }")
+        assert data["errors"] is not None
+        assert data["errors"][0]["message"] == "INTERNAL SERVER ERROR"
 
     @override_settings(DEBUG=False, GRAPHQL_QUERY_COST_THRESHOLD=1000)
     @patch("logging.Logger.error")

--- a/graphql_api/views.py
+++ b/graphql_api/views.py
@@ -292,6 +292,8 @@ class AsyncGraphqlView(GraphQLAsyncView):
 
     def context_value(self, request, *_):
         request_body = json.loads(request.body.decode("utf-8")) if request.body else {}
+        self.request = request
+
         return {
             "request": request,
             "service": request.resolver_match.kwargs["service"],
@@ -300,9 +302,11 @@ class AsyncGraphqlView(GraphQLAsyncView):
         }
 
     def error_formatter(self, error, debug=False):
+        user = self.request.user
+        is_anonymous = user.is_anonymous if user else True
         # the only way to check for a malformed query
         is_bad_query = "Cannot query field" in error.formatted["message"]
-        if debug or is_bad_query:
+        if debug or (not is_anonymous and is_bad_query):
             return format_error(error, debug)
         formatted = error.formatted
         formatted["message"] = "INTERNAL SERVER ERROR"


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
<img width="620" alt="Screenshot 2024-11-04 at 6 05 13 PM" src="https://github.com/user-attachments/assets/fe016065-c063-4943-b800-00e7d12604bb">


### Links to relevant tickets
https://github.com/codecov/internal-issues/issues/915

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
