### PR TITLE
Set bot on owner even if bot name hasn't changed

### DIFF
--- a/codecov_auth/commands/owner/interactors/set_yaml_on_owner.py
+++ b/codecov_auth/commands/owner/interactors/set_yaml_on_owner.py
@@ -68,9 +68,9 @@ class SetYamlOnOwnerInteractor(BaseInteractor):
         old_yaml_bot = old_yaml and old_yaml.get("codecov", {}).get("bot")
         new_yaml_bot = new_yaml and new_yaml.get("codecov", {}).get("bot")
 
-        # Update owner's bot column if bot is updated in yaml
-        if new_yaml_bot != old_yaml_bot:
-            new_bot = (
+        # Update owner's bot column if bot is updated in yaml or if bot is not configured.
+        if new_yaml_bot != old_yaml_bot or self.owner.bot is None:
+            new_bot_id = (
                 get_ownerid_if_member(
                     service=self.owner.service,
                     owner_username=new_yaml_bot,
@@ -79,7 +79,7 @@ class SetYamlOnOwnerInteractor(BaseInteractor):
                 or old_yaml_bot
                 or None
             )
-            self.owner.bot = new_bot
+            self.owner.bot_id = new_bot_id
             self.owner.save()
 
     @sync_to_async

--- a/codecov_auth/commands/owner/interactors/tests/test_set_yaml_on_owner.py
+++ b/codecov_auth/commands/owner/interactors/tests/test_set_yaml_on_owner.py
@@ -66,6 +66,16 @@ class SetYamlOnOwnerInteractorTest(TransactionTestCase):
             organizations=[self.org.ownerid], service=self.org.service
         )
         self.random_owner = OwnerFactory(service=self.org.service)
+        self.codecov_bot = OwnerFactory(
+            username="codecov",
+            organizations=[self.org.ownerid],
+            private_access=True,
+        )
+        self.codecov2_bot = OwnerFactory(
+            username="codecov-2",
+            organizations=[self.org.ownerid],
+            private_access=True,
+        )
 
     # helper to execute the interactor
     def execute(self, owner, *args):
@@ -159,6 +169,7 @@ class SetYamlOnOwnerInteractorTest(TransactionTestCase):
 
     async def test_user_changes_yaml_bot_and_branch(self):
         await sync_to_async(RepositoryFactory)(author=self.org, branch="fake-branch")
+        assert self.current_owner.bot_id is None
         owner_updated = await self.execute(
             self.current_owner, self.org.username, yaml_with_changed_branch_and_bot
         )
@@ -168,3 +179,4 @@ class SetYamlOnOwnerInteractorTest(TransactionTestCase):
             "codecov": {"branch": "test-2", "bot": "codecov-2"},
             "to_string": "\ncodecov:\n  branch: 'test-2'\n  bot: 'codecov-2'\n",
         }
+        assert owner_updated.bot_id == self.codecov2_bot.ownerid


### PR DESCRIPTION
### Purpose/Motivation
This is to ensure that the bot is set, even if the YAML hasn't changed.

### Links to relevant tickets
This fixes: https://github.com/codecov/internal-issues/issues/1244

### What does this PR do?
Include a brief description of the changes in this PR. Bullet points are your friend.

### Notes to Reviewer
Anything to note to the team? Any tips on how to review, or where to start?

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
