### PR TITLE
dev: Add Ruff print rules to API (T20)

### DIFF
--- a/codecov_auth/commands/owner/interactors/get_is_current_user_an_admin.py
+++ b/codecov_auth/commands/owner/interactors/get_is_current_user_an_admin.py
@@ -50,5 +50,5 @@ class GetIsCurrentUserAnAdminInteractor(BaseInteractor):
                         owner.add_admin(current_owner)
                     return isAdmin or (current_owner.ownerid in admins)
                 except Exception as error:
-                    print("Error Calling Admin Provider " + repr(error))
+                    print("Error Calling Admin Provider " + repr(error))  # noqa: T201
                     return False

--- a/core/management/commands/check_for_migration_conflicts.py
+++ b/core/management/commands/check_for_migration_conflicts.py
@@ -22,12 +22,11 @@ class Command(BaseCommand):
                 for prefix, grouped_migrations in migrations_by_prefix.items():
                     if len(grouped_migrations) > 1:
                         conflicts_found = True
-                        print(
+                        print(  # noqa: T201
                             f"Conflict found in migrations for {app.name} with prefix {prefix}:"
                         )
                         for grouped_migration in grouped_migrations:
-                            print(grouped_migration)
-                        print()
+                            print(grouped_migration)  # noqa: T201
             # It's expected to not find migration folders for Django/3rd party apps
             except FileNotFoundError:
                 pass
@@ -35,4 +34,4 @@ class Command(BaseCommand):
         if conflicts_found:
             raise Exception("Found conflicts in migrations.")
         else:
-            print("No conflicts found!")
+            print("No conflicts found!")  # noqa: T201

--- a/core/management/commands/delete_rate_limit_keys.py
+++ b/core/management/commands/delete_rate_limit_keys.py
@@ -21,8 +21,8 @@ class Command(BaseCommand):
             for key in redis.scan_iter(path):
                 # -1 means the key has no expiry
                 if redis.ttl(key) == -1:
-                    print(f"Deleting key: {key.decode('utf-8')}")
+                    print(f"Deleting key: {key.decode('utf-8')}")  # noqa: T201
                     redis.delete(key)
         except Exception as e:
-            print("Error occurred when deleting redis keys")
-            print(e)
+            print("Error occurred when deleting redis keys")  # noqa: T201
+            print(e)  # noqa: T201

--- a/core/management/commands/update_gitlab_webhooks.py
+++ b/core/management/commands/update_gitlab_webhooks.py
@@ -31,11 +31,8 @@ class Command(BaseCommand):
         )
 
         for repo in repos:
-            print("repoid:", repo.pk)
-
             user = get_bot_user(repo)
             if user is None:
-                print("no bot user")
                 continue
 
             webhook_secret = str(uuid.uuid4())
@@ -63,7 +60,7 @@ class Command(BaseCommand):
                 repo.webhook_secret = webhook_secret
                 repo.save()
             except TorngitClientError as e:
-                print("error making GitLab API call")
-                print(e)
+                print("error making GitLab API call")  # noqa: T201
+                print(e)  # noqa: T201
             except TorngitRefreshTokenFailedError:
-                print("refresh token failed")
+                print("refresh token failed")  # noqa: T201

--- a/graphql_api/tests/test_plan.py
+++ b/graphql_api/tests/test_plan.py
@@ -210,7 +210,6 @@ class TestPlanType(GraphQLTestHelper, TransactionTestCase):
                 }
                 """ % (enterprise_org.username)
         data = self.gql_request(query, owner=enterprise_org)
-        print(data, "look here 1")
         assert data["owner"]["plan"]["planUserCount"] == 5
         assert data["owner"]["plan"]["hasSeatsLeft"] == False
 

--- a/open_telemetry.py
+++ b/open_telemetry.py
@@ -141,15 +141,15 @@ class CodecovExporter(SpanExporter):
             logging.exception("failed to export all spans")
             return SpanExportResult.FAILURE
         except requests.HTTPError as e:
-            print(e)
-            logging.exception("HTTP server returned erroneous response")
+            logging.exception(
+                "HTTP server returned erroneous response", extra=dict(error=e)
+            )
             return SpanExportResult.FAILURE
         except requests.Timeout:
             logging.exception("request timed out")
             return SpanExportResult.FAILURE
         except Exception as e:
-            print(e)
-            logging.exception("request failed")
+            logging.exception("request failed", extra=dict(error=e))
             return SpanExportResult.FAILURE
 
         return SpanExportResult.SUCCESS

--- a/ruff.toml
+++ b/ruff.toml
@@ -46,6 +46,7 @@ select = [
     "PERF", # perflint - performance anti-pattern rules
     "PLC", # pylint - convention rules
     "PLE", # pylint - error rules
+    "T20", # flake8-print - print statements
     "W", # pycodestyle - warning rules
 ]
 ignore = ["F405", "F403", "E501", "E712", "C408"]


### PR DESCRIPTION
This PR aims to add the ruff print rules to API, and either removes or ignores each print statement (I just used my best judgement)

Ruff rules can be found here: https://docs.astral.sh/ruff/rules/#flake8-print-t20

Closes https://github.com/codecov/engineering-team/issues/3279


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
