### PR TITLE
[fix] Only count directly changed lines as misses when intended changes is specified

### DIFF
--- a/graphql_api/tests/test_impacted_file.py
+++ b/graphql_api/tests/test_impacted_file.py
@@ -1,5 +1,6 @@
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Callable
 from unittest.mock import PropertyMock, patch
 
 from django.test import TransactionTestCase
@@ -211,6 +212,7 @@ mock_data_from_archive = """
 class MockSegment:
     has_diff_changes: bool = False
     has_unintended_changes: bool = False
+    remove_unintended_changes: Callable[[], None] = field(default=lambda: None)
 
 
 class MockFileComparison(object):

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -98,10 +98,12 @@ def resolve_segments(
         # segments with no diff changes and at least 1 unintended change
         segments = [segment for segment in segments if segment.has_unintended_changes]
     elif filters.get("has_unintended_changes") is False:
-        # segments with at least 1 diff change
-        segments = [segment for segment in segments if segment.has_diff_changes]
-        for s in segments:
-            s.remove_unintended_changes()
+        new_segments = []
+        for segment in segments:
+            if segment.has_diff_changes:
+                segment.remove_unintended_changes()
+                new_segments.append(segment)
+        segments = new_segments
 
     return SegmentComparisons(results=segments)
 

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -100,6 +100,8 @@ def resolve_segments(
     elif filters.get("has_unintended_changes") is False:
         # segments with at least 1 diff change
         segments = [segment for segment in segments if segment.has_diff_changes]
+        for s in segments:
+            s.remove_unintended_changes()
 
     return SegmentComparisons(results=segments)
 

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -480,6 +480,15 @@ class Segment:
             if not (line.added or line.removed) and (base_coverage != head_coverage):
                 return True
         return False
+    
+    def remove_unintended_changes(self):
+        filtered = []
+        for line in self._lines:
+            base_cov = line.coverage["base"]
+            head_cov = line.coverage["head"]
+            if (line.added or line.removed) or (base_cov == head_cov):
+                filtered.append(line)
+        self._lines = filtered
 
 
 class FileComparison:

--- a/services/comparison.py
+++ b/services/comparison.py
@@ -480,7 +480,7 @@ class Segment:
             if not (line.added or line.removed) and (base_coverage != head_coverage):
                 return True
         return False
-    
+
     def remove_unintended_changes(self):
         filtered = []
         for line in self._lines:

--- a/services/tests/test_comparison.py
+++ b/services/tests/test_comparison.py
@@ -1787,50 +1787,18 @@ class ComparisonReportTest(TestCase):
 
     def test_remove_unintended_changes(self):
         lines = [
-            LineComparison(
-                {"base": 1, "head": 1},
-                {"base": 1, "head": 1},
-                "line1",
-                added=False,
-                removed=False,
-            ),
-            LineComparison(
-                {"base": 1, "head": 0},
-                {"base": 2, "head": 2},
-                "line2",
-                added=False,
-                removed=False,
-            ),
-            LineComparison(
-                {"base": 0, "head": 0},
-                {"base": None, "head": 3},
-                "+line3",
-                added=True,
-                removed=False,
-            ),
-            LineComparison(
-                {"base": 0, "head": 0},
-                {"base": 4, "head": None},
-                "-line4",
-                added=False,
-                removed=True,
-            ),
-            LineComparison(
-                {"base": 1, "head": 0},
-                {"base": 5, "head": 5},
-                "line5",
-                added=False,
-                removed=False,
-            ),
+            LineComparison(1, 1, 1, 1, "line1", False),
+            LineComparison(1, 0, 2, 2, "line2", False),
+            LineComparison(0, 0, None, 3, "+line3", True),
+            LineComparison(0, 0, 4, None, "-line4", True),
+            LineComparison(1, 0, 5, 5, "line5", False),
         ]
 
         segment = Segment(lines)
         segment.remove_unintended_changes()
 
-        # Only lines with code changes or no changes remain; coverage-only changes removed
         assert len(segment.lines) == 3
         assert [line.value for line in segment.lines] == ["line1", "+line3", "-line4"]
-
 
 class CommitComparisonTests(TestCase):
     def setUp(self):

--- a/services/tests/test_comparison.py
+++ b/services/tests/test_comparison.py
@@ -1800,6 +1800,7 @@ class ComparisonReportTest(TestCase):
         assert len(segment.lines) == 3
         assert [line.value for line in segment.lines] == ["line1", "+line3", "-line4"]
 
+
 class CommitComparisonTests(TestCase):
     def setUp(self):
         self.base_commit = CommitFactory(updatestamp=datetime(2023, 1, 1))

--- a/services/tests/test_comparison.py
+++ b/services/tests/test_comparison.py
@@ -1787,11 +1787,11 @@ class ComparisonReportTest(TestCase):
 
     def test_remove_unintended_changes(self):
         lines = [
-            LineComparison(1, 1, 1, 1, "line1", False),
-            LineComparison(1, 0, 2, 2, "line2", False),
-            LineComparison(0, 0, None, 3, "+line3", True),
-            LineComparison(0, 0, 4, None, "-line4", True),
-            LineComparison(1, 0, 5, 5, "line5", False),
+            LineComparison([1, "", [], 0, 0], [1, "", [], 0, 0], 1, 1, "line1", False),
+            LineComparison([1, "", [], 0, 0], [0, "", [], 0, 0], 2, 2, "line2", False),
+            LineComparison(None, [0, "", [], 0, 0], None, 3, "+line3", True),
+            LineComparison([0, "", [], 0, 0], None, 4, None, "-line4", True),
+            LineComparison([1, "", [], 0, 0], [0, "", [], 0, 0], 5, 5, "line5", False),
         ]
 
         segment = Segment(lines)


### PR DESCRIPTION
Closes https://github.com/orgs/codecov/projects/31/views/11?pane=issue&itemId=88922866&issue=codecov%7Cengineering-team%7C3030

We choose segments with indirectly changed lines even if a user queries for intended changes only if they have diff changes. With this PR, we will exclude those lines from each segment. 