### PR TITLE
fix: ambiguous expr in polars

### DIFF
--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -218,7 +218,7 @@ def generate_test_results(
             table = table.filter(pl.col("total_flaky_fail_count") > 0)
         case TestResultsFilterParameter.SKIPPED_TESTS:
             table = table.filter(
-                pl.col("total_skip_count") > 0 & pl.col("total_pass_count") == 0
+                (pl.col("total_skip_count") > 0) & (pl.col("total_pass_count") == 0)
             )
         case TestResultsFilterParameter.SLOWEST_TESTS:
             table = table.filter(


### PR DESCRIPTION
### Purpose/Motivation

Supposedly python and polars are fighting to determine who's & is being used in this expression. According to cursor at least, wrapping in () will properly group the expressions so the expression can resolve correctly.

Closes Sentry issue: https://codecov.sentry.io/issues/6060600347/?environment=production&project=5215654&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=6

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
