### PR TITLE
fix: Missed a reference for updating API version

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -24,7 +24,7 @@ SCHEDULE_RELEASE_OFFSET = 10
 
 if settings.STRIPE_API_KEY:
     stripe.api_key = settings.STRIPE_API_KEY
-    stripe.api_version = "2024-04-10"
+    stripe.api_version = "2024-12-18.acacia"
 
 
 def _log_stripe_error(method):


### PR DESCRIPTION
Missed a reference for updating stripe version, oops

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
