### PR TITLE
feat: Export plans and tiers to CSV

### DIFF
--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -1,7 +1,7 @@
-import csv
 import logging
 from datetime import timedelta
 from typing import Optional, Sequence
+
 import django.forms as forms
 from django.conf import settings
 from django.contrib import admin, messages
@@ -9,7 +9,7 @@ from django.contrib.admin.models import LogEntry
 from django.db.models import OuterRef, Subquery
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import CheckboxInput, Select, Textarea
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.utils.html import format_html
@@ -25,7 +25,7 @@ from shared.plan.service import PlanService
 
 from codecov.admin import AdminMixin
 from codecov.commands.exceptions import ValidationError
-from codecov_auth.helpers import History
+from codecov_auth.helpers import History, export_to_csv
 from codecov_auth.models import OrganizationLevelToken, Owner, SentryUser, Session, User
 from codecov_auth.services.org_level_token_service import OrgLevelTokenService
 from services.task import TaskService
@@ -733,21 +733,6 @@ class PlansInline(admin.TabularInline):
     formfield_overrides = {
         Plan._meta.get_field("benefits"): {"widget": Textarea(attrs={"rows": 3})},
     }
-
-def export_to_csv(modeladmin, request, queryset):
-    model = queryset.model
-    response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = f'attachment; filename="{model._meta.model_name}s.csv"'
-    writer = csv.writer(response)
-
-    writer.writerow([field.name for field in model._meta.fields])
-
-    for obj in queryset:
-        writer.writerow([getattr(obj, field.name) for field in model._meta.fields])
-
-    return response
-
-export_to_csv.short_description = "Export selected items to CSV"
 
 
 @admin.register(Tier)

--- a/codecov_auth/helpers.py
+++ b/codecov_auth/helpers.py
@@ -1,8 +1,10 @@
+import csv
 from traceback import format_stack
 
 import requests
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.contenttypes.models import ContentType
+from django.http import HttpResponse
 
 from codecov_auth.constants import GITLAB_BASE_URL
 
@@ -69,3 +71,22 @@ class History:
                 change_message=message,
                 action_flag=action_flag,
             )
+
+
+def export_to_csv(modeladmin, request, queryset):
+    model = queryset.model
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = (
+        f'attachment; filename="{model._meta.model_name}s.csv"'
+    )
+    writer = csv.writer(response)
+
+    writer.writerow([field.name for field in model._meta.fields])
+
+    for obj in queryset:
+        writer.writerow([getattr(obj, field.name) for field in model._meta.fields])
+
+    return response
+
+
+export_to_csv.short_description = "Export selected items to CSV"

--- a/codecov_auth/tests/test_admin.py
+++ b/codecov_auth/tests/test_admin.py
@@ -1007,6 +1007,23 @@ class PlanAdminTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Monthly uploads limit cannot be negative.")
 
+    def test_export_to_csv(self):
+        response = self.client.post(
+            reverse("admin:codecov_auth_plan_changelist"),
+            data={"action": "export_to_csv", ACTION_CHECKBOX_NAME: [self.plan.pk]},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_export_to_csv_with_multiple_selected_items(self):
+        response = self.client.post(
+            reverse("admin:codecov_auth_plan_changelist"),
+            data={
+                "action": "export_to_csv",
+                ACTION_CHECKBOX_NAME: [self.plan.pk, self.tier.pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 class TierAdminTest(TestCase):
     def setUp(self):
@@ -1051,3 +1068,27 @@ class TierAdminTest(TestCase):
             "private_repo_support",
         ]:
             self.assertContains(response, f"id_{field}")
+
+    def test_export_to_csv(self):
+        response = self.client.post(
+            reverse("admin:codecov_auth_tier_changelist"),
+            data={"action": "export_to_csv", ACTION_CHECKBOX_NAME: [self.tier.pk]},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_export_to_csv_with_multiple_selected_items(self):
+        response = self.client.post(
+            reverse("admin:codecov_auth_tier_changelist"),
+            data={
+                "action": "export_to_csv",
+                ACTION_CHECKBOX_NAME: [self.tier.pk, self.plan.pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_export_to_csv_with_no_selected_items(self):
+        response = self.client.post(
+            reverse("admin:codecov_auth_tier_changelist"),
+            data={"action": "export_to_csv"},
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Adding a new generic function that allows you to export data from Django portal and feed it to your local DB. 

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/3288

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
