### PR TITLE
flip default value on upload_token_required_for_public_repos

### DIFF
--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -982,7 +982,11 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         assert data["owner"]["aiEnabledRepos"] == ["b", "a"]
 
     def test_fetch_upload_token_required(self):
-        owner = OwnerFactory(username="sample-owner", service="github")
+        owner = OwnerFactory(
+            username="sample-owner",
+            service="github",
+            upload_token_required_for_public_repos=True,
+        )
         query = """{
             owner(username: "%s") {
                 uploadTokenRequired

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/26f0db073fe2d6355c227d032e1b27c3602a010c.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/9c31870de026a8a3f026f0753b1991e8c832fadb.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ aiodataloader==0.4.0
     # via -r requirements.in
 amqp==5.2.0
     # via kombu
-analytics-python==1.3.0b1
-    # via shared
 annotated-types==0.7.0
     # via pydantic
 anyio==3.6.1
@@ -33,8 +31,6 @@ attrs==20.3.0
     #   cattrs
     #   ddtrace
     #   jsonschema
-backoff==1.6.0
-    # via analytics-python
 billiard==4.2.0
     # via celery
 boto3==1.20.25
@@ -259,8 +255,6 @@ minio==7.1.13
     #   shared
 mmh3==4.0.1
     # via shared
-monotonic==1.5
-    # via analytics-python
 multidict==4.7.6
     # via yarl
 nodeenv==1.5.0
@@ -371,7 +365,6 @@ pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.in
-    #   analytics-python
     #   botocore
     #   celery
     #   django-postgres-extra
@@ -384,9 +377,7 @@ python-redis-lock==4.0.0
     #   -r requirements.in
     #   shared
 pytz==2022.1
-    # via
-    #   -r requirements.in
-    #   shared
+    # via -r requirements.in
 pyyaml==6.0.1
     # via
     #   drf-spectacular
@@ -403,7 +394,6 @@ regex==2023.12.25
 requests==2.32.3
     # via
     #   -r requirements.in
-    #   analytics-python
     #   codecovopentelem
     #   google-api-core
     #   google-cloud-storage
@@ -421,13 +411,12 @@ sentry-sdk[celery]==2.13.0
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/26f0db073fe2d6355c227d032e1b27c3602a010c.tar.gz
+shared @ https://github.com/codecov/shared/archive/9c31870de026a8a3f026f0753b1991e8c832fadb.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in
 six==1.16.0
     # via
-    #   analytics-python
     #   click-repl
     #   ddsketch
     #   ddtrace
@@ -461,8 +450,6 @@ tlslite-ng==0.8.0b1
     # via shared
 toml==0.10.2
     # via pre-commit
-typing==3.7.4.3
-    # via shared
 typing-extensions==4.6.2
     # via
     #   aiodataloader
@@ -471,7 +458,6 @@ typing-extensions==4.6.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
-    #   shared
     #   stripe
 tzdata==2024.1
     # via celery

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -762,7 +762,10 @@ def test_upload_bundle_analysis_tokenless_mismatched_branch(
     upload = mocker.patch.object(TaskService, "upload")
 
     commit_sha = "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef"
-    repository = RepositoryFactory.create(private=False)
+    repository = RepositoryFactory.create(
+        private=False,
+        author__upload_token_required_for_public_repos=True,
+    )
     CommitFactory.create(repository=repository, commitid=commit_sha, branch="main")
 
     client = APIClient()

--- a/upload/tests/views/test_commits.py
+++ b/upload/tests/views/test_commits.py
@@ -234,7 +234,10 @@ def test_create_commit_already_exists(db, client, mocker):
 @pytest.mark.parametrize("private", [True, False])
 def test_commit_tokenless(db, client, mocker, branch, private):
     repository = RepositoryFactory.create(
-        private=private, author__username="codecov", name="the_repo"
+        private=private,
+        author__username="codecov",
+        name="the_repo",
+        author__upload_token_required_for_public_repos=True,
     )
     mocked_call = mocker.patch.object(TaskService, "update_commit")
 

--- a/upload/tests/views/test_reports.py
+++ b/upload/tests/views/test_reports.py
@@ -161,6 +161,7 @@ def test_reports_post_tokenless(client, db, mocker, private, branch, branch_sent
         name="the_repo",
         author__username="codecov",
         author__service="github",
+        author__upload_token_required_for_public_repos=True,
         private=private,
     )
     commit = CommitFactory(repository=repository)

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -307,6 +307,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
         author__username="codecov",
         author__service="github",
         private=private,
+        author__upload_token_required_for_public_repos=True,
     )
     commit = CommitFactory(repository=repository)
     commit.branch = branch
@@ -589,6 +590,7 @@ def test_uploads_post_github_oidc_auth(
         name="the_repo",
         author__username="codecov",
         author__service="github",
+        author__upload_token_required_for_public_repos=True,
         private=False,
     )
     mock_jwt_decode.return_value = {
@@ -861,6 +863,7 @@ class TestGitlabEnterpriseOIDC(APITestCase):
             name="the_repo",
             author__username="codecov",
             author__service="github_enterprise",
+            author__upload_token_required_for_public_repos=True,
             private=False,
         )
         mock_jwt_decode.return_value = {


### PR DESCRIPTION
### Purpose/Motivation
when true tokenless goes live we will merge this, which will make true tokenless default to "on" for new orgs.

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/2623