### PR TITLE
Add `owner` to `eraseRepository` mutation

### DIFF
--- a/graphql_api/types/mutation/erase_repository/erase_repository.graphql
+++ b/graphql_api/types/mutation/erase_repository/erase_repository.graphql
@@ -5,5 +5,6 @@ type EraseRepositoryPayload {
 }
 
 input EraseRepositoryInput {
+  owner: String
   repoName: String!
 }

--- a/graphql_api/types/mutation/erase_repository/erase_repository.py
+++ b/graphql_api/types/mutation/erase_repository/erase_repository.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from ariadne import UnionType
 from graphql import GraphQLResolveInfo
@@ -13,13 +13,14 @@ from graphql_api.helpers.mutation import (
 @wrap_error_handling_mutation
 @require_authenticated
 async def resolve_erase_repository(
-    _: Any, info: GraphQLResolveInfo, input: Dict[str, Any]
+    _: Any, info: GraphQLResolveInfo, input: dict[str, Any]
 ) -> None:
     command = info.context["executor"].get_command("repository")
     current_owner = info.context["request"].current_owner
+
+    owner_username = input.get("owner") or current_owner.username
     repo_name = input.get("repo_name")
-    # TODO: change the graphql mutation to allow working on other owners
-    owner_username = current_owner.username
+
     await command.erase_repository(owner_username, repo_name)
     return None
 


### PR DESCRIPTION
Adding this as an optional input field, meaning it is backwards compatible, and falls back to the existing logic of using the currently logged in user as the target owner.

When specified, it will erase the repository belonging to the given `owner`.