### PR TITLE
chore: Remove deprecated plan name field from plan and plan representation types

### DIFF
--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -678,18 +678,18 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         query = """{
             owner(username: "%s") {
                 availablePlans {
-                    planName
+                    value
                 }
             }
         }
         """ % (current_org.username)
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["availablePlans"] == [
-            {"planName": "users-basic"},
-            {"planName": "users-pr-inappm"},
-            {"planName": "users-pr-inappy"},
-            {"planName": "users-teamm"},
-            {"planName": "users-teamy"},
+            {"value": "users-basic"},
+            {"value": "users-pr-inappm"},
+            {"value": "users-pr-inappy"},
+            {"value": "users-teamm"},
+            {"value": "users-teamy"},
         ]
 
     def test_owner_query_with_no_service(self):

--- a/graphql_api/tests/test_plan.py
+++ b/graphql_api/tests/test_plan.py
@@ -49,7 +49,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                     trialStartDate
                     trialTotalDays
                     marketingName
-                    planName
                     value
                     tierName
                     billingRate
@@ -75,7 +74,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
             "trialStartDate": "2023-06-19T00:00:00",
             "trialTotalDays": None,
             "marketingName": "Developer",
-            "planName": "users-trial",
             "value": "users-trial",
             "tierName": "pro",
             "billingRate": None,
@@ -107,7 +105,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                 owner(username: "%s") {
                     plan {
                         marketingName
-                        planName
                         value
                         tierName
                         billingRate
@@ -126,7 +123,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(query, owner=self.current_org)
         assert data["owner"]["plan"] == {
             "marketingName": "Pro",
-            "planName": "users-pr-inappy",
             "value": "users-pr-inappy",
             "tierName": "pro",
             "billingRate": "annually",

--- a/graphql_api/tests/test_plan_representation.py
+++ b/graphql_api/tests/test_plan_representation.py
@@ -35,7 +35,6 @@ class TestPlanRepresentationsType(GraphQLTestHelper, TransactionTestCase):
             owner(username: "%s") {
                 pretrialPlan {
                     marketingName
-                    planName
                     value
                     billingRate
                     baseUnitPrice
@@ -48,7 +47,6 @@ class TestPlanRepresentationsType(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["pretrialPlan"] == {
             "marketingName": "Developer",
-            "planName": "users-basic",
             "value": "users-basic",
             "billingRate": None,
             "baseUnitPrice": 0,

--- a/graphql_api/types/plan/plan.graphql
+++ b/graphql_api/types/plan/plan.graphql
@@ -11,10 +11,6 @@ type Plan {
   isTrialPlan: Boolean!
   marketingName: String!
   monthlyUploadLimit: Int
-  planName: String!
-    @deprecated(
-      reason: "Plan representations have used `value` for a while, making the frontend code hard to change"
-    )
   planUserCount: Int
   pretrialUsersCount: Int
   tierName: String!

--- a/graphql_api/types/plan/plan.py
+++ b/graphql_api/types/plan/plan.py
@@ -39,11 +39,6 @@ def resolve_marketing_name(plan_service: PlanService, info) -> str:
     return plan_service.marketing_name
 
 
-@plan_bindable.field("planName")
-def resolve_plan_name(plan_service: PlanService, info) -> str:
-    return plan_service.plan_name
-
-
 @plan_bindable.field("value")
 def resolve_plan_name_as_value(plan_service: PlanService, info) -> str:
     return plan_service.plan_name

--- a/graphql_api/types/plan_representation/plan_representation.graphql
+++ b/graphql_api/types/plan_representation/plan_representation.graphql
@@ -1,9 +1,5 @@
 type PlanRepresentation {
   marketingName: String!
-  planName: String!
-    @deprecated(
-      reason: "Plan representations have used `value` for a while, making the frontend code hard to change"
-    )
   value: String!
   billingRate: String
   baseUnitPrice: Int!

--- a/graphql_api/types/plan_representation/plan_representation.graphql
+++ b/graphql_api/types/plan_representation/plan_representation.graphql
@@ -1,8 +1,8 @@
 type PlanRepresentation {
-  marketingName: String!
-  value: String!
-  billingRate: String
   baseUnitPrice: Int!
   benefits: [String!]!
+  billingRate: String
+  marketingName: String!
   monthlyUploadLimit: Int
+  value: String!
 }

--- a/graphql_api/types/plan_representation/plan_representation.py
+++ b/graphql_api/types/plan_representation/plan_representation.py
@@ -17,11 +17,6 @@ def resolve_marketing_name(plan_data: PlanData, info) -> str:
     return plan_data.marketing_name
 
 
-@plan_representation_bindable.field("planName")
-def resolve_plan_name(plan_data: PlanData, info) -> str:
-    return plan_data.value
-
-
 @plan_representation_bindable.field("value")
 def resolve_plan_value(plan_data: PlanData, info) -> str:
     return plan_data.value


### PR DESCRIPTION
### Purpose/Motivation

This PR removes an unused field to help cleanup the plan types that we have and reduce some noise. If we plan on combining the types into one in the future this will make our life just a little bit easier.

Closes https://github.com/codecov/engineering-team/issues/3141

### Notes to Reviewer

No references in gazebo that I could see, this looks safe to remove.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
