### PR TITLE
Use `get_flag_names` more consistently

### DIFF
--- a/api/internal/tests/views/test_coverage_viewset.py
+++ b/api/internal/tests/views/test_coverage_viewset.py
@@ -10,7 +10,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from services.components import Component

--- a/api/public/v2/report/views.py
+++ b/api/public/v2/report/views.py
@@ -112,7 +112,7 @@ class BaseReportViewSet(
                 # empty report since the path is not part of the component
                 return Report()
 
-            component_flags = component.get_matching_flags(report.flags.keys())
+            component_flags = component.get_matching_flags(report.get_flag_names())
             if flag and len(component.flag_regexes) > 0 and flag not in component_flags:
                 # empty report since the flag is not part of the component
                 return Report()

--- a/api/public/v2/tests/test_api_compare_viewset.py
+++ b/api/public/v2/tests/test_api_compare_viewset.py
@@ -12,8 +12,8 @@ from shared.django_apps.core.tests.factories import (
     RepositoryFactory,
 )
 from shared.reports.api_report_service import SerializableReport
-from shared.reports.resources import Report, ReportFile, ReportLine
-from shared.reports.types import ReportTotals
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine, ReportTotals
 from shared.utils.merge import LineType
 from shared.utils.sessions import Session
 

--- a/api/public/v2/tests/test_api_component_viewset.py
+++ b/api/public/v2/tests/test_api_component_viewset.py
@@ -7,7 +7,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from services.components import Component

--- a/api/public/v2/tests/test_file_report_viewset.py
+++ b/api/public/v2/tests/test_file_report_viewset.py
@@ -9,7 +9,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from core.models import Branch

--- a/api/public/v2/tests/test_flag_viewset.py
+++ b/api/public/v2/tests/test_flag_viewset.py
@@ -7,7 +7,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from reports.tests.factories import RepositoryFlagFactory

--- a/api/public/v2/tests/test_report_tree.py
+++ b/api/public/v2/tests/test_report_tree.py
@@ -8,7 +8,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from utils.test_utils import APIClient

--- a/api/public/v2/tests/test_report_viewset.py
+++ b/api/public/v2/tests/test_report_viewset.py
@@ -13,7 +13,8 @@ from shared.django_apps.core.tests.factories import (
     CommitFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from services.components import Component

--- a/api/public/v2/tests/test_totals_viewset.py
+++ b/api/public/v2/tests/test_totals_viewset.py
@@ -10,7 +10,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from services.components import Component

--- a/compare/commands/compare/interactors/fetch_impacted_files.py
+++ b/compare/commands/compare/interactors/fetch_impacted_files.py
@@ -41,6 +41,7 @@ class FetchImpactedFiles(BaseInteractor):
         components_flags = []
 
         head_commit_report = comparison.head_report_without_applied_diff
+        report_flags = head_commit_report and head_commit_report.get_flag_names()
         if components_filter:
             all_components = components.commit_components(
                 comparison.head_commit, comparison.user
@@ -50,9 +51,7 @@ class FetchImpactedFiles(BaseInteractor):
             )
             for component in filtered_components:
                 components_paths.extend(component.paths)
-                components_flags.extend(
-                    component.get_matching_flags(head_commit_report.flags.keys())
-                )
+                components_flags.extend(component.get_matching_flags(report_flags))
 
         # Flags & Components intersection
         if components_flags:
@@ -62,7 +61,7 @@ class FetchImpactedFiles(BaseInteractor):
                 flags_filter = components_flags
 
         if flags_filter:
-            if set(flags_filter) & set(head_commit_report.flags):
+            if set(flags_filter) & set(report_flags):
                 files = files_belonging_to_flags(
                     commit_report=head_commit_report, flags=flags_filter
                 )

--- a/compare/commands/compare/interactors/tests/test_fetch_impacted_files.py
+++ b/compare/commands/compare/interactors/tests/test_fetch_impacted_files.py
@@ -8,7 +8,8 @@ from shared.django_apps.core.tests.factories import (
     PullFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from compare.commands.compare.interactors.fetch_impacted_files import (

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,8 @@ import fakeredis
 import pytest
 import vcr
 from django.conf import settings
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 # we need to enable this in the test environment since we're often creating

--- a/graphql_api/tests/test_branch.py
+++ b/graphql_api/tests/test_branch.py
@@ -173,6 +173,9 @@ class MockReport(object):
         for name in self.files:
             yield MockFile(name)
 
+    def get_flag_names(self):
+        return ["flag_a"]
+
     @property
     def flags(self):
         return {"flag-a": MockFlag()}
@@ -198,6 +201,9 @@ class MockNoFlagsReport(object):
     @property
     def flags(self):
         return None
+
+    def get_flag_names(self):
+        return []
 
 
 class TestBranch(GraphQLTestHelper, TransactionTestCase):

--- a/graphql_api/tests/test_commit.py
+++ b/graphql_api/tests/test_commit.py
@@ -97,9 +97,8 @@ class MockReport(object):
     def filter(self, **kwargs):
         return self
 
-    @property
-    def flags(self):
-        return {"flag_a": True, "flag_b": True}
+    def get_flag_names(self):
+        return ["flag_a", "flag_b"]
 
 
 class EmptyReport(MockReport):

--- a/graphql_api/tests/test_components.py
+++ b/graphql_api/tests/test_components.py
@@ -10,7 +10,8 @@ from shared.django_apps.core.tests.factories import (
     PullFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from compare.models import CommitComparison

--- a/graphql_api/tests/test_impacted_file.py
+++ b/graphql_api/tests/test_impacted_file.py
@@ -10,7 +10,8 @@ from shared.django_apps.core.tests.factories import (
     PullFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.torngit.exceptions import (
     TorngitClientGeneralError,
     TorngitObjectNotFoundError,

--- a/graphql_api/tests/test_path_content.py
+++ b/graphql_api/tests/test_path_content.py
@@ -2,8 +2,8 @@ from unittest.mock import Mock, PropertyMock, patch
 
 from django.test import TransactionTestCase
 from shared.django_apps.core.tests.factories import CommitFactory
-from shared.reports.resources import Report, ReportFile, ReportLine
-from shared.reports.types import ReportTotals
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine, ReportTotals
 from shared.utils.sessions import Session
 
 from services.path import Dir, File

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -160,6 +160,8 @@ def get_sorted_path_contents(
     component_paths = []
     component_flags = []
 
+    report_flags = report.get_flag_names()
+
     if component_filter:
         all_components = components_service.commit_components(commit, current_owner)
         filtered_components = components_service.filter_components_by_name_or_id(
@@ -173,10 +175,8 @@ def get_sorted_path_contents(
 
         for component in filtered_components:
             component_paths.extend(component.paths)
-            if report.flags:
-                component_flags.extend(
-                    component.get_matching_flags(report.flags.keys())
-                )
+            if report_flags:
+                component_flags.extend(component.get_matching_flags(report_flags))
 
     if component_flags:
         if flags_filter:
@@ -184,7 +184,7 @@ def get_sorted_path_contents(
         else:
             flags_filter = component_flags
 
-    if flags_filter and not report.flags:
+    if flags_filter and not report_flags:
         return UnknownFlags(f"No coverage with chosen flags: {flags_filter}")
 
     report_paths = ReportPaths(
@@ -325,8 +325,8 @@ def resolve_coverage_totals(
 @sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("flagNames")
 @sync_to_async
-def resolve_coverage_flags(commit: Commit, info: GraphQLResolveInfo) -> List[str]:
-    return commit.full_report.flags.keys()
+def resolve_coverage_flags(commit: Commit, info: GraphQLResolveInfo) -> list[str]:
+    return commit.full_report.get_flag_names()
 
 
 @sentry_sdk.trace

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -45,7 +45,9 @@ def resolve_impacted_files(
 
     if filters and comparison:
         flags = filters.get("flags", [])
-        if flags and set(flags).isdisjoint(set(comparison.head_report.flags)):
+        if flags and set(flags).isdisjoint(
+            set(comparison.head_report.get_flag_names())
+        ):
             return UnknownFlags()
 
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,4 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-shared = { git = "https://github.com/codecov/shared", rev = "4755e7f77efc711c6ca34c2fb284edce71836402" }
+shared = { git = "https://github.com/codecov/shared", rev = "079d368c402758bc7ccb47572425237a9ebd9f9b" }

--- a/services/components.py
+++ b/services/components.py
@@ -33,7 +33,7 @@ def component_filtered_report(
     """
     flags, paths = [], []
     for component in components:
-        flags.extend(component.get_matching_flags(report.flags.keys()))
+        flags.extend(component.get_matching_flags(report.get_flag_names()))
         paths.extend(component.paths)
     filtered_report = report.filter(flags=flags, paths=paths)
     return filtered_report

--- a/services/tests/test_components.py
+++ b/services/tests/test_components.py
@@ -8,7 +8,8 @@ from shared.django_apps.core.tests.factories import (
     OwnerFactory,
     RepositoryFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 from shared.yaml.user_yaml import UserYaml
 

--- a/services/tests/test_path.py
+++ b/services/tests/test_path.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.test import TestCase
 from shared.django_apps.core.tests.factories import CommitFactory, OwnerFactory
 from shared.reports.api_report_service import SerializableReport
-from shared.reports.resources import Report, ReportFile, ReportLine
-from shared.reports.types import ReportTotals
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine, ReportTotals
 from shared.torngit.exceptions import TorngitClientGeneralError
 from shared.utils.sessions import Session
 

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -10,7 +10,8 @@ from shared.reports.api_report_service import (
     build_report,
     build_report_from_commit,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.storage.exceptions import FileNotInStorageError
 from shared.utils.sessions import Session
 

--- a/timeseries/tests/test_helpers.py
+++ b/timeseries/tests/test_helpers.py
@@ -15,7 +15,8 @@ from shared.django_apps.timeseries.tests.factories import (
     DatasetFactory,
     MeasurementFactory,
 )
-from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.resources import Report, ReportFile
+from shared.reports.types import ReportLine
 from shared.utils.sessions import Session
 
 from timeseries.helpers import (

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
     { name = "sentry-sdk", extras = ["celery"], specifier = "==2.13.0" },
-    { name = "shared", git = "https://github.com/codecov/shared?rev=4755e7f77efc711c6ca34c2fb284edce71836402" },
+    { name = "shared", git = "https://github.com/codecov/shared?rev=079d368c402758bc7ccb47572425237a9ebd9f9b" },
     { name = "simplejson", specifier = "==3.17.2" },
     { name = "starlette", specifier = "==0.40.0" },
     { name = "stripe", specifier = ">=11.4.1" },
@@ -1914,7 +1914,7 @@ wheels = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = { git = "https://github.com/codecov/shared?rev=4755e7f77efc711c6ca34c2fb284edce71836402#4755e7f77efc711c6ca34c2fb284edce71836402" }
+source = { git = "https://github.com/codecov/shared?rev=079d368c402758bc7ccb47572425237a9ebd9f9b#079d368c402758bc7ccb47572425237a9ebd9f9b" }
 dependencies = [
     { name = "amplitude-analytics" },
     { name = "boto3" },


### PR DESCRIPTION
We are using the `.flags` property in a lot of places where we only ever wanted the `.keys()`. So lets use `get_flag_names` instead, which does exactly that.