### PR TITLE
feat: handle file not found from CLI

### DIFF
--- a/upload/tests/views/test_test_results.py
+++ b/upload/tests/views/test_test_results.py
@@ -7,13 +7,14 @@ from rest_framework.test import APIClient
 from shared.django_apps.codecov_auth.tests.factories import (
     OrganizationLevelTokenFactory,
 )
+from shared.django_apps.core.models import Commit
 from shared.django_apps.core.tests.factories import (
     CommitFactory,
     OwnerFactory,
     RepositoryFactory,
 )
+from shared.django_apps.reports.models import ReportSession
 
-from core.models import Commit
 from services.redis_configuration import get_redis_connection
 from services.task import TaskService
 
@@ -377,3 +378,73 @@ def test_update_repo_fields_when_upload_is_triggered(
     assert repository.active is True
     assert repository.activated is True
     assert repository.test_analytics_enabled is True
+
+
+def test_upload_test_results_file_not_found(db, client, mocker, mock_redis):
+    upload = mocker.patch.object(TaskService, "upload")
+    create_presigned_put = mocker.patch(
+        "shared.api_archive.archive.StorageService.create_presigned_put",
+        return_value="test-presigned-put",
+    )
+
+    owner = OwnerFactory(service="github", username="codecov")
+    repository = RepositoryFactory.create(author=owner)
+    commit_sha = "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef"
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"token {repository.upload_token}")
+
+    res = client.post(
+        reverse("upload-test-results"),
+        {
+            "commit": commit_sha,
+            "slug": f"{repository.author.username}::::{repository.name}",
+            "build": "test-build",
+            "buildURL": "test-build-url",
+            "job": "test-job",
+            "service": "github-actions",
+            "branch": "aaaaaa",
+            "file_not_found": True,
+        },
+        format="json",
+        headers={"User-Agent": "codecov-cli/0.4.7"},
+    )
+    assert res.status_code == 201
+
+    assert res.data is None
+
+    create_presigned_put.assert_not_called()
+
+    commit = Commit.objects.get(commitid=commit_sha)
+    assert commit
+    assert commit.branch is not None
+
+    redis = get_redis_connection()
+    args = json.loads(
+        redis.rpop(f"uploads/{repository.repoid}/{commit_sha}/test_results")
+    )
+    assert args == {
+        "reportid": mocker.ANY,
+        "build": "test-build",
+        "build_url": "test-build-url",
+        "job": "test-job",
+        "service": "github-actions",
+        "url": "placeholder",
+        "commit": commit_sha,
+        "report_code": None,
+        "flags": None,
+    }
+
+    # sets latest upload timestamp
+    ts = redis.get(f"latest_upload/{repository.repoid}/{commit_sha}/test_results")
+    assert ts
+
+    # triggers upload task
+    upload.assert_called_with(
+        commitid=commit_sha,
+        repoid=repository.repoid,
+        report_code=None,
+        report_type="test_results",
+        arguments=args,
+        countdown=4,
+    )

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -51,6 +51,7 @@ class UploadSerializer(serializers.Serializer):
     pr = serializers.CharField(required=False)
     branch = serializers.CharField(required=False, allow_null=True)
     storage_path = serializers.CharField(required=False)
+    file_not_found = serializers.BooleanField(required=False)
 
 
 class TestResultsView(
@@ -136,18 +137,23 @@ class TestResultsView(
 
         upload_external_id = str(uuid.uuid4())
 
-        archive_service = ArchiveService(repo)
+        url = None
+        file_not_found = data.get("file_not_found", False)
+        if file_not_found:
+            storage_path = "placeholder"
+        else:
+            archive_service = ArchiveService(repo)
 
-        storage_path = data.get("storage_path", None)
-        if storage_path is None or not self.is_shelter_request():
-            storage_path = MinioEndpoints.test_results.get_path(
-                date=timezone.now().strftime("%Y-%m-%d"),
-                repo_hash=archive_service.get_archive_hash(repo),
-                commit_sha=data["commit"],
-                uploadid=upload_external_id,
-            )
+            storage_path = data.get("storage_path", None)
+            if storage_path is None or not self.is_shelter_request():
+                storage_path = MinioEndpoints.test_results.get_path(
+                    date=timezone.now().strftime("%Y-%m-%d"),
+                    repo_hash=archive_service.get_archive_hash(repo),
+                    commit_sha=data["commit"],
+                    uploadid=upload_external_id,
+                )
 
-        url = archive_service.create_presigned_put(storage_path)
+            url = archive_service.create_presigned_put(storage_path)
 
         task_arguments = {
             # these are used in the upload task when saving an upload record
@@ -181,4 +187,7 @@ class TestResultsView(
             report_type=CommitReport.ReportType.TEST_RESULTS,
         )
 
-        return Response({"raw_upload_location": url}, status=201)
+        if url is None:
+            return Response(status=201)
+        else:
+            return Response({"raw_upload_location": url}, status=201)


### PR DESCRIPTION
we want to be able to notify the user with a comment when they get a file not found error from the CLI so this is our way of doing that

we create a "placeholder" upload which represents this attempt at an upload that was not able to find a file

this upload goes through the upload flow with a placeholder storage path (because we don't want the user to upload anything here) and when it gets to the TA processor, that step will create an upload error which will get notified like all other errors