### PR TITLE
Refactor and optimize querying `pathContents`

### DIFF
--- a/graphql_api/actions/path_contents.py
+++ b/graphql_api/actions/path_contents.py
@@ -1,46 +1,18 @@
-from typing import Iterable, Union
-
 import sentry_sdk
 
 from graphql_api.types.enums import PathContentDisplayType
 from services.path import Dir, File
 
 
-def partition_list_into_files_and_directories(
-    items: Iterable[Union[File, Dir]],
-) -> tuple[Union[File, Dir]]:
-    files = []
-    directories = []
-
-    # Separate files and directories
-    for item in items:
-        if isinstance(item, Dir):
-            directories.append(item)
-        else:
-            files.append(item)
-
-    return (files, directories)
-
-
-def sort_list_by_directory(
-    items: Iterable[Union[File, Dir]],
-) -> Iterable[Union[File, Dir]]:
-    (files, directories) = partition_list_into_files_and_directories(items=items)
-    return directories + files
-
-
 @sentry_sdk.trace
-def sort_path_contents(
-    items: Iterable[Union[File, Dir]], filters={}
-) -> Iterable[Union[File, Dir]]:
+def sort_path_contents(items: list[File | Dir], filters: dict = {}) -> list[File | Dir]:
     filter_parameter = filters.get("ordering", {}).get("parameter")
     filter_direction = filters.get("ordering", {}).get("direction")
 
     if filter_parameter and filter_direction:
         parameter_value = filter_parameter.value
         direction_value = filter_direction.value
-        items = sorted(
-            items,
+        items.sort(
             key=lambda item: getattr(item, parameter_value),
             reverse=direction_value == "descending",
         )
@@ -49,6 +21,6 @@ def sort_path_contents(
             parameter_value == "name"
             and display_type is not PathContentDisplayType.LIST
         ):
-            items = sort_list_by_directory(items=items)
+            items.sort(key=lambda item: isinstance(item, File))
 
     return items

--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -154,6 +154,11 @@ class MockSession(object):
     pass
 
 
+class MockFile:
+    def __init__(self, name: str):
+        self.name = name
+
+
 class MockReport(object):
     def __init__(self):
         self.sessions = {1: MockSession()}
@@ -170,6 +175,10 @@ class MockReport(object):
             "folder/subfolder/fileC.py",
             "folder/subfolder/fileD.py",
         ]
+
+    def __iter__(self):
+        for name in self.files:
+            yield MockFile(name)
 
     @property
     def flags(self):
@@ -774,11 +783,9 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
     @patch("services.components.component_filtered_report")
     @patch("services.components.commit_components")
     @patch("shared.reports.api_report_service.build_report_from_commit")
-    @patch("services.report.files_in_sessions")
     def test_fetch_path_contents_component_filter_has_coverage(
-        self, session_files_mock, report_mock, commit_components_mock, filtered_mock
+        self, report_mock, commit_components_mock, filtered_mock
     ):
-        session_files_mock.return_value = MockReport().files
         components = ["Global"]
         variables = {
             "org": self.org.username,

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -14,6 +14,7 @@ from shared.reports.types import ReportTotals
 import services.components as components_service
 import services.path as path_service
 from codecov.db import sync_to_async
+from codecov_auth.models import Owner
 from core.models import Commit
 from graphql_api.actions.commits import commit_status, commit_uploads
 from graphql_api.actions.comparison import validate_commit_comparison
@@ -44,7 +45,7 @@ from reports.models import CommitReport
 from services.bundle_analysis import BundleAnalysisComparison, BundleAnalysisReport
 from services.comparison import Comparison, ComparisonReport
 from services.components import Component
-from services.path import ReportPaths
+from services.path import Dir, File, ReportPaths
 from services.profiling import CriticalFile, ProfilingSummary
 from services.yaml import (
     YamlStates,
@@ -146,23 +147,19 @@ def resolve_critical_files(commit: Commit, info, **kwargs) -> List[CriticalFile]
     return profiling_summary.critical_files
 
 
-@sentry_sdk.trace
-@commit_bindable.field("pathContents")
-@sync_to_async
-def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
-    """
-    The file directory tree is a list of all the files and directories
-    extracted from the commit report of the latest, head commit.
-    The is resolver results in a list that represent the tree with files
-    and nested directories.
-    """
-    current_owner = info.context["request"].current_owner
-
+def get_sorted_path_contents(
+    current_owner: Owner,
+    commit: Commit,
+    path: str | None = None,
+    filters: dict | None = None,
+) -> (
+    list[File | Dir] | MissingHeadReport | MissingCoverage | UnknownFlags | UnknownPath
+):
     # TODO: Might need to add reports here filtered by flags in the future
-    commit_report = report_service.build_report_from_commit(
+    report = report_service.build_report_from_commit(
         commit, report_class=ReadOnlyReport
     )
-    if not commit_report:
+    if not report:
         return MissingHeadReport()
 
     if filters is None:
@@ -189,9 +186,9 @@ def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
 
         for component in filtered_components:
             component_paths.extend(component.paths)
-            if commit_report.flags:
+            if report.flags:
                 component_flags.extend(
-                    component.get_matching_flags(commit_report.flags.keys())
+                    component.get_matching_flags(report.flags.keys())
                 )
 
     if component_flags:
@@ -200,11 +197,11 @@ def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
         else:
             flags_filter = component_flags
 
-    if flags_filter and not commit_report.flags:
+    if flags_filter and not report.flags:
         return UnknownFlags(f"No coverage with chosen flags: {flags_filter}")
 
     report_paths = ReportPaths(
-        report=commit_report,
+        report=report,
         path=path,
         search_term=search_value,
         filter_flags=flags_filter,
@@ -214,32 +211,59 @@ def resolve_path_contents(commit: Commit, info, path: str = None, filters=None):
     if len(report_paths.paths) == 0:
         # we do not know about this path
 
-        if path_service.provider_path_exists(path, commit, current_owner) is False:
+        if (
+            not path
+            or path_service.provider_path_exists(path, commit, current_owner) is False
+        ):
             # file doesn't exist
             return UnknownPath(f"path does not exist: {path}")
 
         # we're just missing coverage for the file
         return MissingCoverage(f"missing coverage for path: {path}")
 
+    items: list[File | Dir]
     if search_value or display_type == PathContentDisplayType.LIST:
         items = report_paths.full_filelist()
     else:
         items = report_paths.single_directory()
-    return {"results": sort_path_contents(items, filters)}
+    return sort_path_contents(items, filters)
+
+
+@sentry_sdk.trace
+@commit_bindable.field("pathContents")
+@sync_to_async
+def resolve_path_contents(
+    commit: Commit,
+    info: GraphQLResolveInfo,
+    path: str | None = None,
+    filters: dict | None = None,
+) -> Any:
+    """
+    The file directory tree is a list of all the files and directories
+    extracted from the commit report of the latest, head commit.
+    The is resolver results in a list that represent the tree with files
+    and nested directories.
+    """
+    current_owner = info.context["request"].current_owner
+
+    contents = get_sorted_path_contents(current_owner, commit, path, filters)
+    if isinstance(contents, list):
+        return {"results": contents}
+    return contents
 
 
 @commit_bindable.field("deprecatedPathContents")
 @sync_to_async
 def resolve_deprecated_path_contents(
     commit: Commit,
-    info,
-    path: str = None,
-    filters=None,
-    first=None,
-    after=None,
-    last=None,
-    before=None,
-):
+    info: GraphQLResolveInfo,
+    path: str | None = None,
+    filters: dict | None = None,
+    first: Any = None,
+    after: Any = None,
+    last: Any = None,
+    before: Any = None,
+) -> Any:
     """
     The file directory tree is a list of all the files and directories
     extracted from the commit report of the latest, head commit.
@@ -248,80 +272,17 @@ def resolve_deprecated_path_contents(
     """
     current_owner = info.context["request"].current_owner
 
-    # TODO: Might need to add reports here filtered by flags in the future
-    commit_report = report_service.build_report_from_commit(
-        commit, report_class=ReadOnlyReport
-    )
-    if not commit_report:
-        return MissingHeadReport()
-
-    if filters is None:
-        filters = {}
-    search_value = filters.get("search_value")
-    display_type = filters.get("display_type")
-
-    flags_filter = filters.get("flags", [])
-    component_filter = filters.get("components", [])
-
-    component_paths = []
-    component_flags = []
-
-    if component_filter:
-        all_components = components_service.commit_components(commit, current_owner)
-        filtered_components = components_service.filter_components_by_name_or_id(
-            all_components, component_filter
-        )
-
-        if not filtered_components:
-            return MissingCoverage(
-                f"missing coverage for report with components: {component_filter}"
-            )
-
-        for component in filtered_components:
-            component_paths.extend(component.paths)
-            if commit_report.flags:
-                component_flags.extend(
-                    component.get_matching_flags(commit_report.flags.keys())
-                )
-
-    if component_flags:
-        if flags_filter:
-            flags_filter = list(set(flags_filter) & set(component_flags))
-        else:
-            flags_filter = component_flags
-
-    if flags_filter and not commit_report.flags:
-        return UnknownFlags(f"No coverage with chosen flags: {flags_filter}")
-
-    report_paths = ReportPaths(
-        report=commit_report,
-        path=path,
-        search_term=search_value,
-        filter_flags=flags_filter,
-        filter_paths=component_paths,
-    )
-
-    if len(report_paths.paths) == 0:
-        # we do not know about this path
-
-        if path_service.provider_path_exists(path, commit, current_owner) is False:
-            # file doesn't exist
-            return UnknownPath(f"path does not exist: {path}")
-
-        # we're just missing coverage for the file
-        return MissingCoverage(f"missing coverage for path: {path}")
-
-    if search_value or display_type == PathContentDisplayType.LIST:
-        items = report_paths.full_filelist()
-    else:
-        items = report_paths.single_directory()
-
-    sorted_items = sort_path_contents(items, filters)
-
-    kwargs = {"first": first, "after": after, "last": last, "before": before}
+    contents = get_sorted_path_contents(current_owner, commit, path, filters)
+    if not isinstance(contents, list):
+        return contents
 
     return queryset_to_connection_sync(
-        sorted_items, ordering_direction=OrderingDirection.ASC, **kwargs
+        contents,
+        ordering_direction=OrderingDirection.ASC,
+        first=first,
+        last=last,
+        before=before,
+        after=after,
     )
 
 

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -211,10 +211,7 @@ def get_sorted_path_contents(
     if len(report_paths.paths) == 0:
         # we do not know about this path
 
-        if (
-            not path
-            or path_service.provider_path_exists(path, commit, current_owner) is False
-        ):
+        if path_service.provider_path_exists(path, commit, current_owner) is False:
             # file doesn't exist
             return UnknownPath(f"path does not exist: {path}")
 

--- a/services/path.py
+++ b/services/path.py
@@ -109,9 +109,9 @@ class PrefixedPath:
         The base path name (including the prefix).  For example, if `full_path`
         is `a/b/c/d.txt` and `prefix` is `a/b` then this method would return `a/b/c`.
         """
-        name = self.relative_path.split("/", 1)[0]
-        if self.prefix:
-            return f"{self.prefix}/{name}"
+        name = self.full_path.rsplit("/", 1)[0]
+        if name == self.prefix:
+            return self.full_path
         else:
             return name
 

--- a/services/path.py
+++ b/services/path.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import cached_property
@@ -68,7 +70,7 @@ class Dir(PathNode):
     """
 
     full_path: str
-    children: list[File | "Dir"]
+    children: list[File | Dir]
 
     @cached_property
     def totals(self) -> ReportTotals:

--- a/services/path.py
+++ b/services/path.py
@@ -98,7 +98,7 @@ class PrefixedPath:
         if not self.prefix:
             return self.full_path
         else:
-            return self.full_path.replace(f"{self.prefix}/", "", 1)
+            return self.full_path.removeprefix(f"{self.prefix}/")
 
     @property
     def is_file(self) -> bool:
@@ -111,9 +111,9 @@ class PrefixedPath:
         The base path name (including the prefix).  For example, if `full_path`
         is `a/b/c/d.txt` and `prefix` is `a/b` then this method would return `a/b/c`.
         """
-        name = self.full_path.rsplit("/", 1)[0]
-        if name == self.prefix:
-            return self.full_path
+        name = self.relative_path.split("/", 1)[0]
+        if self.prefix:
+            return f"{self.prefix}/{name}"
         else:
             return name
 

--- a/services/path.py
+++ b/services/path.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Iterable, List, Optional, Union
+from typing import Iterable
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
@@ -24,7 +24,7 @@ class PathNode:
     """
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.full_path.split("/")[-1]
 
     @property
@@ -68,10 +68,10 @@ class Dir(PathNode):
     """
 
     full_path: str
-    children: List[PathNode]
+    children: list[File | "Dir"]
 
     @cached_property
-    def totals(self):
+    def totals(self) -> ReportTotals:
         # A dir's totals are sum of its children's totals
         totals = ReportTotals.default_totals()
         for child in self.children:
@@ -88,7 +88,7 @@ class PrefixedPath:
     prefix: str
 
     @property
-    def relative_path(self):
+    def relative_path(self) -> str:
         """
         The path relative to the `prefix`.  For example, if `full_path`
         is `a/b/c/d.txt` and `prefix` is `a/b` then this method would return `c/d.txt`.
@@ -99,12 +99,12 @@ class PrefixedPath:
             return self.full_path.replace(f"{self.prefix}/", "", 1)
 
     @property
-    def is_file(self):
+    def is_file(self) -> bool:
         parts = self.relative_path.split("/")
         return len(parts) == 1
 
     @property
-    def basename(self):
+    def basename(self) -> str:
         """
         The base path name (including the prefix).  For example, if `full_path`
         is `a/b/c/d.txt` and `prefix` is `a/b` then this method would return `a/b/c`.
@@ -116,14 +116,14 @@ class PrefixedPath:
             return name
 
 
-def is_subpath(full_path: str, subpath: str):
+def is_subpath(full_path: str, subpath: str) -> bool:
     if not subpath:
         return True
     return full_path.startswith(f"{subpath}/") or full_path == subpath
 
 
 def dashboard_commit_file_url(
-    path: Optional[str],
+    path: str | None,
     service: str,
     owner: str,
     repo: str,
@@ -146,10 +146,10 @@ class ReportPaths:
     def __init__(
         self,
         report: Report,
-        path: PrefixedPath = None,
-        search_term: str = None,
-        filter_flags: List[str] = [],
-        filter_paths: List[str] = [],
+        path: str | None = None,
+        search_term: str | None = None,
+        filter_flags: list[str] = [],
+        filter_paths: list[str] = [],
     ):
         self.report = report
         self.unfiltered_report = report
@@ -177,7 +177,7 @@ class ReportPaths:
             ]
 
     @cached_property
-    def files(self) -> List[str]:
+    def files(self) -> list[str]:
         # No filtering, just return files in Report
         if not self.filter_flags and not self.filter_paths:
             return self.report.files
@@ -189,10 +189,8 @@ class ReportPaths:
                 commit_report=self.unfiltered_report, flags=self.filter_flags
             )
         else:
-            files = report_service.files_in_sessions(
-                commit_report=self.unfiltered_report,
-                session_ids=self.unfiltered_report.sessions.keys(),
-            )
+            files = [file.name for file in self.unfiltered_report]
+
         # Do path filtering if needed
         if self.filter_paths:
             files = [file for file in files if match(self.filter_paths, file)]
@@ -203,11 +201,11 @@ class ReportPaths:
         self.report = self.report.filter(flags=self.filter_flags)
 
     @property
-    def paths(self):
+    def paths(self) -> list[PrefixedPath]:
         return self._paths
 
     @sentry_sdk.trace
-    def full_filelist(self) -> Iterable[File]:
+    def full_filelist(self) -> list[File | Dir]:
         """
         Return a flat file list of all files under the specified `path` prefix/directory.
         """
@@ -217,7 +215,7 @@ class ReportPaths:
         ]
 
     @sentry_sdk.trace
-    def single_directory(self) -> Iterable[Union[File, Dir]]:
+    def single_directory(self) -> list[File | Dir]:
         """
         Return a single directory (specified by `path`) of mixed file/directory results.
         """
@@ -238,15 +236,14 @@ class ReportPaths:
 
     def _single_directory_recursive(
         self, paths: Iterable[PrefixedPath]
-    ) -> Iterable[Union[File, Dir]]:
+    ) -> list[File | Dir]:
         grouped = defaultdict(list)
         for path in paths:
             grouped[path.basename].append(path)
 
-        results = []
+        results: list[File | Dir] = []
 
         for basename, paths in grouped.items():
-            paths = list(paths)
             if len(paths) == 1 and paths[0].is_file:
                 path = paths[0]
                 results.append(
@@ -254,17 +251,15 @@ class ReportPaths:
                 )
             else:
                 children = self._single_directory_recursive(
-                    [
-                        PrefixedPath(full_path=path.full_path, prefix=basename)
-                        for path in paths
-                    ]
+                    PrefixedPath(full_path=path.full_path, prefix=basename)
+                    for path in paths
                 )
                 results.append(Dir(full_path=basename, children=children))
 
         return results
 
 
-def provider_path_exists(path: str, commit: Commit, owner: Owner):
+def provider_path_exists(path: str, commit: Commit, owner: Owner) -> bool | None:
     """
     Check whether the given path exists on the provider.
     """

--- a/services/report.py
+++ b/services/report.py
@@ -1,41 +1,27 @@
-import logging
-
 from shared.reports.resources import Report
-from shared.utils.sessions import Session
-
-log = logging.getLogger(__name__)
 
 
 def files_belonging_to_flags(commit_report: Report, flags: list[str]) -> list[str]:
-    sessions_for_specific_flags = _sessions_with_specific_flags(
-        commit_report=commit_report, flags=flags
-    )
-    session_ids = list(sessions_for_specific_flags.keys())
+    flags_set = set(flags)
+    session_ids = {
+        sid
+        for sid, session in commit_report.sessions.items()
+        if session.flags and not set(session.flags).isdisjoint(flags_set)
+    }
     files_in_specific_sessions = files_in_sessions(
         commit_report=commit_report, session_ids=session_ids
     )
     return files_in_specific_sessions
 
 
-def _sessions_with_specific_flags(
-    commit_report: Report, flags: list[str]
-) -> dict[int, Session]:
-    sessions = [
-        (sid, session)
-        for sid, session in commit_report.sessions.items()
-        if session.flags and set(session.flags) & set(flags)
-    ]
-    return dict(sessions)
-
-
-def files_in_sessions(commit_report: Report, session_ids: list[int]) -> list[str]:
-    files, session_ids_set = [], set(session_ids)
+def files_in_sessions(commit_report: Report, session_ids: set[int]) -> list[str]:
+    files = []
     for file in commit_report:
         found = False
         for line in file:
             if line:
                 for session in line.sessions:
-                    if session.id in session_ids_set:
+                    if session.id in session_ids:
                         found = True
                         break
             if found:


### PR DESCRIPTION
First of all, this fixes and adds missing type annotations.

It then deduplicates the code between `pathContents` and the `deprecated` variant, which were 99% identical.

Resolving the path contents was also optimized a little bit by not filtering the report for "files matching *any* session in the report", aka "all files". Other optimizations include avoiding some intermediate allocations by sorting lists in-place, and simplifying some functions.