### PR TITLE
fix: Account for Multiple Owners being returned when handling stripe payment intent webhook

### DIFF
--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -1643,6 +1643,119 @@ class StripeWebhookHandlerTests(APITestCase):
             "sub_123", default_payment_method=payment_method_retrieve_mock.return_value
         )
 
+    @patch("services.billing.stripe.PaymentMethod.attach")
+    @patch("services.billing.stripe.Customer.modify")
+    @patch("services.billing.stripe.Subscription.modify")
+    @patch("services.billing.stripe.PaymentMethod.retrieve")
+    def test_check_and_handle_delayed_notification_payment_methods_no_subscription(
+        self,
+        payment_method_retrieve_mock,
+        subscription_modify_mock,
+        customer_modify_mock,
+        payment_method_attach_mock,
+    ):
+        class MockPaymentMethod:
+            type = "us_bank_account"
+            us_bank_account = {}
+            id = "pm_123"
+
+        payment_method_retrieve_mock.return_value = MockPaymentMethod()
+
+        self.owner.stripe_subscription_id = None
+        self.owner.stripe_customer_id = "cus_123"
+        self.owner.save()
+
+        handler = StripeWebhookHandler()
+        handler._check_and_handle_delayed_notification_payment_methods(
+            "cus_123", "pm_123"
+        )
+
+        payment_method_retrieve_mock.assert_called_once_with("pm_123")
+        payment_method_attach_mock.assert_not_called()
+        customer_modify_mock.assert_not_called()
+        subscription_modify_mock.assert_not_called()
+
+    @patch("services.billing.stripe.PaymentMethod.attach")
+    @patch("services.billing.stripe.Customer.modify")
+    @patch("services.billing.stripe.Subscription.modify")
+    @patch("services.billing.stripe.PaymentMethod.retrieve")
+    def test_check_and_handle_delayed_notification_payment_methods_no_customer(
+        self,
+        payment_method_retrieve_mock,
+        subscription_modify_mock,
+        customer_modify_mock,
+        payment_method_attach_mock,
+    ):
+        class MockPaymentMethod:
+            type = "us_bank_account"
+            us_bank_account = {}
+            id = "pm_123"
+
+        payment_method_retrieve_mock.return_value = MockPaymentMethod()
+
+        handler = StripeWebhookHandler()
+        handler._check_and_handle_delayed_notification_payment_methods(
+            "cus_123", "pm_123"
+        )
+
+        payment_method_retrieve_mock.assert_called_once_with("pm_123")
+        payment_method_attach_mock.assert_not_called()
+        customer_modify_mock.assert_not_called()
+        subscription_modify_mock.assert_not_called()
+
+    @patch("logging.Logger.error")
+    @patch("services.billing.stripe.PaymentMethod.attach")
+    @patch("services.billing.stripe.Customer.modify")
+    @patch("services.billing.stripe.Subscription.modify")
+    @patch("services.billing.stripe.PaymentMethod.retrieve")
+    def test_check_and_handle_delayed_notification_payment_methods_multiple_subscriptions(
+        self,
+        payment_method_retrieve_mock,
+        subscription_modify_mock,
+        customer_modify_mock,
+        payment_method_attach_mock,
+    ):
+        class MockPaymentMethod:
+            type = "us_bank_account"
+            us_bank_account = {}
+            id = "pm_123"
+
+        payment_method_retrieve_mock.return_value = MockPaymentMethod()
+
+        self.owner.stripe_subscription_id = "sub_123"
+        self.owner.stripe_customer_id = "cus_123"
+        self.owner.save()
+
+        OwnerFactory(stripe_subscription_id="sub_124", stripe_customer_id="cus_123")
+
+        handler = StripeWebhookHandler()
+        handler._check_and_handle_delayed_notification_payment_methods(
+            "cus_123", "pm_123"
+        )
+
+        payment_method_retrieve_mock.assert_called_once_with("pm_123")
+        payment_method_attach_mock.assert_called_once_with(
+            payment_method_retrieve_mock.return_value, customer="cus_123"
+        )
+        customer_modify_mock.assert_called_once_with(
+            "cus_123",
+            invoice_settings={
+                "default_payment_method": payment_method_retrieve_mock.return_value
+            },
+        )
+        subscription_modify_mock.assert_has_calls(
+            [
+                call(
+                    "sub_123",
+                    default_payment_method=payment_method_retrieve_mock.return_value,
+                ),
+                call(
+                    "sub_124",
+                    default_payment_method=payment_method_retrieve_mock.return_value,
+                ),
+            ]
+        )
+
     @patch(
         "billing.views.StripeWebhookHandler._check_and_handle_delayed_notification_payment_methods"
     )

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -1643,6 +1643,7 @@ class StripeWebhookHandlerTests(APITestCase):
             "sub_123", default_payment_method=payment_method_retrieve_mock.return_value
         )
 
+    @patch("logging.Logger.error")
     @patch("services.billing.stripe.PaymentMethod.attach")
     @patch("services.billing.stripe.Customer.modify")
     @patch("services.billing.stripe.Subscription.modify")
@@ -1653,6 +1654,7 @@ class StripeWebhookHandlerTests(APITestCase):
         subscription_modify_mock,
         customer_modify_mock,
         payment_method_attach_mock,
+        log_error_mock,
     ):
         class MockPaymentMethod:
             type = "us_bank_account"
@@ -1675,6 +1677,12 @@ class StripeWebhookHandlerTests(APITestCase):
         customer_modify_mock.assert_not_called()
         subscription_modify_mock.assert_not_called()
 
+        log_error_mock.assert_called_once_with(
+            "No owners found with that customer_id, something went wrong",
+            extra=dict(customer_id="cus_123"),
+        )
+
+    @patch("logging.Logger.error")
     @patch("services.billing.stripe.PaymentMethod.attach")
     @patch("services.billing.stripe.Customer.modify")
     @patch("services.billing.stripe.Subscription.modify")
@@ -1685,6 +1693,7 @@ class StripeWebhookHandlerTests(APITestCase):
         subscription_modify_mock,
         customer_modify_mock,
         payment_method_attach_mock,
+        log_error_mock,
     ):
         class MockPaymentMethod:
             type = "us_bank_account"
@@ -1695,7 +1704,7 @@ class StripeWebhookHandlerTests(APITestCase):
 
         handler = StripeWebhookHandler()
         handler._check_and_handle_delayed_notification_payment_methods(
-            "cus_123", "pm_123"
+            "cus_1", "pm_123"
         )
 
         payment_method_retrieve_mock.assert_called_once_with("pm_123")
@@ -1703,7 +1712,11 @@ class StripeWebhookHandlerTests(APITestCase):
         customer_modify_mock.assert_not_called()
         subscription_modify_mock.assert_not_called()
 
-    @patch("logging.Logger.error")
+        log_error_mock.assert_called_once_with(
+            "No owners found with that customer_id, something went wrong",
+            extra=dict(customer_id="cus_1"),
+        )
+
     @patch("services.billing.stripe.PaymentMethod.attach")
     @patch("services.billing.stripe.Customer.modify")
     @patch("services.billing.stripe.Subscription.modify")


### PR DESCRIPTION
### Purpose/Motivation

This PR aims to fix a Sentry issue that popped up after we launched ACH related to a customer trying to update their payment method while having multiple stripe subscription_ids tied to the customer_id in our DB. I noticed that for this customer both of the subscription_ids were the same, but wanted the code to accommodate cases where that wasn't necessarily the case; potentially someone who wants to spread Codecov across the many orgs their apart of ;) 

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/3323

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
