### PR TITLE
fix: TA GQL term filtering

### DIFF
--- a/graphql_api/tests/test_test_analytics.py
+++ b/graphql_api/tests/test_test_analytics.py
@@ -468,7 +468,7 @@ class TestAnalyticsTestCase(
     def test_test_analytics_term_filter(self, repository, store_in_redis, mock_storage):
         test_results = generate_test_results(
             repoid=repository.repoid,
-            term=rows[0]["name"],
+            term=rows[0]["name"][2:],
             ordering=TestResultsOrderingParameter.UPDATED_AT,
             ordering_direction=OrderingDirection.DESC,
             measurement_interval=MeasurementInterval.INTERVAL_30_DAY,

--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -198,7 +198,7 @@ def generate_test_results(
         )
 
     if term:
-        table = table.filter(pl.col("name").str.starts_with(term))
+        table = table.filter(pl.col("name").str.contains(term))
 
     if testsuites:
         table = table.filter(


### PR DESCRIPTION
instead of using startswith on the polars dataframe we want to filter by tests that contain the filtering term