### PR TITLE
add true tokenless to all upload endpoints, remove from TR

### DIFF
--- a/upload/views/empty_upload.py
+++ b/upload/views/empty_upload.py
@@ -16,6 +16,7 @@ from codecov_auth.authentication.repo_auth import (
     GlobalTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
+    UploadTokenRequiredAuthenticationCheck,
     repo_auth_custom_exception_handler,
 )
 from codecov_auth.authentication.types import RepositoryAsUser
@@ -73,6 +74,7 @@ class EmptyUploadSerializer(serializers.Serializer):
 class EmptyUploadView(CreateAPIView, GetterMixin):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
+        UploadTokenRequiredAuthenticationCheck,
         GlobalTokenAuthentication,
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -14,7 +14,6 @@ from codecov_auth.authentication.repo_auth import (
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
     TokenlessAuthentication,
-    UploadTokenRequiredAuthenticationCheck,
     repo_auth_custom_exception_handler,
 )
 from codecov_auth.authentication.types import RepositoryAsUser
@@ -59,7 +58,6 @@ class TestResultsView(
 ):
     permission_classes = [UploadTestResultsPermission]
     authentication_classes = [
-        UploadTokenRequiredAuthenticationCheck,
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,

--- a/upload/views/upload_completion.py
+++ b/upload/views/upload_completion.py
@@ -10,6 +10,7 @@ from codecov_auth.authentication.repo_auth import (
     GlobalTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
+    UploadTokenRequiredAuthenticationCheck,
     repo_auth_custom_exception_handler,
 )
 from reports.models import ReportSession
@@ -25,6 +26,7 @@ log = logging.getLogger(__name__)
 class UploadCompletionView(CreateAPIView, GetterMixin):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
+        UploadTokenRequiredAuthenticationCheck,
         GlobalTokenAuthentication,
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,


### PR DESCRIPTION
### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/2300

### What does this PR do?
Auth stack on upload endpoints needs to match what's on `shelter`, which treats all upload endpoints equally.
