### PR TITLE
chore: Update Stripe and pin API to latest version

### DIFF
--- a/billing/views.py
+++ b/billing/views.py
@@ -20,7 +20,7 @@ from .constants import StripeHTTPHeaders, StripeWebhookEvents
 
 if settings.STRIPE_API_KEY:
     stripe.api_key = settings.STRIPE_API_KEY
-    stripe.api_version = "2024-04-10"
+    stripe.api_version = "2024-12-18.acacia"
 
 log = logging.getLogger(__name__)
 

--- a/requirements.in
+++ b/requirements.in
@@ -56,7 +56,7 @@ sentry-sdk[celery]
 setproctitle
 simplejson
 starlette==0.40.0
-stripe>=9.6.0
+stripe>=11.4.1
 urllib3>=1.26.19
 vcrpy
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -443,7 +443,7 @@ starlette==0.40.0
     # via
     #   -r requirements.in
     #   ariadne
-stripe==9.6.0
+stripe==11.4.1
     # via -r requirements.in
 text-unidecode==1.3
     # via faker


### PR DESCRIPTION
### Purpose/Motivation

This PR bumps the stripe version from 9.6 -> 11.4.1 and changes the API version from 4/24 -> 12/24.

[Changelog](https://github.com/stripe/stripe-python/releases?page=1)

[Stripe Docs](https://docs.stripe.com/upgrades#2024-12-18.acacia)

Additional context on worker PR

Relates to https://github.com/codecov/worker/pull/981


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
