### PR TITLE
dev: Add default plan name var to settings

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -110,6 +110,8 @@ GRAPHQL_MAX_DEPTH = get_config("setup", "graphql", "max_depth", default=20)
 
 GRAPHQL_MAX_ALIASES = get_config("setup", "graphql", "max_aliases", default=10)
 
+DEFAULT_PLAN_NAME = get_config("setup", "default_plan_name", default="users-developer")
+
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 


### PR DESCRIPTION
Add default plan name var to worker so it doesn't break when we merge https://github.com/codecov/shared/pull/495

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
