### PR TITLE
feat: Re-enable failed payment emails

### DIFF
--- a/billing/helpers.py
+++ b/billing/helpers.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db.models import QuerySet
 from shared.plan.constants import ENTERPRISE_CLOUD_USER_PLAN_REPRESENTATIONS
 
 from codecov_auth.models import Owner
@@ -8,3 +9,17 @@ def on_enterprise_plan(owner: Owner) -> bool:
     return settings.IS_ENTERPRISE or (
         owner.plan in ENTERPRISE_CLOUD_USER_PLAN_REPRESENTATIONS.keys()
     )
+
+
+def get_all_admins_for_owners(owners: QuerySet[Owner]):
+    admin_ids = set()
+    for owner in owners:
+        if owner.admins:
+            admin_ids.update(owner.admins)
+
+        # Add the owner's email as well - for user owners, admins is empty.
+        if owner.email:
+            admin_ids.add(owner.ownerid)
+
+    admins: QuerySet[Owner] = Owner.objects.filter(pk__in=admin_ids)
+    return admins

--- a/billing/views.py
+++ b/billing/views.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.plan.service import PlanService
 
+from billing.helpers import get_all_admins_for_owners
 from codecov_auth.models import Owner
 from services.task.task import TaskService
 
@@ -66,17 +67,7 @@ class StripeWebhookHandler(APIView):
         self._log_updated(list(owners))
 
         # Send failed payment email to all owner admins
-
-        admin_ids = set()
-        for owner in owners:
-            if owner.admins:
-                admin_ids.update(owner.admins)
-
-            # Add the owner's email as well - for user owners, admins is empty.
-            if owner.email:
-                admin_ids.add(owner.ownerid)
-
-        admins: QuerySet[Owner] = Owner.objects.filter(pk__in=admin_ids)
+        admins = get_all_admins_for_owners(owners)
 
         task_service = TaskService()
         card = (
@@ -101,6 +92,15 @@ class StripeWebhookHandler(APIView):
                     name=admin.username,
                     **template_vars,
                 )
+
+        # temporary just making sure these look okay in the real world
+        task_service.send_email(
+            to_addr="spencer.murray@sentry.io",
+            subject="Your Codecov payment failed",
+            template_name="failed-payment",
+            name="spalmurray-codecov",
+            **template_vars,
+        )
 
     def customer_subscription_deleted(self, subscription: stripe.Subscription) -> None:
         log.info(

--- a/services/task/task.py
+++ b/services/task/task.py
@@ -402,8 +402,6 @@ class TaskService(object):
         from_addr: str | None = None,
         **kwargs,
     ):
-        # Disabling this while we fix HTML templates.
-        return
         # Templates can be found in worker/templates
         self._create_signature(
             "app.tasks.send_email.SendEmail",


### PR DESCRIPTION
This PR re-enables failed payment emails after fixing the template. Also pulls out the logic for fetching admins from owners to a helper function for easier reuse.
