### PR TITLE
Update workflow to use basic-test-results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,17 @@ concurrency:
 permissions:
   contents: "read"
   id-token: "write"
+  issues: "write"
+  pull-requests: "write"
 
 jobs:
   lint:
     name: Run Lint
-    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.26
 
   build:
     name: Build API
-    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.26
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -31,7 +33,7 @@ jobs:
   codecovstartup:
     name: Codecov Startup
     needs: build
-    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.26
     secrets: inherit
 
   # ats:
@@ -47,7 +49,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.26
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -55,7 +57,7 @@ jobs:
   build-self-hosted:
     name: Build Self Hosted API
     needs: [build, test]
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.26
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}
@@ -64,7 +66,7 @@ jobs:
     name: Push Staging Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/staging' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.26
     secrets: inherit
     with:
       environment: staging
@@ -74,7 +76,7 @@ jobs:
     name: Push Production Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.26
     secrets: inherit
     with:
       environment: production
@@ -85,7 +87,7 @@ jobs:
     needs: [build-self-hosted, test]
     secrets: inherit
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.24
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.26
     with:
       push_rolling: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-api' }}


### PR DESCRIPTION
### Purpose/Motivation
We want to add `basic-test-results` to our CI workflow for dogfodding.

### What does this PR do?
Update test workflow to also use the `basic-test-results` action.

The change to add the action to the shared actions is: https://github.com/codecov/gha-workflows/pull/34

### Notes to Reviewer
This will add another message spam to our PRs.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
