### PR TITLE
ref: Remove isCriticalFile and profilingToken from GQL API

### DIFF
--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -47,9 +47,6 @@ query_files = """
                                         partials
                                         lines
                                         percentCovered
-                                        ... on PathContentFile {
-                                            isCriticalFile
-                                        }
                                     }
                                 }
                                 ... on MissingHeadReport {
@@ -94,9 +91,6 @@ query_files_connection = """
                                             partials
                                             lines
                                             percentCovered
-                                            ... on PathContentFile {
-                                                isCriticalFile
-                                            }
                                         }
                                     }
                                     totalCount
@@ -390,7 +384,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -401,7 +394,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                 ],
                             }
@@ -449,7 +441,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentDir",
@@ -504,7 +495,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -515,7 +505,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                 ],
                             }
@@ -557,7 +546,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -568,7 +556,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -579,7 +566,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -590,7 +576,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -601,7 +586,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                 ],
                             }
@@ -1165,7 +1149,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentFile",
@@ -1176,7 +1159,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                         "partials": 0,
                                         "lines": 10,
                                         "percentCovered": 80.0,
-                                        "isCriticalFile": False,
                                     },
                                     {
                                         "__typename": "PathContentDir",
@@ -1232,7 +1214,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                     {
@@ -1246,7 +1227,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                 ],
@@ -1492,7 +1472,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                     {
@@ -1506,7 +1485,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                     {
@@ -1520,7 +1498,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                     {
@@ -1534,7 +1511,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                     {
@@ -1548,7 +1524,6 @@ class TestBranch(GraphQLTestHelper, TransactionTestCase):
                                             "partials": 0,
                                             "lines": 10,
                                             "percentCovered": 80.0,
-                                            "isCriticalFile": False,
                                         },
                                     },
                                 ],

--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -529,7 +529,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
     ):
         query = (
             query_commit
-            % 'coverageAnalytics { coverageFile(path: "path") { hashedPath, content, isCriticalFile, coverage { line,coverage }, totals { percentCovered } } }'
+            % 'coverageAnalytics { coverageFile(path: "path") { hashedPath, content, coverage { line,coverage }, totals { percentCovered } } }'
         )
         variables = {
             "org": self.org.username,
@@ -556,7 +556,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
         assert coverageFile["content"] == fake_coverage["content"]
         assert coverageFile["coverage"] == fake_coverage["coverage"]
         assert coverageFile["totals"] == fake_coverage["totals"]
-        assert coverageFile["isCriticalFile"] == False
         assert coverageFile["hashedPath"] == hashlib.md5("path".encode()).hexdigest()
 
     @patch("services.components.component_filtered_report")
@@ -609,7 +608,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                         commit(id: $commit) {
                             coverageAnalytics {
                                 coverageFile(path: "path", components: $components) {
-                                    hashedPath, content, isCriticalFile, coverage { line,coverage }, totals { percentCovered }
+                                    hashedPath, content, coverage { line,coverage }, totals { percentCovered }
                                 }
                             }
                         }
@@ -634,7 +633,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                                     {"coverage": "M", "line": 2},
                                 ],
                                 "hashedPath": "d6fe1d0be6347b8ef2427fa629c04485",
-                                "isCriticalFile": False,
                                 "totals": {"percentCovered": 83.0},
                             }
                         }
@@ -652,7 +650,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
     ):
         query = (
             query_commit
-            % 'coverageAnalytics { coverageFile(path: "path") { content, isCriticalFile, coverage { line,coverage }, totals { percentCovered } } }'
+            % 'coverageAnalytics { coverageFile(path: "path") { content, coverage { line,coverage }, totals { percentCovered } } }'
         )
         variables = {
             "org": self.org.username,
@@ -671,7 +669,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
         assert coverageFile["content"] == fake_coverage["content"]
         assert coverageFile["coverage"] == fake_coverage["coverage"]
         assert coverageFile["totals"] == fake_coverage["totals"]
-        assert coverageFile["isCriticalFile"] == False
 
     @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_flag_names(self, report_mock):
@@ -2627,7 +2624,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
     ):
         query = (
             query_commit
-            % 'coverageAnalytics { coverageFile(path: "path") { hashedPath, content, isCriticalFile, coverage { line,coverage }, totals { percentCovered } } }'
+            % 'coverageAnalytics { coverageFile(path: "path") { hashedPath, content, coverage { line,coverage }, totals { percentCovered } } }'
         )
         variables = {
             "org": self.org.username,
@@ -2654,7 +2651,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
         assert coverageFile["content"] == fake_coverage["content"]
         assert coverageFile["coverage"] == fake_coverage["coverage"]
         assert coverageFile["totals"] == fake_coverage["totals"]
-        assert coverageFile["isCriticalFile"] == False
         assert coverageFile["hashedPath"] == hashlib.md5("path".encode()).hexdigest()
 
     @patch("services.components.component_filtered_report")
@@ -2707,7 +2703,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                         commit(id: $commit) {
                             coverageAnalytics {
                                 coverageFile(path: "path", components: $components) {
-                                    hashedPath, content, isCriticalFile, coverage { line,coverage }, totals { percentCovered }
+                                    hashedPath, content, coverage { line,coverage }, totals { percentCovered }
                                 }
                             }
                         }
@@ -2732,7 +2728,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
                                     {"coverage": "M", "line": 2},
                                 ],
                                 "hashedPath": "d6fe1d0be6347b8ef2427fa629c04485",
-                                "isCriticalFile": False,
                                 "totals": {"percentCovered": 83.0},
                             }
                         }
@@ -2750,7 +2745,7 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
     ):
         query = (
             query_commit
-            % 'coverageAnalytics { coverageFile(path: "path") { content, isCriticalFile, coverage { line,coverage }, totals { percentCovered } }}'
+            % 'coverageAnalytics { coverageFile(path: "path") { content, coverage { line,coverage }, totals { percentCovered } }}'
         )
         variables = {
             "org": self.org.username,
@@ -2769,7 +2764,6 @@ class TestCommit(GraphQLTestHelper, TransactionTestCase):
         assert coverageFile["content"] == fake_coverage["content"]
         assert coverageFile["coverage"] == fake_coverage["coverage"]
         assert coverageFile["totals"] == fake_coverage["totals"]
-        assert coverageFile["isCriticalFile"] == False
 
     @patch("shared.reports.api_report_service.build_report_from_commit")
     def test_coverage_flag_names(self, report_mock):

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -60,7 +60,6 @@ default_fields = """
     uploadToken
     defaultBranch
     author { username }
-    profilingToken
     graphToken
     yaml
     isATSConfigured
@@ -136,7 +135,6 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "uploadToken": repo.upload_token,
             "defaultBranch": "main",
             "author": {"username": "codecov-user"},
-            "profilingToken": "",
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,
@@ -198,7 +196,6 @@ class TestFetchRepository(GraphQLTestHelper, TransactionTestCase):
             "uploadToken": repo.upload_token,
             "defaultBranch": "main",
             "author": {"username": "codecov-user"},
-            "profilingToken": "",
             "graphToken": graphToken,
             "yaml": "test: test\n",
             "isATSConfigured": False,

--- a/graphql_api/types/file/file.graphql
+++ b/graphql_api/types/file/file.graphql
@@ -1,16 +1,11 @@
 type File {
-    content: String
-    coverage: [CoverageAnnotation]
-    totals: CoverageTotals
-    isCriticalFile: Boolean @deprecated(reason: "Impact Analysis is deprecated.")
-    hashedPath: String!
+  content: String
+  coverage: [CoverageAnnotation]
+  totals: CoverageTotals
+  hashedPath: String!
 }
 
 type CoverageAnnotation {
-    line: Int
-    coverage: CoverageLine
-}
-
-type CriticalFile {
-  name: String!
+  line: Int
+  coverage: CoverageLine
 }

--- a/graphql_api/types/file/file.py
+++ b/graphql_api/types/file/file.py
@@ -3,7 +3,6 @@ import hashlib
 from ariadne import ObjectType
 from shared.utils.merge import LineType, line_type
 
-from codecov.db import sync_to_async
 from graphql_api.types.enums import CoverageLine
 
 file_bindable = ObjectType("File")
@@ -43,13 +42,6 @@ def resolve_coverage(data, info):
 def resolve_totals(data, info):
     file_report = data.get("file_report")
     return file_report.totals if file_report else None
-
-
-@file_bindable.field("isCriticalFile")
-@sync_to_async
-def resolve_is_critical_file(data, info):
-    """DEPRECATED. Returning dummy value"""
-    return False
 
 
 @file_bindable.field("hashedPath")

--- a/graphql_api/types/path_contents/path_content.graphql
+++ b/graphql_api/types/path_contents/path_content.graphql
@@ -16,7 +16,6 @@ type PathContentFile implements PathContent {
   partials: Int!
   lines: Int!
   percentCovered: Float!
-  isCriticalFile: Boolean! @deprecated(reason: "Impact Analysis is deprecated.")
 }
 
 type PathContentDir implements PathContent {
@@ -45,14 +44,14 @@ type PathContentConnection {
 }
 
 union PathContentsResult =
-  PathContents
+    PathContents
   | MissingHeadReport
   | MissingCoverage
   | UnknownPath
   | UnknownFlags
 
 union DeprecatedPathContentsResult =
-  PathContentConnection
+    PathContentConnection
   | MissingHeadReport
   | MissingCoverage
   | UnknownPath

--- a/graphql_api/types/path_contents/path_content.py
+++ b/graphql_api/types/path_contents/path_content.py
@@ -2,7 +2,6 @@ from typing import List, Union
 
 from ariadne import InterfaceType, ObjectType, UnionType
 
-from codecov.db import sync_to_async
 from graphql_api.helpers.connection import (
     ArrayConnection,
     Connection,
@@ -57,13 +56,6 @@ def resolve_lines(item: Union[File, Dir], info) -> int:
 @path_content_bindable.field("percentCovered")
 def resolve_percent_covered(item: Union[File, Dir], info) -> float:
     return item.coverage
-
-
-@path_content_file_bindable.field("isCriticalFile")
-@sync_to_async
-def resolve_is_critical_file(item: Union[File, Dir], info) -> bool:
-    """DEPRECATED. Returning dummy value"""
-    return False
 
 
 path_contents_result_bindable = UnionType("PathContentsResult")

--- a/graphql_api/types/repository/repository.graphql
+++ b/graphql_api/types/repository/repository.graphql
@@ -39,7 +39,6 @@ type Repository {
     before: String
   ): BranchConnection @cost(complexity: 3, multipliers: ["first", "last"])
   defaultBranch: String
-  profilingToken: String @deprecated(reason: "Impact Analysis is deprecated.")
   graphToken: String
   yaml: String
   bot: Owner

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -165,12 +165,6 @@ def resolve_default_branch(repository: Repository, info: GraphQLResolveInfo) -> 
     return repository.branch
 
 
-@repository_bindable.field("profilingToken")
-def resolve_profiling_token(repository: Repository, info: GraphQLResolveInfo) -> str:
-    """DEPRECATED"""
-    return ""
-
-
 @repository_bindable.field("staticAnalysisToken")
 def resolve_static_analysis_token(
     repository: Repository, info: GraphQLResolveInfo


### PR DESCRIPTION
### Purpose/Motivation

We're removing the deprecated impact analysis references now that these fields are no longer being queried for in API. Simple removal, in addition to removing the related references in the test suite

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
