### PR TITLE
fix: get_results returns none if table is empty

### DIFF
--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -70,4 +70,7 @@ def get_results(
     # deserialize
     table = pl.read_ipc(result)
 
+    if table.height == 0:
+        return None
+
     return table


### PR DESCRIPTION
previously we were returning a table that had a bunch of null columns
this is actually due to us not having a strict schema on the worker side
but a good fix here anyways is to return None from get_results when
there's no data in the table