### PR TITLE
adjust deactivated repo url

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -754,9 +754,9 @@ def dispatch_upload_task(
 
 def validate_activated_repo(repository):
     if repository.active and not repository.activated:
-        settings_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/settings"
+        config_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/config/general"
         raise ValidationError(
-            f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings_url}"
+            f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {config_url}"
         )
 
 

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -259,12 +259,12 @@ def test_validate_upload_too_many_uploads_for_commit(
 
 def test_deactivated_repo(db, mocker):
     repository = RepositoryFactory.create(active=True, activated=False)
-    /config/general = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/config/general"
+    config_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/config/general"
 
     with pytest.raises(ValidationError) as exp:
         validate_activated_repo(repository)
     assert exp.match(
-        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {/config/general}"
+        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {config_url}"
     )
 
 

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -259,12 +259,12 @@ def test_validate_upload_too_many_uploads_for_commit(
 
 def test_deactivated_repo(db, mocker):
     repository = RepositoryFactory.create(active=True, activated=False)
-    settings_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/config/general"
+    /config/general = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/config/general"
 
     with pytest.raises(ValidationError) as exp:
         validate_activated_repo(repository)
     assert exp.match(
-        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings_url}"
+        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {/config/general}"
     )
 
 

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -259,7 +259,7 @@ def test_validate_upload_too_many_uploads_for_commit(
 
 def test_deactivated_repo(db, mocker):
     repository = RepositoryFactory.create(active=True, activated=False)
-    settings_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/settings"
+    settings_url = f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/config/general"
 
     with pytest.raises(ValidationError) as exp:
         validate_activated_repo(repository)

--- a/upload/tests/views/test_commits.py
+++ b/upload/tests/views/test_commits.py
@@ -68,7 +68,7 @@ def test_deactivated_repo(db):
     response_json = response.json()
     assert response.status_code == 400
     assert response_json == [
-        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings.CODECOV_DASHBOARD_URL}/github/codecov/the_repo/settings"
+        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings.CODECOV_DASHBOARD_URL}/github/codecov/the_repo/config/general"
     ]
 
 

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -65,7 +65,7 @@ def test_deactivated_repo(db):
     response_json = response.json()
     assert response.status_code == 400
     assert response_json == [
-        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings.CODECOV_DASHBOARD_URL}/github/codecov/the_repo/settings"
+        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings.CODECOV_DASHBOARD_URL}/github/codecov/the_repo/config/general"
     ]
 
 

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -793,7 +793,7 @@ def test_deactivated_repo(db, mocker, mock_redis):
     response_json = response.json()
     assert response.status_code == 400
     assert response_json == [
-        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings.CODECOV_DASHBOARD_URL}/github/codecov/the_repo/settings"
+        f"This repository is deactivated. To resume uploading to it, please activate the repository in the codecov UI: {settings.CODECOV_DASHBOARD_URL}/github/codecov/the_repo/config/general"
     ]
 
 


### PR DESCRIPTION
This link has pointed to the wrong place ever since we moved from the settings page to the configuration page. This PR adjusts that.

Ticket: https://github.com/codecov/engineering-team/issues/2841

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
