### PR TITLE
feat: Add repoid to repository graphql schema

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -51,6 +51,7 @@ query Repositories($repoNames: [String!]!) {
 """
 
 default_fields = """
+    repoid
     name
     active
     private
@@ -103,6 +104,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     @freeze_time("2021-01-01")
     def test_when_repository_has_no_coverage(self):
         repo = RepositoryFactory(
+            repoid=1,
             author=self.owner,
             active=True,
             private=True,
@@ -122,6 +124,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             + "coverageAnalytics { percentCovered commitSha hits misses lines },",
         ) == {
             "__typename": "Repository",
+            "repoid": 1,
             "name": "a",
             "active": True,
             "private": True,
@@ -154,6 +157,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
     @freeze_time("2021-01-01")
     def test_when_repository_has_coverage(self):
         repo = RepositoryFactory(
+            repoid=1,
             author=self.owner,
             active=True,
             private=True,
@@ -186,6 +190,7 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             + "coverageAnalytics { percentCovered commitSha hits misses lines },",
         ) == {
             "__typename": "Repository",
+            "repoid": 1,
             "name": "b",
             "active": True,
             "latestCommitAt": None,

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -3,6 +3,7 @@ Repository is a named collection of files uploaded
 """
 type Repository {
   isFirstPullRequest: Boolean!
+  repoid: Int!
   name: String!
   active: Boolean!
   activated: Boolean!

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -41,6 +41,16 @@ repository_bindable.set_alias("updatedAt", "updatestamp")
 repository_bindable.set_alias("latestCommitAt", "true_latest_commit_at")
 
 
+@repository_bindable.field("repoid")
+def resolve_repoid(repository: Repository, info: GraphQLResolveInfo) -> int:
+    return repository.repoid
+
+
+@repository_bindable.field("name")
+def resolve_name(repository: Repository, info: GraphQLResolveInfo) -> str:
+    return repository.name
+
+
 @repository_bindable.field("oldestCommitAt")
 def resolve_oldest_commit_at(
     repository: Repository, info: GraphQLResolveInfo


### PR DESCRIPTION
Exposes repoid in our GraphQL repository schema. This is necessitated by incoming Amplitude integration in Gazebo.
