### PR TITLE
Bundle analysis: Temp mock for routes field of Assets

### DIFF
--- a/graphql_api/types/bundle_analysis/base.graphql
+++ b/graphql_api/types/bundle_analysis/base.graphql
@@ -55,6 +55,7 @@ type BundleAsset {
     after: DateTime
     branch: String
   ): BundleAnalysisMeasurements
+  routes: [String!]
 }
 
 type BundleReport {

--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -158,6 +158,13 @@ def resolve_asset_report_measurements(
     return bundle_analysis_measurements.compute_asset(bundle_asset)
 
 
+@bundle_asset_bindable.field("routes")
+def resolve_routes(
+    bundle_asset: AssetReport, info: GraphQLResolveInfo
+) -> Optional[List[str]]:
+    return ["/", "/about", "/login", "/super/long/url/path"]
+
+
 # ============= Bundle Report Bindable =============
 
 


### PR DESCRIPTION
Set up the GQL field for returning routes of a given asset. Currently just hardcode some return value so that FE can start using it for testing. Coming up next PR will be calculating the real values
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
