### PR TITLE
Make timeseries variable dynamic

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -110,6 +110,9 @@ GRAPHQL_MAX_DEPTH = get_config("setup", "graphql", "max_depth", default=20)
 
 GRAPHQL_MAX_ALIASES = get_config("setup", "graphql", "max_aliases", default=10)
 
+# Timeseries
+TIMESERIES_ENABLED = get_config("setup", "timeseries", "enabled", default=False)
+
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Seemingly we don't check for timeseries enabled in API while we do so in worker. This has worked so far cause our pods define that variable. This actually reads from your config file and makes it dynamic for people not wanting to opt to the feature.

I defaulted to false but please let me know if that's a wrong assumption.

<img width="472" alt="Screenshot 2024-12-19 at 1 32 05 PM" src="https://github.com/user-attachments/assets/710ad639-5573-4bb6-a7c1-3c23dc6df2bb" />

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/1514