### PR TITLE
fix: make inf percent change result null

### DIFF
--- a/graphql_api/types/flake_aggregates/flake_aggregates.py
+++ b/graphql_api/types/flake_aggregates/flake_aggregates.py
@@ -42,7 +42,11 @@ def flake_aggregates_with_percentage(
     merged_results: pl.DataFrame = pl.concat([past_aggregates, curr_aggregates])
 
     merged_results = merged_results.with_columns(
-        pl.all().pct_change().fill_nan(0).name.suffix("_percent_change")
+        pl.all()
+        .pct_change()
+        .replace([float("inf"), None], None)
+        .fill_nan(0)
+        .name.suffix("_percent_change")
     )
     aggregates = merged_results.row(1, named=True)
 

--- a/graphql_api/types/test_results_aggregates/test_results_aggregates.py
+++ b/graphql_api/types/test_results_aggregates/test_results_aggregates.py
@@ -71,7 +71,11 @@ def test_results_aggregates_with_percentage(
     # with_columns upserts the new columns, so if the name already exists it get overwritten
     # otherwise it's just added
     merged_results = merged_results.with_columns(
-        pl.all().pct_change().fill_nan(0).name.suffix("_percent_change")
+        pl.all()
+        .pct_change()
+        .replace([float("inf"), None], None)
+        .fill_nan(0)
+        .name.suffix("_percent_change")
     )
     aggregates = merged_results.row(1, named=True)
 


### PR DESCRIPTION
previously if the result of aggregation for a column for the previous interval was 0 and the result for the current interval was not zero then we would get inf as the percent_change value for that column and that would break GQL