### PR TITLE
Change combined-upload to upload-coverage for clarity

### DIFF
--- a/upload/tests/views/test_upload_coverage.py
+++ b/upload/tests/views/test_upload_coverage.py
@@ -15,7 +15,7 @@ from reports.models import (
     UploadFlagMembership,
 )
 from services.archive import ArchiveService, MinioEndpoints
-from upload.views.combined_upload import CanDoCoverageUploadsPermission
+from upload.views.upload_coverage import CanDoCoverageUploadsPermission
 
 
 def test_get_repo(db):
@@ -25,7 +25,7 @@ def test_get_repo(db):
     repository.save()
     repo_slug = f"{repository.author.username}::::{repository.name}"
     url = reverse(
-        "new_upload.combined_upload",
+        "new_upload.upload_coverage",
         args=[repository.author.service, repo_slug],
     )
     client = APIClient()
@@ -42,7 +42,7 @@ def test_get_repo_not_found(upload, db):
     )
     repo_slug = "codecov::::wrong-repo-name"
     url = reverse(
-        "new_upload.combined_upload",
+        "new_upload.upload_coverage",
         args=[repository.author.service, repo_slug],
     )
     client = APIClient()
@@ -63,7 +63,7 @@ def test_deactivated_repo(db):
     repository.save()
     repo_slug = f"{repository.author.username}::::{repository.name}"
     url = reverse(
-        "new_upload.combined_upload",
+        "new_upload.upload_coverage",
         args=[repository.author.service, repo_slug],
     )
     client = APIClient()
@@ -73,11 +73,11 @@ def test_deactivated_repo(db):
     assert "This repository is deactivated" in str(response.json())
 
 
-def test_combined_upload_with_errors(db):
+def test_upload_coverage_with_errors(db):
     repository = RepositoryFactory()
     repo_slug = f"{repository.author.username}::::{repository.name}"
     url = reverse(
-        "new_upload.combined_upload",
+        "new_upload.upload_coverage",
         args=[repository.author.service, repo_slug],
     )
 
@@ -97,7 +97,7 @@ def test_combined_upload_with_errors(db):
     assert "flags" in response.json()
 
 
-def test_combined_upload_post(db, mocker):
+def test_upload_coverage_post(db, mocker):
     mocker.patch.object(
         CanDoCoverageUploadsPermission, "has_permission", return_value=True
     )
@@ -121,7 +121,7 @@ def test_combined_upload_post(db, mocker):
     client.force_authenticate(user=owner)
     repo_slug = f"{repository.author.username}::::{repository.name}"
     url = reverse(
-        "new_upload.combined_upload",
+        "new_upload.upload_coverage",
         args=[repository.author.service, repo_slug],
     )
     response = client.post(
@@ -195,7 +195,7 @@ def test_combined_upload_post(db, mocker):
 
 
 @override_settings(SHELTER_SHARED_SECRET="shelter-shared-secret")
-def test_combined_upload_post_shelter(db, mocker):
+def test_upload_coverage_post_shelter(db, mocker):
     mocker.patch.object(
         CanDoCoverageUploadsPermission, "has_permission", return_value=True
     )
@@ -219,7 +219,7 @@ def test_combined_upload_post_shelter(db, mocker):
     client.force_authenticate(user=owner)
     repo_slug = f"{repository.author.username}::::{repository.name}"
     url = reverse(
-        "new_upload.combined_upload",
+        "new_upload.upload_coverage",
         args=[repository.author.service, repo_slug],
     )
     response = client.post(

--- a/upload/urls.py
+++ b/upload/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 
 from upload.views.bundle_analysis import BundleAnalysisView
-from upload.views.combined_upload import CombinedUploadView
+from upload.views.upload_coverage import UploadCoverageView
 from upload.views.commits import CommitViews
 from upload.views.empty_upload import EmptyUploadView
 from upload.views.legacy import UploadDownloadHandler, UploadHandler
@@ -59,9 +59,9 @@ urlpatterns = [
         name="new_upload.commits",
     ),
     path(
-        "<str:service>/<str:repo>/combined-upload",
-        CombinedUploadView.as_view(),
-        name="new_upload.combined_upload",
+        "<str:service>/<str:repo>/upload-coverage",
+        UploadCoverageView.as_view(),
+        name="new_upload.upload_coverage",
     ),
     # This was getting in the way of the new endpoints, so I moved to the end
     re_path(r"(?P<version>\w+)/?", UploadHandler.as_view(), name="upload-handler"),

--- a/upload/urls.py
+++ b/upload/urls.py
@@ -1,13 +1,13 @@
 from django.urls import path, re_path
 
 from upload.views.bundle_analysis import BundleAnalysisView
-from upload.views.upload_coverage import UploadCoverageView
 from upload.views.commits import CommitViews
 from upload.views.empty_upload import EmptyUploadView
 from upload.views.legacy import UploadDownloadHandler, UploadHandler
 from upload.views.reports import ReportResultsView, ReportViews
 from upload.views.test_results import TestResultsView
 from upload.views.upload_completion import UploadCompletionView
+from upload.views.upload_coverage import UploadCoverageView
 from upload.views.uploads import UploadViews
 
 urlpatterns = [

--- a/upload/views/upload_coverage.py
+++ b/upload/views/upload_coverage.py
@@ -37,7 +37,7 @@ from upload.views.uploads import (
 log = logging.getLogger(__name__)
 
 
-class CombinedUploadView(APIView, GetterMixin):
+class UploadCoverageView(APIView, GetterMixin):
     permission_classes = [CanDoCoverageUploadsPermission]
     authentication_classes = [
         UploadTokenRequiredAuthenticationCheck,
@@ -57,7 +57,7 @@ class CombinedUploadView(APIView, GetterMixin):
             API_UPLOAD_COUNTER,
             labels=generate_upload_prometheus_metrics_labels(
                 action="coverage",
-                endpoint="combined_upload",
+                endpoint="upload_coverage",
                 request=self.request,
                 is_shelter_request=self.is_shelter_request(),
                 position=position,
@@ -85,7 +85,7 @@ class CombinedUploadView(APIView, GetterMixin):
         commit = create_commit(commit_serializer, repository)
 
         log.info(
-            "Request to create new combined upload",
+            "Request to create new coverage upload",
             extra=dict(
                 repo=repository.name,
                 commit=commit.commitid,


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

After some discussion it seems `combined-upload` should be renamed to `upload-coverage`.

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
