### PR TITLE
fix: stop double-counting unhandled_event in github webhook handler

### DIFF
--- a/webhook_handlers/views/github.py
+++ b/webhook_handlers/views/github.py
@@ -100,7 +100,6 @@ class GithubWebhookHandler(APIView):
             raise PermissionDenied()
 
     def unhandled_webhook_event(self, request, *args, **kwargs):
-        self._inc_err("unhandled_event")
         return Response(data=WebhookHandlerErrorMessages.UNSUPPORTED_EVENT)
 
     def _get_repo(self, request):


### PR DESCRIPTION
it's handled here
https://github.com/codecov/codecov-api/blob/ca253c138ce000c16126f7b3693a7bbd90ce1086/webhook_handlers/views/github.py#L732-L737

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
