### PR TITLE
fix: Handle disabled shelter

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -395,6 +395,7 @@ DISABLE_GIT_BASED_LOGIN = IS_ENTERPRISE and get_config(
 )
 
 SHELTER_SHARED_SECRET = get_config("setup", "shelter_shared_secret", default=None)
+SHELTER_ENABLED = get_config("setup", "shelter_enabled", default=True)
 
 SENTRY_ENV = os.environ.get("CODECOV_ENV", False)
 SENTRY_DSN = os.environ.get("SERVICES__SENTRY__SERVER_DSN", None)

--- a/codecov/settings_enterprise.py
+++ b/codecov/settings_enterprise.py
@@ -72,3 +72,5 @@ CSRF_TRUSTED_ORIGINS = [
 ]
 
 GUEST_ACCESS = get_config("setup", "guest_access", default=True)
+
+SHELTER_ENABLED = get_config("setup", "shelter_enabled", default=False)

--- a/utils/shelter.py
+++ b/utils/shelter.py
@@ -23,6 +23,9 @@ class ShelterPubsub:
         return cls._instance
 
     def __init__(self) -> None:
+        if not settings.SHELTER_ENABLED:
+            return
+
         if not self.pubsub_publisher:
             self.pubsub_publisher = pubsub_v1.PublisherClient()
         pubsub_project_id: str = settings.SHELTER_PUBSUB_PROJECT_ID
@@ -32,6 +35,9 @@ class ShelterPubsub:
         self.topic_path = self.pubsub_publisher.topic_path(pubsub_project_id, topic_id)
 
     def publish(self, data: Dict[str, Any]) -> None:
+        if not settings.SHELTER_ENABLED:
+            return
+
         try:
             self.pubsub_publisher.publish(
                 self.topic_path,


### PR DESCRIPTION
In self-hosted / enterprise, our customers may not always have shelter deployed. Only initialize the shelter PubSub client if shelter is enabled.
This fixes a bug where regenerateOrgUploadToken was failing when the token object was attempted to create but the corresponding signal failed.

I tested against local gazebo pointed to this with enterprise env vars that an org upload token was generated

Closes https://github.com/codecov/engineering-team/issues/3211
