### PR TITLE
Update `shared` to pull in migrations

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ freezegun
 google-cloud-pubsub
 gunicorn>=22.0.0
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/de4b37bc5a736317c6e7c93f9c58e9ae07f8c96b.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/07b39b24cc32b384df311262e4253f0c891562db.tar.gz#egg=shared
 https://github.com/photocrowd/django-cursor-pagination/archive/f560902696b0c8509e4d95c10ba0d62700181d84.tar.gz
 idna>=3.7
 minio

--- a/requirements.txt
+++ b/requirements.txt
@@ -416,7 +416,7 @@ sentry-sdk[celery]==2.13.0
     #   shared
 setproctitle==1.1.10
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/de4b37bc5a736317c6e7c93f9c58e9ae07f8c96b.tar.gz
+shared @ https://github.com/codecov/shared/archive/07b39b24cc32b384df311262e4253f0c891562db.tar.gz
     # via -r requirements.in
 simplejson==3.17.2
     # via -r requirements.in


### PR DESCRIPTION
This primarily pulls in https://github.com/codecov/shared/pull/442 to remove some unused indices from the production table, and align the migration state with the reality of the DB.