### PR TITLE
Enable timeseries tests, differently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ REQUIREMENTS_TAG := requirements-v1-$(shell sha1sum requirements.txt | cut -d ' 
 VERSION := release-${sha}
 CODECOV_UPLOAD_TOKEN ?= "notset"
 CODECOV_STATIC_TOKEN ?= "notset"
-TIMESERIES_ENABLED ?= "true"
 CODECOV_URL ?= "https://api.codecov.io"
 export DOCKER_BUILDKIT=1
 export API_DOCKER_REPO=${AR_REPO}
@@ -191,7 +190,7 @@ shell:
 	
 test_env.up:
 	env | grep GITHUB > .testenv; true
-	TIMESERIES_ENABLED=${TIMESERIES_ENABLED} docker-compose up -d
+	docker-compose up -d
 
 test_env.prepare:
 	docker-compose exec api make test_env.container_prepare

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,14 @@ services:
           size: 2048M
 
   timescale:
-    image: timescale/timescaledb:latest-pg14
+    image: timescale/timescaledb-ha:pg14-latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_PASSWORD=password
     volumes:
       - type: tmpfs
-        target: /var/lib/postgresql/data
+        target: /home/postgres/pgdata/data
         tmpfs:
           size: 2048M
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,11 +38,6 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_PASSWORD=password
-    volumes:
-      - type: tmpfs
-        target: /home/postgres/pgdata/data
-        tmpfs:
-          size: 2048M
 
   redis:
     image: redis:6-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,14 @@ services:
       - ./dev.sh
     environment:
       - RUN_ENV=DEV
-      - SETUP__TIMESERIES__ENABLED=${TIMESERIES_ENABLED-true}
       # Improves pytest-cov performance in python 3.12
       # https://github.com/nedbat/coveragepy/issues/1665#issuecomment-1937075835
       - COVERAGE_CORE=sysmon 
     env_file:
       - .testenv
+
   postgres:
-    image: postgres:14.7-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
@@ -31,8 +31,9 @@ services:
         target: /var/lib/postgresql/data
         tmpfs:
           size: 2048M
+
   timescale:
-    image: timescale/timescaledb-ha:pg14-latest
+    image: timescale/timescaledb:latest-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
@@ -42,6 +43,7 @@ services:
         target: /var/lib/postgresql/data
         tmpfs:
           size: 2048M
+
   redis:
     image: redis:6-alpine
 

--- a/docker/test.yml
+++ b/docker/test.yml
@@ -3,6 +3,8 @@ setup:
   debug: no
   loglvl: INFO
   encryption_secret: "zp^P9*i8aR3"
+  timeseries:
+    enabled: true
   okta:
     iss: "https://example.okta.com"
   http:
@@ -11,18 +13,6 @@ setup:
     timeouts:
       connect: 10
       receive: 15
-  tasks:
-    celery:
-      soft_timelimit: 200
-      hard_timelimit: 240
-    upload:
-      queue: uploads
-  cache:
-    yaml: 600 # 10 minutes
-    tree: 600 # 10 minutes
-    diff: 300 # 5 minutes
-    chunks: 300 # 5 minutes
-    uploads: 86400 # 1 day
 
 services:
   database_url: postgres://postgres:password@postgres:5432/postgres

--- a/graphql_api/tests/test_config.py
+++ b/graphql_api/tests/test_config.py
@@ -107,9 +107,7 @@ class TestConfigType(GraphQLTestHelper, TestCase):
             },
         }
 
-    @override_settings(
-        TIMESERIES_ENABLED=True,
-    )
+    @override_settings(TIMESERIES_ENABLED=True)
     def test_timeseries_enabled(self):
         data = self.gql_request("query { config { isTimescaleEnabled }}")
         assert data == {
@@ -118,9 +116,7 @@ class TestConfigType(GraphQLTestHelper, TestCase):
             },
         }
 
-    @override_settings(
-        TIMESERIES_ENABLED=False,
-    )
+    @override_settings(TIMESERIES_ENABLED=False)
     def test_timeseries_enabled_is_false(self):
         data = self.gql_request("query { config { isTimescaleEnabled }}")
         assert data == {
@@ -129,9 +125,7 @@ class TestConfigType(GraphQLTestHelper, TestCase):
             },
         }
 
-    @override_settings(
-        TIMESERIES_ENABLED="true",
-    )
+    @override_settings(TIMESERIES_ENABLED="true")
     def test_timeseries_enabled_is_true_string(self):
         data = self.gql_request("query { config { isTimescaleEnabled }}")
         assert data == {
@@ -140,9 +134,7 @@ class TestConfigType(GraphQLTestHelper, TestCase):
             },
         }
 
-    @override_settings(
-        TIMESERIES_ENABLED="false",
-    )
+    @override_settings(TIMESERIES_ENABLED="false")
     def test_timeseries_enabled_is_false_string(self):
         data = self.gql_request("query { config { isTimescaleEnabled }}")
         assert data == {


### PR DESCRIPTION
Rather than messing with ENV in docker, this uses the test-global `config.yml` to enable timeseries tests, and switches to a lighter-weight timescale docker image.