### PR TITLE
[fix] Fix trial status resolver when status is None

### DIFF
--- a/graphql_api/tests/test_plan.py
+++ b/graphql_api/tests/test_plan.py
@@ -243,3 +243,25 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
         data = self.gql_request(query, owner=enterprise_org)
         assert data["owner"]["plan"]["planUserCount"] == 0
         assert data["owner"]["plan"]["hasSeatsLeft"] == False
+
+    def test_owner_plan_data_when_trial_status_is_none(self):
+        now = timezone.now()
+        later = now + timedelta(days=14)
+        current_org = OwnerFactory(
+            username="random-plan-user",
+            service="github",
+            plan=PlanName.TRIAL_PLAN_NAME.value,
+            trial_start_date=now,
+            trial_end_date=later,
+            trial_status=None,
+        )
+        query = """{
+            owner(username: "%s") {
+                plan {
+                    trialStatus
+                }
+            }
+        }
+        """ % (current_org.username)
+        data = self.gql_request(query, owner=current_org)
+        assert data["owner"]["plan"]["trialStatus"] == "NOT_STARTED"

--- a/graphql_api/types/plan/plan.py
+++ b/graphql_api/types/plan/plan.py
@@ -30,6 +30,8 @@ def resolve_trial_end_date(plan_service: PlanService, info) -> Optional[datetime
 
 @plan_bindable.field("trialStatus")
 def resolve_trial_status(plan_service: PlanService, info) -> TrialStatus:
+    if plan_service.trial_status is None:
+        return TrialStatus.NOT_STARTED
     return TrialStatus(plan_service.trial_status)
 
 


### PR DESCRIPTION
Resolves the following error

```
None is not a valid TrialStatus\n\nGraphQL request:14:9\n13 | trialEndDate\n14 | trialStatus\n | ^\n15 | trialStartDate
...
File \"/app/graphql_api/types/plan/plan.py\", line 35, in resolve_trial_status\n return TrialStatus(plan_service.trial_status)\n
```