### PR TITLE
remove OpenSSL download

### DIFF
--- a/.github/workflows/upload-overwatch.yml
+++ b/.github/workflows/upload-overwatch.yml
@@ -24,12 +24,6 @@ jobs:
         run: |
           pip install mypy==1.15.0
           pip install ruff==0.9.6
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get update
-          # Install libssl1.1 from Ubuntu 20.04 repositories
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
       - name: Install Overwatch CLI
         run: |
           curl -o overwatch-cli https://overwatch.codecov.dev/linux/cli


### PR DESCRIPTION
Changes from https://github.com/codecov/overwatch/pull/227 should make it so we don't have to explicitly install OpenSSL anymore. The Overwatch CLI is now using a rust package for TLS implementation.

This is basically testing that it works