### PR TITLE
v2 API: add endpoint to activate and deactivate users

### DIFF
--- a/api/public/v2/owner/serializers.py
+++ b/api/public/v2/owner/serializers.py
@@ -31,3 +31,11 @@ class UserSessionSerializer(serializers.ModelSerializer):
         model = Owner
         fields = ("username", "name", "has_active_session", "expiry_date")
         read_only_fields = fields
+
+
+class UserUpdateActivationSerializer(serializers.ModelSerializer):
+    activated = serializers.BooleanField()
+
+    class Meta:
+        model = Owner
+        fields = ("activated",)

--- a/api/public/v2/tests/test_api_owner_viewset.py
+++ b/api/public/v2/tests/test_api_owner_viewset.py
@@ -63,6 +63,11 @@ class UserViewSetTests(APITestCase):
     def _detail(self, kwargs):
         return self.client.get(reverse("api-v2-users-detail", kwargs=kwargs))
 
+    def _patch(self, kwargs, data):
+        return self.client.patch(
+            reverse("api-v2-users-detail", kwargs=kwargs), data=data
+        )
+
     def setUp(self):
         self.org = OwnerFactory(service="github")
         self.current_owner = OwnerFactory(service="github", organizations=[self.org.pk])
@@ -177,6 +182,302 @@ class UserViewSetTests(APITestCase):
             "activated": False,
             "is_admin": False,
             "email": another_user.email,
+        }
+
+    def test_update_activate_by_username(self):
+        another_user = OwnerFactory(service="github", organizations=[self.org.pk])
+
+        # Activate user
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": True,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+        # Deactivate user
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": False,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+    def test_update_activate_by_ownerid(self):
+        another_user = OwnerFactory(service="github", organizations=[self.org.pk])
+
+        # Activate user
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.ownerid,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": True,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+        # Deactivate user
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.ownerid,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": False,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+    def test_update_activate_unauthorized_members_of_other_orgs(self):
+        another_org = OwnerFactory(service="github")
+        another_user = OwnerFactory(service="github", organizations=[another_org.pk])
+
+        # Activate user - not allowed
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # Deactivate user - not allowed
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # Request allowed after user joins the org
+        another_user.organizations.append(self.org.pk)
+        another_user.save()
+
+        # Activate user
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": True,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+        # Deactivate user
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": False,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+    def test_update_activate_unauthorized_not_member_of_org(self):
+        another_org = OwnerFactory(service="github")
+        another_user = OwnerFactory(service="github", organizations=[another_org.pk])
+
+        # Activate user - not allowed
+        response = self._patch(
+            kwargs={
+                "service": another_org.service,
+                "owner_username": another_org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # Deactivate user - not allowed
+        response = self._patch(
+            kwargs={
+                "service": another_org.service,
+                "owner_username": another_org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # Request owner now joins the other org and thus is allowed to activate/deactivate
+        self.current_owner.organizations.append(another_org.pk)
+        self.current_owner.save()
+
+        # Activate user
+        response = self._patch(
+            kwargs={
+                "service": another_org.service,
+                "owner_username": another_org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": True,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+        # Deactivate user
+        response = self._patch(
+            kwargs={
+                "service": another_org.service,
+                "owner_username": another_org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": False,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+    def test_update_activate_no_seats_left(self):
+        another_user = OwnerFactory(service="github", organizations=[self.org.pk])
+        another_user_2 = OwnerFactory(service="github", organizations=[self.org.pk])
+
+        # Activate user 1
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": True,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+        # Activate user 2
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user_2.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data == {
+            "detail": ErrorDetail(
+                string=f"Cannot activate user {self.org.username} -- not enough seats left.",
+                code="permission_denied",
+            )
+        }
+
+        # Deactivate user 1 to make room for user 2
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user.username,
+            },
+            data={"activated": False},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user.username,
+            "name": another_user.name,
+            "activated": False,
+            "is_admin": False,
+            "email": another_user.email,
+        }
+
+        # Activate user 2 now that there's room
+        response = self._patch(
+            kwargs={
+                "service": self.org.service,
+                "owner_username": self.org.username,
+                "user_username_or_ownerid": another_user_2.username,
+            },
+            data={"activated": True},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "service": "github",
+            "username": another_user_2.username,
+            "name": another_user_2.name,
+            "activated": True,
+            "is_admin": False,
+            "email": another_user_2.email,
         }
 
 


### PR DESCRIPTION
Introduce endpoint
`PATCH /api/v2/{service}/{owner_username}/users/{user_username_or_ownerid}/`
to activate or deactivate the specified user via request body:
`{activated: boolean}`

closes: https://github.com/codecov/feedback/issues/559

<img width="828" alt="Screenshot 2024-11-28 at 2 58 42 PM" src="https://github.com/user-attachments/assets/ddce04ce-7657-41b9-90e0-7056813c847d">


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
