### PR TITLE
fix: Make PathContent's path non-nullable

### DIFF
--- a/graphql_api/types/path_contents/path_content.graphql
+++ b/graphql_api/types/path_contents/path_content.graphql
@@ -1,6 +1,6 @@
 interface PathContent {
   name: String!
-  path: String
+  path: String!
   hits: Int!
   misses: Int!
   partials: Int!
@@ -10,7 +10,7 @@ interface PathContent {
 
 type PathContentFile implements PathContent {
   name: String!
-  path: String
+  path: String!
   hits: Int!
   misses: Int!
   partials: Int!
@@ -21,7 +21,7 @@ type PathContentFile implements PathContent {
 
 type PathContentDir implements PathContent {
   name: String!
-  path: String
+  path: String!
   hits: Int!
   misses: Int!
   partials: Int!


### PR DESCRIPTION
Makes PathContent's path attribute non-nullable. Was doing a TS conversion in Gazebo and noticed this was nullable, but upon checking the types in the resolver, path will always be defined.
