### PR TITLE
dev: Swap Transaction Test case for Test Case in api/internal tests

### DIFF
--- a/api/internal/tests/views/test_self_hosted_user_viewset.py
+++ b/api/internal/tests/views/test_self_hosted_user_viewset.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, override_settings
 from rest_framework.reverse import reverse
 from shared.django_apps.core.tests.factories import OwnerFactory
 
@@ -10,7 +10,7 @@ from utils.test_utils import APIClient
 
 
 @override_settings(IS_ENTERPRISE=True, ROOT_URLCONF="api.internal.enterprise_urls")
-class UserViewsetUnauthenticatedTestCase(TransactionTestCase):
+class UserViewsetUnauthenticatedTestCase(TestCase):
     def test_list_users(self):
         res = self.client.get(reverse("selfhosted-users-list"))
         # not authenticated
@@ -18,7 +18,7 @@ class UserViewsetUnauthenticatedTestCase(TransactionTestCase):
 
 
 @override_settings(IS_ENTERPRISE=True, ROOT_URLCONF="api.internal.enterprise_urls")
-class UserViewsetTestCase(TransactionTestCase):
+class UserViewsetTestCase(TestCase):
     def setUp(self):
         self.owner = OwnerFactory()
         self.current_owner = OwnerFactory(organizations=[self.owner.ownerid])

--- a/api/internal/tests/views/test_user_viewset.py
+++ b/api/internal/tests/views/test_user_viewset.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from rest_framework import status
 from rest_framework.reverse import reverse
-from rest_framework.test import APITransactionTestCase
+from rest_framework.test import APITestCase
 from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     PullFactory,
@@ -14,7 +14,7 @@ from core.models import Pull
 from utils.test_utils import APIClient
 
 
-class UserViewSetTests(APITransactionTestCase):
+class UserViewSetTests(APITestCase):
     def setUp(self):
         non_org_active_user = OwnerFactory()
         self.current_owner = OwnerFactory(

--- a/codecov/tests/base_test.py
+++ b/codecov/tests/base_test.py
@@ -1,10 +1,10 @@
 import json
 
 from django.conf import settings
-from django.test import TransactionTestCase
+from django.test import TestCase
 
 
-class InternalAPITest(TransactionTestCase):
+class InternalAPITest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/services/tests/test_repo_providers.py
+++ b/services/tests/test_repo_providers.py
@@ -3,11 +3,11 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.test import TransactionTestCase
 from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
 from shared.torngit import Bitbucket, Github, Gitlab
 
 from codecov.db import sync_to_async
-from codecov.tests.base_test import InternalAPITest
 from codecov_auth.models import (
     GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     GithubAppInstallation,
@@ -114,7 +114,7 @@ def test_token_refresh_callback_none_cases(should_have_owner, service, db):
     assert get_token_refresh_callback(owner, service) is None
 
 
-class TestRepoProviderService(InternalAPITest):
+class TestRepoProviderService(TransactionTestCase):
     def setUp(self):
         self.repo_gh = RepositoryFactory.create(
             author__unencrypted_oauth_token="testaaft3ituvli790m1yajovjv5eg0r4j0264iw",


### PR DESCRIPTION
### Purpose/Motivation

I was looking into ways to speed up our test suite and stumbled upon a comment on the "TestCase" class in Pytest where it mentioned it being quicker to execute than TransactionTestCase

<img width="866" alt="Screenshot 2024-12-26 at 10 57 49 AM" src="https://github.com/user-attachments/assets/e2546264-d698-4986-95e5-e04181cf8323" />


I got to tinkering a bit and saw that with a simple drop in replacement of TestCase from TransactionTestCase we were able to reduce the runtime of our api/internal pathed test suites from ~38 seconds to under 15 🤯 The results honestly astonished me, and this might end up being a better way to tackle the speed problem prior to doing the parallelization effort, which seemed kinda tough due to needing to understand all our test fixtures anyway.

I may end up creating an investigation ticket at some point to try and migrate some more of these over, or hand off to someone else, but this seems really big! Even after this initial set of updates we have 115 files (probably even more due to classes implementing TransactionTestCase and being used throughout) where we can try and make similar modifications.

**PRE**

<img width="638" alt="Screenshot 2024-12-26 at 10 55 17 AM" src="https://github.com/user-attachments/assets/d2281b08-1fb3-4430-bde4-f09da43a671e" />


**POST**

<img width="637" alt="Screenshot 2024-12-26 at 10 55 06 AM" src="https://github.com/user-attachments/assets/bfea5918-b996-4b0f-80f9-38d51eb5964f" />


### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
