### PR TITLE
fix: Use new func name in sentry-sdk celery config

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ factory-boy
 fakeredis
 freezegun
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/9c31870de026a8a3f026f0753b1991e8c832fadb.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/12361de9ed29116b068805c1f7bfd90e9d659de5.tar.gz#egg=shared
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -411,7 +411,7 @@ sentry-sdk[celery]==2.13.0
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/9c31870de026a8a3f026f0753b1991e8c832fadb.tar.gz
+shared @ https://github.com/codecov/shared/archive/12361de9ed29116b068805c1f7bfd90e9d659de5.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ billiard==4.2.0
     # via celery
 boto3==1.35.59
     # via shared
-botocore==1.23.25
+botocore==1.35.59
     # via
     #   boto3
     #   s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ attrs==20.3.0
     #   jsonschema
 billiard==4.2.0
     # via celery
-boto3==1.20.25
+boto3==1.35.59
     # via shared
 botocore==1.23.25
     # via

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -19,6 +19,7 @@ celery_app.config_from_object("shared.celery_config:BaseCeleryConfig")
 
 log = logging.getLogger(__name__)
 
+# https://github.com/getsentry/sentry-python/issues/1416
 if settings.SENTRY_ENV:
     celery.group.apply_async = _wrap_task_run(celery.group.apply_async)
     celery.chunks.apply_async = _wrap_task_run(celery.chunks.apply_async)

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -2,12 +2,8 @@ import logging
 from datetime import datetime, timedelta
 from typing import Iterable, List, Optional, Tuple
 
-import celery
 from celery import Celery, chain, group, signature
-from celery.canvas import Signature
-from django.conf import settings
 from sentry_sdk import set_tag
-from sentry_sdk.integrations.celery import _wrap_apply_async
 from shared import celery_config
 
 from core.models import Repository
@@ -18,17 +14,6 @@ celery_app = Celery("tasks")
 celery_app.config_from_object("shared.celery_config:BaseCeleryConfig")
 
 log = logging.getLogger(__name__)
-
-if settings.SENTRY_ENV:
-    celery.group.apply_async = _wrap_apply_async(celery.group.apply_async)
-    celery.chunks.apply_async = _wrap_apply_async(celery.chunks.apply_async)
-    celery.canvas._chain.apply_async = _wrap_apply_async(
-        celery.canvas._chain.apply_async
-    )
-    celery.canvas._chord.apply_async = _wrap_apply_async(
-        celery.canvas._chord.apply_async
-    )
-    Signature.apply_async = _wrap_apply_async(Signature.apply_async)
 
 
 class TaskService(object):


### PR DESCRIPTION
It appears we have custom configuration of sentry-sdk to address this issue with celery - https://github.com/getsentry/sentry-python/issues/1416

When bumping to the latest [version](https://github.com/getsentry/sentry-python/commit/0fb9606eca582f44897253ed1dda426161c5b3e6) of sentry-sdk, we need to rename the function `_wrap_apply_async` --> `_wrap_task_run`
