### PR TITLE
fix: Fix auto activation in the repo level 

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -438,6 +438,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             private=True,
             coverage_enabled=True,
             bundle_analysis_enabled=True,
+            test_analytics_enabled=True,
         )
 
         is_activated.return_value = False
@@ -461,6 +462,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             private=True,
             coverage_enabled=True,
             bundle_analysis_enabled=True,
+            test_analytics_enabled=True,
         )
 
         data = self.gql_request(

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -431,52 +431,6 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
 
     @patch("services.activation.is_activated")
     @patch("services.activation.try_auto_activate")
-    def test_repository_not_activated(self, try_auto_activate, is_activated):
-        repo = RepositoryFactory(
-            author=self.owner,
-            active=True,
-            private=True,
-            coverage_enabled=True,
-            bundle_analysis_enabled=True,
-            test_analytics_enabled=True,
-        )
-
-        is_activated.return_value = False
-
-        data = self.gql_request(
-            query_repository % "name",
-            owner=self.owner,
-            variables={"name": repo.name},
-        )
-        assert data["me"]["owner"]["repository"] == {
-            "__typename": "OwnerNotActivatedError",
-            "message": "You must be activated in the org",
-        }
-
-    @override_settings(IS_ENTERPRISE=True)
-    @patch("services.activation.try_auto_activate")
-    def test_repository_not_activated_self_hosted(self, try_auto_activate):
-        repo = RepositoryFactory(
-            author=self.owner,
-            active=True,
-            private=True,
-            coverage_enabled=True,
-            bundle_analysis_enabled=True,
-            test_analytics_enabled=True,
-        )
-
-        data = self.gql_request(
-            query_repository % "name",
-            owner=self.owner,
-            variables={"name": repo.name},
-        )
-        assert data["me"]["owner"]["repository"] == {
-            "__typename": "OwnerNotActivatedError",
-            "message": "You must be activated in the org",
-        }
-
-    @patch("services.activation.is_activated")
-    @patch("services.activation.try_auto_activate")
     def test_resolve_inactive_user_on_unconfigured_repo(
         self, try_auto_activate, is_activated
     ):

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -163,7 +163,9 @@ async def resolve_repository(
 
     current_owner = info.context["request"].current_owner
     has_products_enabled = (
-        repository.bundle_analysis_enabled and repository.coverage_enabled
+        repository.bundle_analysis_enabled
+        or repository.coverage_enabled
+        or repository.test_analytics_enabled
     )
 
     if repository.private and has_products_enabled:

--- a/services/activation.py
+++ b/services/activation.py
@@ -71,7 +71,7 @@ def _get_activator(org: Owner, owner: Owner) -> BaseActivator:
 
 def try_auto_activate(org: Owner, owner: Owner) -> bool:
     """
-    Returns true iff the user was able to be activated, false otherwise.
+    Returns true if the user was able to be activated, false otherwise.
     """
     activator = _get_activator(org, owner)
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
We used to auto-activate only if both coverage and bundle were enabled. This fix ensures that if one product is enabled, auto-activation still works as expected.

We don't need OwnerNotActivatedError anymore, this is handled by isCurrentUserActivated in gazebo 

### Links to relevant tickets
Fixes: [[Self-hosted] Auto-activate members doesn't work in latest/24.10.1](https://github.com/codecov/feedback/issues/554)


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
