### PR TITLE
Temporarily disable trials starting for paid orgs

### DIFF
--- a/codecov_auth/tests/test_admin.py
+++ b/codecov_auth/tests/test_admin.py
@@ -25,7 +25,7 @@ from shared.django_apps.codecov_auth.tests.factories import (
 )
 from shared.django_apps.core.tests.factories import PullFactory, RepositoryFactory
 
-from codecov.commands.exceptions import ValidationError
+# from codecov.commands.exceptions import ValidationError
 from codecov_auth.admin import (
     AccountAdmin,
     InvoiceBillingAdmin,
@@ -337,25 +337,26 @@ class OwnerAdminTest(TestCase):
         assert mock_start_trial_service.called
         assert mock_start_trial_service.call_args.kwargs == {"is_extension": True}
 
-    @patch("plan.service.PlanService.start_trial_manually")
-    def test_start_trial_paid_plan(self, mock_start_trial_service):
-        mock_start_trial_service.side_effect = ValidationError(
-            "Cannot trial from a paid plan"
-        )
+    # Temporarily comment for the time being
+    # @patch("plan.service.PlanService.start_trial_manually")
+    # def test_start_trial_paid_plan(self, mock_start_trial_service):
+    #     mock_start_trial_service.side_effect = ValidationError(
+    #         "Cannot trial from a paid plan"
+    #     )
 
-        org_to_be_trialed = OwnerFactory()
+    #     org_to_be_trialed = OwnerFactory()
 
-        res = self.client.post(
-            reverse("admin:codecov_auth_owner_changelist"),
-            {
-                "action": "extend_trial",
-                ACTION_CHECKBOX_NAME: [org_to_be_trialed.pk],
-                "end_date": "2024-01-01 01:02:03",
-                "extend_trial": True,
-            },
-        )
-        assert res.status_code == 302
-        assert mock_start_trial_service.called
+    #     res = self.client.post(
+    #         reverse("admin:codecov_auth_owner_changelist"),
+    #         {
+    #             "action": "extend_trial",
+    #             ACTION_CHECKBOX_NAME: [org_to_be_trialed.pk],
+    #             "end_date": "2024-01-01 01:02:03",
+    #             "extend_trial": True,
+    #         },
+    #     )
+    #     assert res.status_code == 302
+    #     assert mock_start_trial_service.called
 
     def test_account_widget(self):
         owner = OwnerFactory(user=UserFactory(), plan="users-enterprisey")

--- a/plan/service.py
+++ b/plan/service.py
@@ -219,15 +219,16 @@ class PlanService:
         Returns:
             No value
         """
-        # Start a new trial plan for free users currently not on trial
-        if self.plan_name in FREE_PLAN_REPRESENTATIONS:
-            self._start_trial_helper(current_owner, end_date, is_extension=False)
         # Extend an existing trial plan for users currently on trial
-        elif self.plan_name in TRIAL_PLAN_REPRESENTATION:
+        if self.plan_name in TRIAL_PLAN_REPRESENTATION:
             self._start_trial_helper(current_owner, end_date, is_extension=True)
-        # Paying users cannot start a trial
+        # Start a new trial plan for any users, used to be free but temporarily doing it for anyone
+        # as long as the person extending the trial is responsible to manually returning the users
+        # the way they were before
         else:
-            raise ValidationError("Cannot trial from a paid plan")
+            self._start_trial_helper(current_owner, end_date, is_extension=False)
+        # Paying users cannot start a trial
+        #     raise ValidationError("Cannot trial from a paid plan")
 
     def cancel_trial(self) -> None:
         if not self.is_org_trialing:

--- a/plan/tests/test_plan.py
+++ b/plan/tests/test_plan.py
@@ -226,20 +226,21 @@ class PlanServiceTests(TestCase):
         assert current_org.plan_auto_activate == True
         assert current_org.trial_fired_by == current_owner.ownerid
 
-    def test_plan_service_start_trial_manually_already_on_paid_plan(self):
-        current_org = OwnerFactory(
-            plan=PlanName.CODECOV_PRO_MONTHLY.value,
-            trial_start_date=None,
-            trial_end_date=None,
-            trial_status=TrialStatus.NOT_STARTED.value,
-        )
-        plan_service = PlanService(current_org=current_org)
-        current_owner = OwnerFactory()
+    # Temporarily comment this
+    # def test_plan_service_start_trial_manually_already_on_paid_plan(self):
+    #     current_org = OwnerFactory(
+    #         plan=PlanName.CODECOV_PRO_MONTHLY.value,
+    #         trial_start_date=None,
+    #         trial_end_date=None,
+    #         trial_status=TrialStatus.NOT_STARTED.value,
+    #     )
+    #     plan_service = PlanService(current_org=current_org)
+    #     current_owner = OwnerFactory()
 
-        with self.assertRaises(ValidationError):
-            plan_service.start_trial_manually(
-                current_owner=current_owner, end_date="2024-01-01 00:00:00"
-            )
+    #     with self.assertRaises(ValidationError):
+    #         plan_service.start_trial_manually(
+    #             current_owner=current_owner, end_date="2024-01-01 00:00:00"
+    #         )
 
     def test_plan_service_returns_plan_data_for_non_trial_basic_plan(self):
         trial_start_date = None


### PR DESCRIPTION
### Purpose/Motivation
This is a temporary PR to remove the requirement to start trials on a paid org to easily capture customers in paid plans we want to offer TA features to.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
