### PR TITLE
feat: Track Upload Sent events for Coverage/BA/TA

### DIFF
--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -110,7 +110,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
     mock_amplitude.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": commit.author.ownerid,
+            "user_ownerid": -1,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -10,6 +10,7 @@ from shared.django_apps.codecov_auth.tests.factories import (
     OrganizationLevelTokenFactory,
 )
 from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.events.amplitude import UNKNOWN_USER_OWNERID
 
 from core.models import Commit
 from services.redis_configuration import get_redis_connection
@@ -110,7 +111,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
     mock_amplitude.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": -1,
+            "user_ownerid": UNKNOWN_USER_OWNERID,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -27,6 +27,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="test-presigned-put",
     )
+    mock_amplitude = mocker.patch("shared.events.amplitude.AmplitudeEventPublisher")
 
     repository = RepositoryFactory.create()
     commit_sha = "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef"
@@ -100,6 +101,19 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+        },
+    )
+
+    # emits Amplitude event
+    mock_amplitude.return_value.publish.assert_called_with(
+        "Upload Sent",
+        {
+            "user_ownerid": commit.repository.author.ownerid,
+            "ownerid": commit.repository.author.ownerid,
+            "repoid": commit.repository.repoid,
+            "commitid": commit.id,
+            "pullid": commit.pullid,
+            "upload_type": "Bundle",
         },
     )
 

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -110,7 +110,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
     mock_amplitude.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": commit.repository.author.ownerid,
+            "user_ownerid": commit.author.ownerid,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -27,7 +27,9 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="test-presigned-put",
     )
-    mock_amplitude = mocker.patch("shared.events.amplitude.AmplitudeEventPublisher")
+    mock_amplitude = mocker.patch(
+        "shared.events.amplitude.AmplitudeEventPublisher.publish"
+    )
 
     repository = RepositoryFactory.create()
     commit_sha = "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef"
@@ -105,7 +107,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
     )
 
     # emits Amplitude event
-    mock_amplitude.return_value.publish.assert_called_with(
+    mock_amplitude.assert_called_with(
         "Upload Sent",
         {
             "user_ownerid": commit.repository.author.ownerid,

--- a/upload/tests/views/test_test_results.py
+++ b/upload/tests/views/test_test_results.py
@@ -13,6 +13,7 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
+from shared.events.amplitude import UNKNOWN_USER_OWNERID
 
 from services.redis_configuration import get_redis_connection
 from services.task import TaskService
@@ -122,7 +123,7 @@ def test_upload_test_results(db, client, mocker, mock_redis):
     mock_amplitude.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": -1,
+            "user_ownerid": UNKNOWN_USER_OWNERID,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_test_results.py
+++ b/upload/tests/views/test_test_results.py
@@ -122,7 +122,7 @@ def test_upload_test_results(db, client, mocker, mock_redis):
     mock_amplitude.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": commit.author.ownerid,
+            "user_ownerid": -1,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_test_results.py
+++ b/upload/tests/views/test_test_results.py
@@ -25,7 +25,9 @@ def test_upload_test_results(db, client, mocker, mock_redis):
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="test-presigned-put",
     )
-    mock_amplitude = mocker.patch("shared.events.amplitude.AmplitudeEventPublisher")
+    mock_amplitude = mocker.patch(
+        "shared.events.amplitude.AmplitudeEventPublisher.publish"
+    )
 
     owner = OwnerFactory(service="github", username="codecov")
     repository = RepositoryFactory.create(author=owner)
@@ -117,7 +119,7 @@ def test_upload_test_results(db, client, mocker, mock_redis):
     )
 
     # emits Amplitude event
-    mock_amplitude.return_value.publish.assert_called_with(
+    mock_amplitude.assert_called_with(
         "Upload Sent",
         {
             "user_ownerid": commit.repository.author.ownerid,

--- a/upload/tests/views/test_test_results.py
+++ b/upload/tests/views/test_test_results.py
@@ -122,7 +122,7 @@ def test_upload_test_results(db, client, mocker, mock_redis):
     mock_amplitude.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": commit.repository.author.ownerid,
+            "user_ownerid": commit.author.ownerid,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -314,6 +314,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
     analytics_service_mock = mocker.patch("upload.views.uploads.AnalyticsService")
+    amplitude_mock = mocker.path("shared.events.amplitude.AmplitudeEventPublisher")
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -431,6 +432,17 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
                 "uploader_type": "CLI",
             },
         )
+        amplitude_mock.return_value.publish.assert_called_with(
+            "Upload Sent",
+            {
+                "user_ownerid": commit.author.ownerid,
+                "ownerid": commit.repository.author.ownerid,
+                "repoid": commit.repository.repoid,
+                "commitid": commit.id,
+                "pullid": commit.pullid,
+                "upload_type": "Coverage report",
+            },
+        )
     else:
         assert response.status_code == 401
         assert response.json().get("detail") == "Not valid tokenless upload"
@@ -459,6 +471,7 @@ def test_uploads_post_token_required_auth_check(
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
     analytics_service_mock = mocker.patch("upload.views.uploads.AnalyticsService")
+    amplitude_mock = mocker.path("shared.events.amplitude.AmplitudeEventPublisher")
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -583,11 +596,23 @@ def test_uploads_post_token_required_auth_check(
                 "uploader_type": "CLI",
             },
         )
+        amplitude_mock.return_value.publish.assert_called_with(
+            "Upload Sent",
+            {
+                "user_ownerid": commit.author.ownerid,
+                "ownerid": commit.repository.author.ownerid,
+                "repoid": commit.repository.repoid,
+                "commitid": commit.id,
+                "pullid": commit.pullid,
+                "upload_type": "Coverage report",
+            },
+        )
     else:
         assert response.status_code == 401
         assert response.json().get("detail") == "Not valid tokenless upload"
 
 
+@patch("shared.events.amplitude.AmplitudeEventPublisher")
 @patch("upload.views.uploads.AnalyticsService")
 @patch("upload.helpers.jwt.decode")
 @patch("upload.helpers.PyJWKClient")
@@ -595,6 +620,7 @@ def test_uploads_post_github_oidc_auth(
     mock_jwks_client,
     mock_jwt_decode,
     analytics_service_mock,
+    amplitude_mock,
     db,
     mocker,
     mock_redis,
@@ -715,6 +741,17 @@ def test_uploads_post_github_oidc_auth(
             "token": "oidc_token_upload",
             "version": "version",
             "uploader_type": "CLI",
+        },
+    )
+    amplitude_mock.return_value.publish.assert_called_with(
+        "Upload Sent",
+        {
+            "user_ownerid": commit.author.ownerid,
+            "ownerid": commit.repository.author.ownerid,
+            "repoid": commit.repository.repoid,
+            "commitid": commit.id,
+            "pullid": commit.pullid,
+            "upload_type": "Coverage report",
         },
     )
 

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -437,7 +437,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
         amplitude_mock.assert_called_with(
             "Upload Sent",
             {
-                "user_ownerid": commit.repository.author.ownerid,
+                "user_ownerid": commit.author.ownerid,
                 "ownerid": commit.repository.author.ownerid,
                 "repoid": commit.repository.repoid,
                 "commitid": commit.id,
@@ -603,7 +603,7 @@ def test_uploads_post_token_required_auth_check(
         amplitude_mock.assert_called_with(
             "Upload Sent",
             {
-                "user_ownerid": commit.repository.author.ownerid,
+                "user_ownerid": commit.author.ownerid,
                 "ownerid": commit.repository.author.ownerid,
                 "repoid": commit.repository.repoid,
                 "commitid": commit.id,
@@ -750,7 +750,7 @@ def test_uploads_post_github_oidc_auth(
     amplitude_mock.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": commit.repository.author.ownerid,
+            "user_ownerid": commit.author.ownerid,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -435,7 +435,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
         amplitude_mock.return_value.publish.assert_called_with(
             "Upload Sent",
             {
-                "user_ownerid": commit.author.ownerid,
+                "user_ownerid": commit.repository.author.ownerid,
                 "ownerid": commit.repository.author.ownerid,
                 "repoid": commit.repository.repoid,
                 "commitid": commit.id,
@@ -599,7 +599,7 @@ def test_uploads_post_token_required_auth_check(
         amplitude_mock.return_value.publish.assert_called_with(
             "Upload Sent",
             {
-                "user_ownerid": commit.author.ownerid,
+                "user_ownerid": commit.repository.author.ownerid,
                 "ownerid": commit.repository.author.ownerid,
                 "repoid": commit.repository.repoid,
                 "commitid": commit.id,
@@ -746,7 +746,7 @@ def test_uploads_post_github_oidc_auth(
     amplitude_mock.return_value.publish.assert_called_with(
         "Upload Sent",
         {
-            "user_ownerid": commit.author.ownerid,
+            "user_ownerid": commit.repository.author.ownerid,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -314,7 +314,9 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
     analytics_service_mock = mocker.patch("upload.views.uploads.AnalyticsService")
-    amplitude_mock = mocker.path("shared.events.amplitude.AmplitudeEventPublisher")
+    amplitude_mock = mocker.patch(
+        "shared.events.amplitude.AmplitudeEventPublisher.publish"
+    )
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -432,7 +434,7 @@ def test_uploads_post_tokenless(db, mocker, mock_redis, private, branch, branch_
                 "uploader_type": "CLI",
             },
         )
-        amplitude_mock.return_value.publish.assert_called_with(
+        amplitude_mock.assert_called_with(
             "Upload Sent",
             {
                 "user_ownerid": commit.repository.author.ownerid,
@@ -471,7 +473,9 @@ def test_uploads_post_token_required_auth_check(
         "upload.views.uploads.trigger_upload_task", return_value=True
     )
     analytics_service_mock = mocker.patch("upload.views.uploads.AnalyticsService")
-    amplitude_mock = mocker.path("shared.events.amplitude.AmplitudeEventPublisher")
+    amplitude_mock = mocker.patch(
+        "shared.events.amplitude.AmplitudeEventPublisher.publish"
+    )
 
     repository = RepositoryFactory(
         name="the_repo",
@@ -596,7 +600,7 @@ def test_uploads_post_token_required_auth_check(
                 "uploader_type": "CLI",
             },
         )
-        amplitude_mock.return_value.publish.assert_called_with(
+        amplitude_mock.assert_called_with(
             "Upload Sent",
             {
                 "user_ownerid": commit.repository.author.ownerid,
@@ -612,7 +616,7 @@ def test_uploads_post_token_required_auth_check(
         assert response.json().get("detail") == "Not valid tokenless upload"
 
 
-@patch("shared.events.amplitude.AmplitudeEventPublisher")
+@patch("shared.events.amplitude.AmplitudeEventPublisher.publish")
 @patch("upload.views.uploads.AnalyticsService")
 @patch("upload.helpers.jwt.decode")
 @patch("upload.helpers.PyJWKClient")
@@ -743,7 +747,7 @@ def test_uploads_post_github_oidc_auth(
             "uploader_type": "CLI",
         },
     )
-    amplitude_mock.return_value.publish.assert_called_with(
+    amplitude_mock.assert_called_with(
         "Upload Sent",
         {
             "user_ownerid": commit.repository.author.ownerid,

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -224,7 +224,7 @@ class BundleAnalysisView(APIView, ShelterMixin):
         AmplitudeEventPublisher().publish(
             "Upload Sent",
             {
-                "user_ownerid": repo.author.ownerid,
+                "user_ownerid": commit.author.ownerid if commit.author else -1,
                 "ownerid": repo.author.ownerid,
                 "repoid": repo.repoid,
                 "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService
 from shared.bundle_analysis.storage import StoragePaths, get_bucket_name
+from shared.events.amplitude import AmplitudeEventPublisher
 from shared.metrics import Counter, inc_counter
 
 from codecov_auth.authentication.repo_auth import (
@@ -219,5 +220,17 @@ class BundleAnalysisView(APIView, ShelterMixin):
                             measurement_type=measurement_type,
                         ),
                     )
+
+        AmplitudeEventPublisher().publish(
+            "Upload Sent",
+            {
+                "user_ownerid": repo.author.ownerid,
+                "ownerid": repo.author.ownerid,
+                "repoid": repo.repoid,
+                "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!
+                "pullid": commit.pullid,
+                "upload_type": "Bundle",
+            },
+        )
 
         return Response({"url": url}, status=201)

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService
 from shared.bundle_analysis.storage import StoragePaths, get_bucket_name
-from shared.events.amplitude import AmplitudeEventPublisher
+from shared.events.amplitude import UNKNOWN_USER_OWNERID, AmplitudeEventPublisher
 from shared.metrics import Counter, inc_counter
 
 from codecov_auth.authentication.repo_auth import (
@@ -224,7 +224,9 @@ class BundleAnalysisView(APIView, ShelterMixin):
         AmplitudeEventPublisher().publish(
             "Upload Sent",
             {
-                "user_ownerid": commit.author.ownerid if commit.author else -1,
+                "user_ownerid": commit.author.ownerid
+                if commit.author
+                else UNKNOWN_USER_OWNERID,
                 "ownerid": repo.author.ownerid,
                 "repoid": repo.repoid,
                 "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService, MinioEndpoints
-from shared.events.amplitude import AmplitudeEventPublisher
+from shared.events.amplitude import UNKNOWN_USER_OWNERID, AmplitudeEventPublisher
 from shared.metrics import inc_counter
 
 from codecov_auth.authentication.repo_auth import (
@@ -191,7 +191,9 @@ class TestResultsView(
         AmplitudeEventPublisher().publish(
             "Upload Sent",
             {
-                "user_ownerid": commit.author.ownerid if commit.author else -1,
+                "user_ownerid": commit.author.ownerid
+                if commit.author
+                else UNKNOWN_USER_OWNERID,
                 "ownerid": repo.author.ownerid,
                 "repoid": repo.repoid,
                 "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -191,7 +191,7 @@ class TestResultsView(
         AmplitudeEventPublisher().publish(
             "Upload Sent",
             {
-                "user_ownerid": repo.author.ownerid,
+                "user_ownerid": commit.author.ownerid if commit.author else -1,
                 "ownerid": repo.author.ownerid,
                 "repoid": repo.repoid,
                 "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -8,6 +8,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService, MinioEndpoints
+from shared.events.amplitude import AmplitudeEventPublisher
 from shared.metrics import inc_counter
 
 from codecov_auth.authentication.repo_auth import (
@@ -185,6 +186,18 @@ class TestResultsView(
             repo,
             get_redis_connection(),
             report_type=CommitReport.ReportType.TEST_RESULTS,
+        )
+
+        AmplitudeEventPublisher().publish(
+            "Upload Sent",
+            {
+                "user_ownerid": repo.author.ownerid,
+                "ownerid": repo.author.ownerid,
+                "repoid": repo.repoid,
+                "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!
+                "pullid": commit.pullid,
+                "upload_type": "Test results",
+            },
         )
 
         if url is None:

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -171,7 +171,12 @@ def send_analytics_data(
     AmplitudeEventPublisher().publish(
         "Upload Sent",
         {
-            "user_ownerid": commit.author.ownerid,
+            # Attribute this event to the repo owner. For BA/TA uploads we
+            # don't necessarily have the commit author at upload time, so to
+            # align the upload events, we will always attribute uploads to the
+            # repo owner. It's also not necessarily the case that the commit
+            # author is the owner performing the 'Upload Sent' action.
+            "user_ownerid": commit.repository.author.ownerid,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
             "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -171,15 +171,10 @@ def send_analytics_data(
     AmplitudeEventPublisher().publish(
         "Upload Sent",
         {
-            # Attribute this event to the repo owner. For BA/TA uploads we
-            # don't necessarily have the commit author at upload time, so to
-            # align the upload events, we will always attribute uploads to the
-            # repo owner. It's also not necessarily the case that the commit
-            # author is the owner performing the 'Upload Sent' action.
-            "user_ownerid": commit.repository.author.ownerid,
+            "user_ownerid": commit.author.ownerid,
             "ownerid": commit.repository.author.ownerid,
             "repoid": commit.repository.repoid,
-            "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!
+            "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here.
             "pullid": commit.pullid,
             "upload_type": "Coverage report",
         },

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService, MinioEndpoints
+from shared.events.amplitude import AmplitudeEventPublisher
 from shared.metrics import inc_counter
 from shared.upload.utils import UploaderType, insert_coverage_measurement
 
@@ -166,6 +167,17 @@ def send_analytics_data(
     }
     AnalyticsService().account_uploaded_coverage_report(
         commit.repository.author.ownerid, analytics_upload_data
+    )
+    AmplitudeEventPublisher().publish(
+        "Upload Sent",
+        {
+            "user_ownerid": commit.author.ownerid,
+            "ownerid": commit.repository.author.ownerid,
+            "repoid": commit.repository.repoid,
+            "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here!
+            "pullid": commit.pullid,
+            "upload_type": "Coverage report",
+        },
     )
 
 


### PR DESCRIPTION
Adds event tracking of 'Upload Sent' events for Coverage, Bundles, and test results.

It seems in some cases commit may not have an author set during TA/BA ingest. In these cases we've decided to attribute the events to a special anonymous user that has a special user id constant in shared.

Note that we are using `commit.id` instead of the commit sha because a full commit sha is functionally identifiable information (for public repos at least). No reason to use this when we have an internal id that does the same thing but is only useful to us.