### PR TITLE
feat: Add success after failed payment email (and fix card in failed-payment email)

### DIFF
--- a/billing/views.py
+++ b/billing/views.py
@@ -46,10 +46,41 @@ class StripeWebhookHandler(APIView):
         owners: QuerySet[Owner] = Owner.objects.filter(
             stripe_customer_id=invoice.customer,
             stripe_subscription_id=invoice.subscription,
+            delinquent=True,
         )
-        owners.update(delinquent=False)
 
+        if not owners.exists():
+            return
+
+        admins = get_all_admins_for_owners(owners)
+        owners.update(delinquent=False)
         self._log_updated(list(owners))
+
+        # Send a success email to all admins
+
+        task_service = TaskService()
+        template_vars = {
+            "amount": invoice.total / 100,
+            "date": datetime.now().strftime("%B %-d, %Y"),
+            "cta_link": invoice.hosted_invoice_url,
+        }
+
+        for admin in admins:
+            if admin.email:
+                task_service.send_email(
+                    to_addr=admin.email,
+                    subject="You're all set",
+                    template_name="success-after-failed-payment",
+                    **template_vars,
+                )
+
+        # temporary just making sure these look okay in the real world
+        task_service.send_email(
+            to_addr="spencer.murray@sentry.io",
+            subject="You're all set",
+            template_name="success-after-failed-payment",
+            **template_vars,
+        )
 
     def invoice_payment_failed(self, invoice: stripe.Invoice) -> None:
         log.info(
@@ -70,9 +101,13 @@ class StripeWebhookHandler(APIView):
         admins = get_all_admins_for_owners(owners)
 
         task_service = TaskService()
+        payment_intent = stripe.PaymentIntent.retrieve(
+            invoice["payment_intent"], expand=["payment_method"]
+        )
         card = (
-            invoice.default_payment_method.card
-            if invoice.default_payment_method
+            payment_intent.payment_method.card
+            if payment_intent.payment_method
+            and not isinstance(payment_intent.payment_method, str)
             else None
         )
         template_vars = {


### PR DESCRIPTION
This PR adds the logic for sending the new success-after-failed-payment email template. It also addresses a bug where the card wasn't being properly populated on the other failed-payment email.

Closes https://github.com/codecov/engineering-team/issues/2503
Closes https://github.com/codecov/engineering-team/issues/3119
