### PR TITLE
fix: Fix deactivated enterprise user when no plan activated users

### DIFF
--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -806,6 +806,26 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
             assert e.message == UnauthorizedGuestAccess.message
             assert e.extensions["code"] == UnauthorizedGuestAccess.code
 
+    @override_settings(IS_ENTERPRISE=True, GUEST_ACCESS=False)
+    def test_fetch_owner_plan_activated_users_is_none(self):
+        """
+        This test is when Enterprise guest access is disabled, and you are
+        trying to view an org that does not track plan activated users (e.g., historic data)
+        """
+        user = OwnerFactory(username="sample-user")
+        owner = OwnerFactory(username="sample-owner", plan_activated_users=None)
+        user.save()
+        owner.save()
+        query = """{
+            owner(username: "%s") {
+                username
+            }
+        }
+        """ % (owner.username)
+
+        data = self.gql_request(query, owner=user)
+        assert data["owner"]["username"] == "sample-owner"
+
     def test_fetch_current_user_is_okta_authenticated(self):
         account = AccountFactory()
         owner = OwnerFactory(username="sample-owner", service="github", account=account)

--- a/graphql_api/types/query/query.py
+++ b/graphql_api/types/query/query.py
@@ -51,9 +51,13 @@ async def resolve_owner(
     if settings.IS_ENTERPRISE and settings.GUEST_ACCESS is False:
         if not user or not user.is_authenticated:
             raise UnauthorizedGuestAccess()
+
+        # if the owner tracks plan activated users, check if the user is in the list
         target_owner = await get_owner(service, username)
         has_plan_activated_users = (
-            target_owner and target_owner.plan_activated_users is not None
+            target_owner
+            and target_owner.plan_activated_users is not None
+            and len(target_owner.plan_activated_users) > 0
         )
         if (
             has_plan_activated_users

--- a/graphql_api/types/query/query.py
+++ b/graphql_api/types/query/query.py
@@ -51,9 +51,9 @@ async def resolve_owner(
     if settings.IS_ENTERPRISE and settings.GUEST_ACCESS is False:
         if not user or not user.is_authenticated:
             raise UnauthorizedGuestAccess()
-
-        target = await get_owner(service, username)
-        if user.ownerid not in target.plan_activated_users:
+        target_owner = await get_owner(service, username)
+        has_plan_activated_users = target_owner and target_owner.plan_activated_users is not None
+        if has_plan_activated_users and user.ownerid not in target_owner.plan_activated_users:
             raise UnauthorizedGuestAccess()
 
     return await get_owner(service, username)

--- a/graphql_api/types/query/query.py
+++ b/graphql_api/types/query/query.py
@@ -52,8 +52,13 @@ async def resolve_owner(
         if not user or not user.is_authenticated:
             raise UnauthorizedGuestAccess()
         target_owner = await get_owner(service, username)
-        has_plan_activated_users = target_owner and target_owner.plan_activated_users is not None
-        if has_plan_activated_users and user.ownerid not in target_owner.plan_activated_users:
+        has_plan_activated_users = (
+            target_owner and target_owner.plan_activated_users is not None
+        )
+        if (
+            has_plan_activated_users
+            and user.ownerid not in target_owner.plan_activated_users
+        ):
             raise UnauthorizedGuestAccess()
 
     return await get_owner(service, username)


### PR DESCRIPTION
Follows up to https://github.com/codecov/codecov-api/pull/910 which added restrictions to Enterprise "guest_access: off" behavior.

This PR adds in a fix to account for when a user owner does not have any plan_activated_users. From what I could tell from our current data model this is not possible, but I think historic data ends up with this case which caused the reported issue by customer, so fixed with this PR.
