### PR TITLE
Add upload-coverage to regex for Auth

### DIFF
--- a/codecov_auth/authentication/helpers.py
+++ b/codecov_auth/authentication/helpers.py
@@ -14,7 +14,7 @@ def get_upload_info_from_request_path(request: HttpRequest) -> UploadInfo | None
     path_info = request.get_full_path_info()
     # The repo part comes from https://stackoverflow.com/a/22312124
     upload_views_prefix_regex = (
-        r"\/upload\/(\w+)\/([\w\.@:_/\-~]+)\/commits(?:\/([a-f0-9]{40}))?"
+        r"\/upload\/(\w+)\/([\w\.@:_/\-~]+)\/(commits(?:\/([a-f0-9]{40}))?|upload-coverage)"
     )
     match = re.search(upload_views_prefix_regex, path_info)
 

--- a/codecov_auth/authentication/helpers.py
+++ b/codecov_auth/authentication/helpers.py
@@ -13,9 +13,7 @@ class UploadInfo(NamedTuple):
 def get_upload_info_from_request_path(request: HttpRequest) -> UploadInfo | None:
     path_info = request.get_full_path_info()
     # The repo part comes from https://stackoverflow.com/a/22312124
-    upload_views_prefix_regex = (
-        r"\/upload\/(\w+)\/([\w\.@:_/\-~]+)\/(commits(?:\/([a-f0-9]{40}))?|upload-coverage)"
-    )
+    upload_views_prefix_regex = r"\/upload\/(\w+)\/([\w\.@:_/\-~]+)\/(commits(?:\/([a-f0-9]{40}))?|upload-coverage)"
     match = re.search(upload_views_prefix_regex, path_info)
 
     if match is None:

--- a/codecov_auth/authentication/helpers.py
+++ b/codecov_auth/authentication/helpers.py
@@ -13,7 +13,7 @@ class UploadInfo(NamedTuple):
 def get_upload_info_from_request_path(request: HttpRequest) -> UploadInfo | None:
     path_info = request.get_full_path_info()
     # The repo part comes from https://stackoverflow.com/a/22312124
-    upload_views_prefix_regex = r"\/upload\/(\w+)\/([\w\.@:_/\-~]+)\/(commits(?:\/([a-f0-9]{40}))?|upload-coverage)"
+    upload_views_prefix_regex = r"\/upload\/(\w+)\/([\w\.@:_/\-~]+)\/(commits|upload-coverage)(?:\/([a-f0-9]{40}))?"
     match = re.search(upload_views_prefix_regex, path_info)
 
     if match is None:
@@ -21,6 +21,9 @@ def get_upload_info_from_request_path(request: HttpRequest) -> UploadInfo | None
 
     service = match.group(1)
     encoded_slug = match.group(2)
-    commitid = match.group(3)
+    if match.group(3) == "commits":
+        commitid = match.group(4)
+    else:
+        commitid = None
 
     return UploadInfo(service, encoded_slug, commitid)


### PR DESCRIPTION
### Purpose/Motivation
The new endpoint `upload/<service>/<slug>/upload-coverage` does not follow the regex `upload/<service>/<slug>/commits/...`, which is used in for example:
- `upload/<service>/<slug>/commits/<commit-sha>`
- `upload/<service>/<slug>/commits/<commit-sha>/report/<report-code>`
- `upload/<service>/<slug>/commits/<commit-sha>/report/<report-code>/upload`)

and this fix adds `upload-coverage` to the regex to correct auth behaviour for the new endpoint.

### Links to relevant tickets

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
