### PR TITLE
makefile changes for monorepo prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ test_env.install_cli:
 
 test_env.container_prepare:
 	apt-get -y install git build-essential netcat-traditional
-	git config --global --add safe.directory /app
+	git config --global --add safe.directory /app || true
 
 test_env.container_check_db:
 	while ! nc -vz postgres 5432; do sleep 1; echo "waiting for postgres"; done


### PR DESCRIPTION
needed for https://github.com/codecov/umbrella/pull/4

we bindmount our local `codecov-api` into the docker container. currently our local `codecov-api` is the actual git repo, so the `git` invocation works. in umbrella, it's not the actual git repo, so the command fails

apparently this is all i need to change...?