### PR TITLE
feat: New properties for owner repos

### DIFF
--- a/graphql_api/tests/test_owner.py
+++ b/graphql_api/tests/test_owner.py
@@ -720,12 +720,37 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         query = """{
             owner(username: "%s") {
                 hasPrivateRepos
+                hasPublicRepos
+                hasActiveRepos
             }
         }
         """ % (current_org.username)
 
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["hasPrivateRepos"] == True
+        assert data["owner"]["hasPublicRepos"] == False
+        assert data["owner"]["hasActiveRepos"] == True
+
+    def test_owner_query_with_no_active_repos(self):
+        current_org = OwnerFactory(
+            username="random-plan-user",
+            service="github",
+        )
+        RepositoryFactory(
+            author=current_org, active=False, activated=False, private=True
+        )
+        query = """{
+            owner(username: "%s") {
+                hasPrivateRepos
+                hasPublicRepos
+                hasActiveRepos
+            }
+        }
+        """ % (current_org.username)
+        data = self.gql_request(query, owner=current_org)
+        assert data["owner"]["hasPrivateRepos"] == True
+        assert data["owner"]["hasPublicRepos"] == False
+        assert data["owner"]["hasActiveRepos"] == False
 
     def test_owner_query_with_public_repos(self):
         current_org = OwnerFactory(
@@ -749,12 +774,16 @@ class TestOwnerType(GraphQLTestHelper, TransactionTestCase):
         query = """{
             owner(username: "%s") {
                 hasPrivateRepos
+                hasPublicRepos
+                hasActiveRepos
             }
         }
         """ % (current_org.username)
 
         data = self.gql_request(query, owner=current_org)
         assert data["owner"]["hasPrivateRepos"] == False
+        assert data["owner"]["hasPublicRepos"] == True
+        assert data["owner"]["hasActiveRepos"] == True
 
     def test_owner_hash_owner_id(self):
         user = OwnerFactory(username="sample-user")

--- a/graphql_api/types/owner/owner.graphql
+++ b/graphql_api/types/owner/owner.graphql
@@ -6,7 +6,9 @@ type Owner {
   defaultOrgUsername: String
   delinquent: Boolean
   hashOwnerid: String
+  hasActiveRepos: Boolean
   hasPrivateRepos: Boolean
+  hasPublicRepos: Boolean
   invoice(invoiceId: String!): Invoice
   invoices: [Invoice] @cost(complexity: 100)
   isAdmin: Boolean

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -134,6 +134,20 @@ def resolve_has_private_repos(owner: Owner, info: GraphQLResolveInfo) -> bool:
     return owner.has_private_repos
 
 
+@owner_bindable.field("hasPublicRepos")
+@sync_to_async
+@require_part_of_org
+def resolve_has_public_repos(owner: Owner, info: GraphQLResolveInfo) -> bool:
+    return owner.has_public_repos
+
+
+@owner_bindable.field("hasActiveRepos")
+@sync_to_async
+@require_part_of_org
+def resolve_has_active_repos(owner: Owner, info: GraphQLResolveInfo) -> bool:
+    return owner.has_active_repos
+
+
 @owner_bindable.field("ownerid")
 @require_part_of_org
 def resolve_ownerid(owner: Owner, info: GraphQLResolveInfo) -> int:


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?

Giving access to two new owner properties regarding repos for use in this FE change https://github.com/codecov/engineering-team/issues/3074

### What does this PR do?
- Adds `hasActiveRepos` and `hasPublicRepos` to the owner type

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
