### PR TITLE
fix: TA tokenless uploads

### DIFF
--- a/codecov_auth/authentication/repo_auth.py
+++ b/codecov_auth/authentication/repo_auth.py
@@ -338,6 +338,49 @@ class TokenlessAuthentication(authentication.TokenAuthentication):
             raise exceptions.AuthenticationFailed(self.auth_failed_message)
 
 
+class TestAnalyticsTokenlessAuthentication(TokenlessAuthentication):
+    def _get_info_from_request_path(
+        self, request: HttpRequest
+    ) -> tuple[Repository, str | None]:
+        try:
+            body = json.loads(str(request.body, "utf8"))
+
+            # Validate provider
+            service_enum = Service(body.get("service"))
+
+            # Validate that next group exists and decode slug
+            repo = get_repository_from_string(service_enum, body.get("slug"))
+            if repo is None:
+                # Purposefully using the generic message so that we don't tell that
+                # we don't have a certain repo
+                raise exceptions.AuthenticationFailed(self.auth_failed_message)
+
+            return repo, body.get("commit")
+        except json.JSONDecodeError:
+            # Validate request body format
+            raise exceptions.AuthenticationFailed(self.auth_failed_message)
+        except ValueError:
+            # Validate provider
+            raise exceptions.AuthenticationFailed(self.auth_failed_message)
+
+    def get_branch(
+        self,
+        request: HttpRequest,
+        repoid: Optional[int] = None,
+        commitid: Optional[str] = None,
+    ) -> str:
+        body = json.loads(str(request.body, "utf8"))
+
+        # If commit is not created yet (ie first upload for this commit), we just validate branch format.
+        # However, if a commit exists already (ie not the first upload for this commit), we must additionally
+        # validate the saved commit branch matches what is requested in this upload call.
+        commit = Commit.objects.filter(repository_id=repoid, commitid=commitid).first()
+        if commit and commit.branch != body.get("branch"):
+            raise exceptions.AuthenticationFailed(self.auth_failed_message)
+
+        return body.get("branch")
+
+
 class BundleAnalysisTokenlessAuthentication(TokenlessAuthentication):
     def _get_info_from_request_path(
         self, request: HttpRequest

--- a/upload/views/test_results.py
+++ b/upload/views/test_results.py
@@ -14,7 +14,7 @@ from codecov_auth.authentication.repo_auth import (
     GitHubOIDCTokenAuthentication,
     OrgLevelTokenAuthentication,
     RepositoryLegacyTokenAuthentication,
-    TokenlessAuthentication,
+    TestAnalyticsTokenlessAuthentication,
     UploadTokenRequiredGetFromBodyAuthenticationCheck,
     repo_auth_custom_exception_handler,
 )
@@ -64,7 +64,7 @@ class TestResultsView(
         OrgLevelTokenAuthentication,
         GitHubOIDCTokenAuthentication,
         RepositoryLegacyTokenAuthentication,
-        TokenlessAuthentication,
+        TestAnalyticsTokenlessAuthentication,
     ]
 
     def get_exception_handler(self):

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -207,6 +207,7 @@ class UploadViews(ListCreateAPIView, GetterMixin):
         RepositoryLegacyTokenAuthentication,
         TokenlessAuthentication,
     ]
+
     throttle_classes = [UploadsPerCommitThrottle, UploadsPerWindowThrottle]
 
     def get_exception_handler(self) -> Callable[[Exception, Dict[str, Any]], Response]:


### PR DESCRIPTION
previously it was broken because it was trying to get the repository and commit information from the request path, when TA requests store that information in the body. So we take the same modifications that the BA tokenless authentication made but change the service to be fetched from the "service" key instead of the "git_service" key

Fixes: https://github.com/codecov/codecov-action/issues/1762