### PR TITLE
feat: Add list unverified payment methods api

### DIFF
--- a/graphql_api/tests/test_billing.py
+++ b/graphql_api/tests/test_billing.py
@@ -58,7 +58,9 @@ class BillingTestCase(GraphQLTestHelper, TransactionTestCase):
             patch("services.billing.stripe.SetupIntent.list") as setup_intent_list_mock,
         ):
             payment_intent_list_mock.return_value.data = [payment_intent]
+            payment_intent_list_mock.return_value.has_more = False
             setup_intent_list_mock.return_value.data = [setup_intent]
+            setup_intent_list_mock.return_value.has_more = False
 
             result = self.gql_request(query, owner=self.owner)
 

--- a/graphql_api/tests/test_billing.py
+++ b/graphql_api/tests/test_billing.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+from django.test import TransactionTestCase
+from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
+from stripe.api_resources import PaymentIntent, SetupIntent
+
+from .helper import GraphQLTestHelper
+
+
+class BillingTestCase(GraphQLTestHelper, TransactionTestCase):
+    def setUp(self):
+        self.owner = OwnerFactory(stripe_customer_id="test-customer-id")
+
+    def test_fetch_unverified_payment_methods(self):
+        query = """
+            query {
+                owner(username: "%s") {
+                    billing {
+                        unverifiedPaymentMethods {
+                            paymentMethodId
+                            hostedVerificationUrl
+                        }
+                    }
+                }
+            }
+        """ % (self.owner.username)
+
+        payment_intent = PaymentIntent.construct_from(
+            {
+                "payment_method": "pm_123",
+                "next_action": {
+                    "type": "verify_with_microdeposits",
+                    "verify_with_microdeposits": {
+                        "hosted_verification_url": "https://verify.stripe.com/1"
+                    },
+                },
+            },
+            "fake_api_key",
+        )
+
+        setup_intent = SetupIntent.construct_from(
+            {
+                "payment_method": "pm_456",
+                "next_action": {
+                    "type": "verify_with_microdeposits",
+                    "verify_with_microdeposits": {
+                        "hosted_verification_url": "https://verify.stripe.com/2"
+                    },
+                },
+            },
+            "fake_api_key",
+        )
+
+        with (
+            patch(
+                "services.billing.stripe.PaymentIntent.list"
+            ) as payment_intent_list_mock,
+            patch("services.billing.stripe.SetupIntent.list") as setup_intent_list_mock,
+        ):
+            payment_intent_list_mock.return_value.data = [payment_intent]
+            setup_intent_list_mock.return_value.data = [setup_intent]
+
+            result = self.gql_request(query, owner=self.owner)
+
+        assert "errors" not in result
+        data = result["owner"]["billing"]["unverifiedPaymentMethods"]
+        assert len(data) == 2
+        assert data[0]["paymentMethodId"] == "pm_123"
+        assert data[0]["hostedVerificationUrl"] == "https://verify.stripe.com/1"
+        assert data[1]["paymentMethodId"] == "pm_456"
+        assert data[1]["hostedVerificationUrl"] == "https://verify.stripe.com/2"

--- a/graphql_api/types/__init__.py
+++ b/graphql_api/types/__init__.py
@@ -3,7 +3,7 @@ from ariadne_django.scalars import datetime_scalar
 
 from ..helpers.ariadne import ariadne_load_local_graphql
 from .account import account, account_bindable
-from .billing import billing_bindable
+from .billing import billing, billing_bindable
 from .branch import branch, branch_bindable
 from .bundle_analysis import (
     bundle_analysis,
@@ -30,10 +30,7 @@ from .comparison import comparison, comparison_bindable, comparison_result_binda
 from .component import component, component_bindable
 from .component_comparison import component_comparison, component_comparison_bindable
 from .config import config, config_bindable
-from .coverage_analytics import (
-    coverage_analytics,
-    coverage_analytics_bindable,
-)
+from .coverage_analytics import coverage_analytics, coverage_analytics_bindable
 from .coverage_totals import coverage_totals, coverage_totals_bindable
 from .enums import enum_types
 from .file import commit_file, file_bindable

--- a/graphql_api/types/__init__.py
+++ b/graphql_api/types/__init__.py
@@ -3,6 +3,7 @@ from ariadne_django.scalars import datetime_scalar
 
 from ..helpers.ariadne import ariadne_load_local_graphql
 from .account import account, account_bindable
+from .billing import billing_bindable
 from .branch import branch, branch_bindable
 from .bundle_analysis import (
     bundle_analysis,
@@ -90,6 +91,7 @@ inputs = ariadne_load_local_graphql(__file__, "./inputs")
 enums = ariadne_load_local_graphql(__file__, "./enums")
 errors = ariadne_load_local_graphql(__file__, "./errors")
 types = [
+    billing,
     branch,
     bundle_analysis_comparison,
     bundle_analysis_report,
@@ -140,6 +142,7 @@ types = [
 bindables = [
     *enum_types.enum_types,
     *mutation_resolvers,
+    billing_bindable,
     branch_bindable,
     bundle_analysis_comparison_bindable,
     bundle_analysis_comparison_result_bindable,

--- a/graphql_api/types/billing/__init__.py
+++ b/graphql_api/types/billing/__init__.py
@@ -1,0 +1,8 @@
+from graphql_api.helpers.ariadne import ariadne_load_local_graphql
+
+from .billing import billing_bindable
+
+billing = ariadne_load_local_graphql(__file__, "billing.graphql")
+
+
+__all__ = ["billing_bindable"]

--- a/graphql_api/types/billing/billing.graphql
+++ b/graphql_api/types/billing/billing.graphql
@@ -1,0 +1,8 @@
+type Billing {
+  unVerifiedPaymentMethods: [UnverifiedPaymentMethod!]!
+}
+
+type UnverifiedPaymentMethod {
+  paymentMethodId: String!
+  hostedVerificationUrl: String
+}

--- a/graphql_api/types/billing/billing.graphql
+++ b/graphql_api/types/billing/billing.graphql
@@ -1,5 +1,5 @@
 type Billing {
-  unVerifiedPaymentMethods: [UnverifiedPaymentMethod!]!
+  unverifiedPaymentMethods: [UnverifiedPaymentMethod]
 }
 
 type UnverifiedPaymentMethod {

--- a/graphql_api/types/billing/billing.py
+++ b/graphql_api/types/billing/billing.py
@@ -1,0 +1,14 @@
+from ariadne import ObjectType
+from graphql import GraphQLResolveInfo
+
+from codecov_auth.models import Owner
+from services.billing import BillingService
+
+billing_bindable = ObjectType("Billing")
+
+
+@billing_bindable.field("unverifiedPaymentMethods")
+def resolve_unverified_payment_methods(
+    owner: Owner, info: GraphQLResolveInfo
+) -> list[dict]:
+    return BillingService(requesting_user=owner).get_unverified_payment_methods()

--- a/graphql_api/types/billing/billing.py
+++ b/graphql_api/types/billing/billing.py
@@ -11,4 +11,4 @@ billing_bindable = ObjectType("Billing")
 def resolve_unverified_payment_methods(
     owner: Owner, info: GraphQLResolveInfo
 ) -> list[dict]:
-    return BillingService(requesting_user=owner).get_unverified_payment_methods()
+    return BillingService(requesting_user=owner).get_unverified_payment_methods(owner)

--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -2,6 +2,7 @@ type Owner {
   account: Account
   availablePlans: [PlanRepresentation!]
   avatarUrl: String!
+  billing: Billing
   defaultOrgUsername: String
   delinquent: Boolean
   hashOwnerid: String

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -396,3 +396,10 @@ def resolve_upload_token_required(
 @require_shared_account_or_part_of_org
 def resolve_activated_user_count(owner: Owner, info: GraphQLResolveInfo) -> int:
     return owner.activated_user_count
+
+
+
+@owner_bindable.field("billing")
+@sync_to_async
+@require_part_of_org
+def resolve_billing(owner: Owner, info: GraphQLResolveInfo) -> dict | None:

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -25,9 +25,7 @@ from codecov_auth.models import (
 )
 from codecov_auth.views.okta_cloud import OKTA_SIGNED_IN_ACCOUNTS_SESSION_KEY
 from core.models import Repository
-from graphql_api.actions.repository import (
-    list_repository_for_owner,
-)
+from graphql_api.actions.repository import list_repository_for_owner
 from graphql_api.helpers.ariadne import ariadne_load_local_graphql
 from graphql_api.helpers.connection import (
     Connection,
@@ -398,8 +396,8 @@ def resolve_activated_user_count(owner: Owner, info: GraphQLResolveInfo) -> int:
     return owner.activated_user_count
 
 
-
 @owner_bindable.field("billing")
 @sync_to_async
 @require_part_of_org
 def resolve_billing(owner: Owner, info: GraphQLResolveInfo) -> dict | None:
+    return owner

--- a/services/billing.py
+++ b/services/billing.py
@@ -6,10 +6,7 @@ from datetime import datetime, timezone
 import stripe
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from shared.plan.constants import (
-    PlanBillingRate,
-    TierName,
-)
+from shared.plan.constants import PlanBillingRate, TierName
 from shared.plan.service import PlanService
 
 from billing.constants import REMOVED_INVOICE_STATUSES
@@ -744,7 +741,7 @@ class StripeService(AbstractPaymentService):
             payment_intents = stripe.PaymentIntent.list(
                 customer=owner.stripe_customer_id,
                 limit=20,
-                starting_after=starting_after
+                starting_after=starting_after,
             )
             for intent in payment_intents.data or []:
                 if (
@@ -771,7 +768,7 @@ class StripeService(AbstractPaymentService):
             setup_intents = stripe.SetupIntent.list(
                 customer=owner.stripe_customer_id,
                 limit=20,
-                starting_after=starting_after
+                starting_after=starting_after,
             )
             for intent in setup_intents.data:
                 if (

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import requests
 from django.conf import settings
@@ -1847,6 +1847,7 @@ class StripeServiceTests(TestCase):
         owner = OwnerFactory(stripe_customer_id="test-customer-id")
         payment_intent = PaymentIntent.construct_from(
             {
+                "id": "pi_123",
                 "payment_method": "pm_123",
                 "next_action": {
                     "type": "verify_with_microdeposits",
@@ -1860,6 +1861,7 @@ class StripeServiceTests(TestCase):
 
         setup_intent = SetupIntent.construct_from(
             {
+                "id": "si_123",
                 "payment_method": "pm_456",
                 "next_action": {
                     "type": "verify_with_microdeposits",
@@ -1872,7 +1874,9 @@ class StripeServiceTests(TestCase):
         )
 
         payment_intent_list_mock.return_value.data = [payment_intent]
+        payment_intent_list_mock.return_value.has_more = False
         setup_intent_list_mock.return_value.data = [setup_intent]
+        setup_intent_list_mock.return_value.has_more = False
 
         expected = [
             {
@@ -1885,6 +1889,123 @@ class StripeServiceTests(TestCase):
             },
         ]
         assert self.stripe.get_unverified_payment_methods(owner) == expected
+
+    @patch("services.billing.stripe.PaymentIntent.list")
+    @patch("services.billing.stripe.SetupIntent.list")
+    def test_get_unverified_payment_methods_pagination(
+        self, setup_intent_list_mock, payment_intent_list_mock
+    ):
+        owner = OwnerFactory(stripe_customer_id="test-customer-id")
+
+        # Create 42 payment intents with only 2 having microdeposits verification
+        payment_intents = []
+        for i in range(42):
+            next_action = None
+            if i in [0, 41]:  # First and last have verification
+                next_action = {
+                    "type": "verify_with_microdeposits",
+                    "verify_with_microdeposits": {
+                        "hosted_verification_url": f"https://verify.stripe.com/pi_{i}"
+                    },
+                }
+            payment_intents.append(
+                PaymentIntent.construct_from(
+                    {
+                        "id": f"pi_{i}",
+                        "payment_method": f"pm_pi_{i}",
+                        "next_action": next_action,
+                    },
+                    "fake_api_key",
+                )
+            )
+
+        # Create 42 setup intents with only 2 having microdeposits verification
+        setup_intents = []
+        for i in range(42):
+            next_action = None
+            if i in [0, 41]:  # First and last have verification
+                next_action = {
+                    "type": "verify_with_microdeposits",
+                    "verify_with_microdeposits": {
+                        "hosted_verification_url": f"https://verify.stripe.com/si_{i}"
+                    },
+                }
+            setup_intents.append(
+                SetupIntent.construct_from(
+                    {
+                        "id": f"si_{i}",
+                        "payment_method": f"pm_si_{i}",
+                        "next_action": next_action,
+                    },
+                    "fake_api_key",
+                )
+            )
+
+        # Split into pages of 20
+        payment_intent_pages = [
+            type(
+                "obj",
+                (object,),
+                {
+                    "data": payment_intents[i : i + 20],
+                    "has_more": i + 20 < len(payment_intents),
+                },
+            )
+            for i in range(0, len(payment_intents), 20)
+        ]
+
+        setup_intent_pages = [
+            type(
+                "obj",
+                (object,),
+                {
+                    "data": setup_intents[i : i + 20],
+                    "has_more": i + 20 < len(setup_intents),
+                },
+            )
+            for i in range(0, len(setup_intents), 20)
+        ]
+
+        payment_intent_list_mock.side_effect = payment_intent_pages
+        setup_intent_list_mock.side_effect = setup_intent_pages
+
+        expected = [
+            {
+                "payment_method_id": "pm_pi_0",
+                "hosted_verification_url": "https://verify.stripe.com/pi_0",
+            },
+            {
+                "payment_method_id": "pm_pi_41",
+                "hosted_verification_url": "https://verify.stripe.com/pi_41",
+            },
+            {
+                "payment_method_id": "pm_si_0",
+                "hosted_verification_url": "https://verify.stripe.com/si_0",
+            },
+            {
+                "payment_method_id": "pm_si_41",
+                "hosted_verification_url": "https://verify.stripe.com/si_41",
+            },
+        ]
+
+        result = self.stripe.get_unverified_payment_methods(owner)
+        assert result == expected
+        assert len(result) == 4  # Verify we got exactly 4 results
+
+        # Verify pagination calls
+        payment_intent_calls = [
+            call(customer="test-customer-id", limit=20, starting_after=None),
+            call(customer="test-customer-id", limit=20, starting_after="pi_19"),
+            call(customer="test-customer-id", limit=20, starting_after="pi_39"),
+        ]
+        setup_intent_calls = [
+            call(customer="test-customer-id", limit=20, starting_after=None),
+            call(customer="test-customer-id", limit=20, starting_after="si_19"),
+            call(customer="test-customer-id", limit=20, starting_after="si_39"),
+        ]
+
+        payment_intent_list_mock.assert_has_calls(payment_intent_calls)
+        setup_intent_list_mock.assert_has_calls(setup_intent_calls)
 
 
 class MockPaymentService(AbstractPaymentService):

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from shared.django_apps.core.tests.factories import OwnerFactory
 from shared.plan.constants import PlanName
 from stripe import InvalidRequestError
+from stripe.api_resources import PaymentIntent, SetupIntent
 
 from codecov_auth.models import Service
 from services.billing import AbstractPaymentService, BillingService, StripeService
@@ -1831,6 +1832,53 @@ class StripeServiceTests(TestCase):
         setup_intent_create_mock.return_value = {"client_secret": "test-client-secret"}
         resp = self.stripe.create_setup_intent(owner)
         assert resp["client_secret"] == "test-client-secret"
+
+    @patch("services.billing.stripe.PaymentIntent.list")
+    @patch("services.billing.stripe.SetupIntent.list")
+    def test_get_unverified_payment_methods(
+        self, setup_intent_list_mock, payment_intent_list_mock
+    ):
+        owner = OwnerFactory(stripe_customer_id="test-customer-id")
+        payment_intent = PaymentIntent.construct_from(
+            {
+                "payment_method": "pm_123",
+                "next_action": {
+                    "type": "verify_with_microdeposits",
+                    "verify_with_microdeposits": {
+                        "hosted_verification_url": "https://verify.stripe.com/1"
+                    },
+                },
+            },
+            "fake_api_key",
+        )
+
+        setup_intent = SetupIntent.construct_from(
+            {
+                "payment_method": "pm_456",
+                "next_action": {
+                    "type": "verify_with_microdeposits",
+                    "verify_with_microdeposits": {
+                        "hosted_verification_url": "https://verify.stripe.com/2"
+                    },
+                },
+            },
+            "fake_api_key",
+        )
+
+        payment_intent_list_mock.return_value.data = [payment_intent]
+        setup_intent_list_mock.return_value.data = [setup_intent]
+
+        expected = [
+            {
+                "payment_method_id": "pm_123",
+                "hosted_verification_url": "https://verify.stripe.com/1",
+            },
+            {
+                "payment_method_id": "pm_456",
+                "hosted_verification_url": "https://verify.stripe.com/2",
+            },
+        ]
+        assert self.stripe.get_unverified_payment_methods(owner) == expected
 
 
 class MockPaymentService(AbstractPaymentService):

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -45,10 +45,10 @@ class TestMigrations(TestCase):
     migrate_to = None
 
     def setUp(self) -> None:
-        assert (
-            self.migrate_from and self.migrate_to
-        ), "TestCase '{}' must define migrate_from and migrate_to properties".format(
-            type(self).__name__
+        assert self.migrate_from and self.migrate_to, (
+            "TestCase '{}' must define migrate_from and migrate_to properties".format(
+                type(self).__name__
+            )
         )
         self.migrate_from = [(self.app, self.migrate_from)]
         self.migrate_to = [(self.app, self.migrate_to)]

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -45,10 +45,10 @@ class TestMigrations(TestCase):
     migrate_to = None
 
     def setUp(self) -> None:
-        assert self.migrate_from and self.migrate_to, (
-            "TestCase '{}' must define migrate_from and migrate_to properties".format(
-                type(self).__name__
-            )
+        assert (
+            self.migrate_from and self.migrate_to
+        ), "TestCase '{}' must define migrate_from and migrate_to properties".format(
+            type(self).__name__
         )
         self.migrate_from = [(self.app, self.migrate_from)]
         self.migrate_to = [(self.app, self.migrate_to)]


### PR DESCRIPTION
Another piece of work for the ACH microdeposits delayed payment verification flow - https://github.com/codecov/engineering-team/issues/2622

This PR adds an endpoint to fetch from Stripe any payment methods awaiting delayed payment notification (e.g., ACH 2-day later microdeposits).
It hooks into our GraphQL api at a new `billing` key that we can extend and add to as we cut over stuff from the existing /internal/account-details REST api.

It will be used by gazebo UI to reflect this waiting status to the user in that 2-day period.