### PR TITLE
ref: Plan query optimizations

### DIFF
--- a/api/internal/owner/serializers.py
+++ b/api/internal/owner/serializers.py
@@ -339,11 +339,13 @@ class AccountDetailsSerializer(serializers.ModelSerializer):
                 instance, desired_plan
             )
 
-            sentry_plans = Plan.objects.filter(
-                tier__tier_name=TierName.SENTRY.value, is_active=True
-            ).values_list("name", flat=True)
+            plan = (
+                Plan.objects.select_related("tier")
+                .filter(name=desired_plan["value"])
+                .first()
+            )
 
-            if desired_plan["value"] in sentry_plans:
+            if plan and plan.tier.tier_name == TierName.SENTRY.value:
                 current_owner = self.context["view"].request.current_owner
                 send_sentry_webhook(current_owner, instance)
 

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1385,121 +1385,191 @@ class StripeServiceTests(TestCase):
     def test_get_proration_params(self):
         # Test same plan, increased users
         owner = OwnerFactory(plan=PlanName.CODECOV_PRO_YEARLY.value, plan_user_count=10)
-        desired_plan = {"value": PlanName.CODECOV_PRO_YEARLY.value, "quantity": 14}
+        plan = Plan.objects.get(name=PlanName.CODECOV_PRO_YEARLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=14
+            )
+            == "always_invoice"
         )
 
         # Test same plan, decrease users
         owner = OwnerFactory(plan=PlanName.CODECOV_PRO_YEARLY.value, plan_user_count=20)
-        desired_plan = {"value": PlanName.CODECOV_PRO_YEARLY.value, "quantity": 14}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=14
+            )
+            == "none"
+        )
 
         # Test going from monthly to yearly
         owner = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value, plan_user_count=20
         )
-        desired_plan = {"value": PlanName.CODECOV_PRO_YEARLY.value, "quantity": 14}
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=14
+            )
+            == "always_invoice"
         )
 
         # monthly to Sentry monthly plan
         owner = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value, plan_user_count=20
         )
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 19}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 20}
+        plan = Plan.objects.get(name=PlanName.SENTRY_MONTHLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=19
+            )
+            == "none"
         )
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 21}
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=20
+            )
+            == "always_invoice"
+        )
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=21
+            )
+            == "always_invoice"
         )
 
         # yearly to Sentry monthly plan
         owner = OwnerFactory(plan=PlanName.CODECOV_PRO_YEARLY.value, plan_user_count=20)
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 19}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 20}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 21}
+        plan = Plan.objects.get(name=PlanName.SENTRY_MONTHLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=19
+            )
+            == "none"
+        )
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=20
+            )
+            == "none"
+        )
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=21
+            )
+            == "always_invoice"
         )
 
         # monthly to Sentry monthly plan
         owner = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value, plan_user_count=20
         )
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 19}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 20}
+        plan = Plan.objects.get(name=PlanName.SENTRY_MONTHLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=19
+            )
+            == "none"
         )
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 21}
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=20
+            )
+            == "always_invoice"
+        )
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=21
+            )
+            == "always_invoice"
         )
 
         # yearly to Sentry yearly plan
         owner = OwnerFactory(plan=PlanName.CODECOV_PRO_YEARLY.value, plan_user_count=20)
-        desired_plan = {"value": PlanName.SENTRY_YEARLY.value, "quantity": 19}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
-        desired_plan = {"value": PlanName.SENTRY_YEARLY.value, "quantity": 20}
+        plan = Plan.objects.get(name=PlanName.SENTRY_YEARLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=19
+            )
+            == "none"
         )
-        desired_plan = {"value": PlanName.SENTRY_YEARLY.value, "quantity": 21}
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=20
+            )
+            == "always_invoice"
+        )
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=21
+            )
+            == "always_invoice"
         )
 
         # monthly to Sentry yearly plan
         owner = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value, plan_user_count=20
         )
-        desired_plan = {"value": PlanName.SENTRY_YEARLY.value, "quantity": 19}
+        plan = Plan.objects.get(name=PlanName.SENTRY_YEARLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=19
+            )
+            == "always_invoice"
         )
-        desired_plan = {"value": PlanName.SENTRY_YEARLY.value, "quantity": 20}
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=20
+            )
+            == "always_invoice"
         )
-        desired_plan = {"value": PlanName.SENTRY_YEARLY.value, "quantity": 21}
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=21
+            )
+            == "always_invoice"
         )
 
         # Team to Sentry
         owner = OwnerFactory(plan=PlanName.TEAM_MONTHLY.value, plan_user_count=10)
-        desired_plan = {"value": PlanName.SENTRY_MONTHLY.value, "quantity": 10}
+        plan = Plan.objects.get(name=PlanName.SENTRY_MONTHLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=10
+            )
+            == "always_invoice"
         )
 
         # Team to Pro
         owner = OwnerFactory(plan=PlanName.TEAM_MONTHLY.value, plan_user_count=10)
-        desired_plan = {"value": PlanName.CODECOV_PRO_MONTHLY.value, "quantity": 10}
+        plan = Plan.objects.get(name=PlanName.CODECOV_PRO_MONTHLY.value)
         assert (
-            self.stripe._get_proration_params(owner, desired_plan) == "always_invoice"
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=10
+            )
+            == "always_invoice"
         )
 
         # Sentry to Team
         owner = OwnerFactory(plan=PlanName.SENTRY_MONTHLY.value, plan_user_count=10)
-        desired_plan = {"value": PlanName.TEAM_MONTHLY.value, "quantity": 10}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
+        plan = Plan.objects.get(name=PlanName.TEAM_MONTHLY.value)
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=10
+            )
+            == "none"
+        )
 
         # Sentry to Pro
         owner = OwnerFactory(
             plan=PlanName.CODECOV_PRO_MONTHLY.value, plan_user_count=10
         )
-        desired_plan = {"value": PlanName.TEAM_MONTHLY.value, "quantity": 10}
-        assert self.stripe._get_proration_params(owner, desired_plan) == "none"
+        plan = Plan.objects.get(name=PlanName.TEAM_MONTHLY.value)
+        assert (
+            self.stripe._get_proration_params(
+                owner=owner, desired_plan_info=plan, quantity=10
+            )
+            == "none"
+        )
 
     @patch("services.billing.stripe.checkout.Session.create")
     def test_create_checkout_session_with_no_stripe_customer_id(


### PR DESCRIPTION
### Purpose/Motivation

Some more plan optimizations for the update_plan helper and when determining if we want to fire the sentry webhook when moving to a sentry plan. Consequently updates the tests.

The update_plan helper change is the main one, mostly just consolidating the 2 queries to a single one and passing the relevant params down that are needed

This should be merged into the remove reference PR before merging that one, but can also be done separately

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
