### PR TITLE
fix: Check if user exists in info context before raising Guest Access error 

### DIFF
--- a/graphql_api/types/query/query.py
+++ b/graphql_api/types/query/query.py
@@ -44,7 +44,7 @@ def resolve_owner(_, info, username):
     configure_sentry_scope(query_name(info))
 
     service = info.context["service"]
-    user = info.context["request"].current_owner
+    user = info.context["request"].current_owner or info.context["request"].user
 
     if settings.IS_ENTERPRISE and settings.GUEST_ACCESS is False:
         if not user or not user.is_authenticated:


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
We must check for user in the request, current owner might not always be set for enterprise. 

### Links to relevant tickets
[[Self-hosted] UnauthorizedGuestAccess error after updating from 24.8.1 to 24.9.3/24.10.1/24.11.1](https://github.com/codecov/feedback/issues/536)

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
