### PR TITLE
fix: Fix stripe invoice time bounding param names

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -175,8 +175,8 @@ class StripeService(AbstractPaymentService):
             subscription=owner.stripe_subscription_id,
             status="paid",
             created={
-                "created.gte": int(start_of_last_period.timestamp()),
-                "created.lt": int(current_subscription_datetime.timestamp()),
+                "gte": int(start_of_last_period.timestamp()),
+                "lt": int(current_subscription_datetime.timestamp()),
             },
         )
 

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -448,7 +448,7 @@ class StripeServiceTests(TestCase):
         list_invoice_mock.assert_called_once_with(
             subscription=stripe_subscription_id,
             status="paid",
-            created={"created.gte": 1458263420, "created.lt": 1489799420},
+            created={"gte": 1458263420, "lt": 1489799420},
         )
         self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(
@@ -523,7 +523,7 @@ class StripeServiceTests(TestCase):
         list_invoice_mock.assert_called_once_with(
             subscription=stripe_subscription_id,
             status="paid",
-            created={"created.gte": 1458263420, "created.lt": 1489799420},
+            created={"gte": 1458263420, "lt": 1489799420},
         )
         self.assertEqual(create_refund_mock.call_count, 2)
         modify_customer_mock.assert_called_once_with(
@@ -600,7 +600,7 @@ class StripeServiceTests(TestCase):
         list_invoice_mock.assert_called_once_with(
             subscription=stripe_subscription_id,
             status="paid",
-            created={"created.gte": 1458263420, "created.lt": 1489799420},
+            created={"gte": 1458263420, "lt": 1489799420},
         )
         create_refund_mock.assert_not_called()
         modify_customer_mock.assert_not_called()


### PR DESCRIPTION
Parameters should not include `created.` as it is inside of the `created` dictionary.

https://dashboard.stripe.com/logs?showIP=false&created%5Bgte%5D=1730707200&created%5Blte%5D=1730793599&method%5B0%5D=get&method%5B1%5D=delete&path=%2Fv1%2Finvoices&direction%5B0%5D=self&direction%5B1%5D=connect_in&starting_after=1730793070-req_kZrihx2qSFEA9u

<img width="501" alt="Screenshot 2024-11-08 at 10 48 54 AM" src="https://github.com/user-attachments/assets/d3097b50-c1e9-48b5-ab6d-7f8d01579f75">

