### PR TITLE
"Fix" errors calling `get_flag_names` on `None`

### DIFF
--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -326,7 +326,7 @@ def resolve_coverage_totals(
 @commit_coverage_analytics_bindable.field("flagNames")
 @sync_to_async
 def resolve_coverage_flags(commit: Commit, info: GraphQLResolveInfo) -> list[str]:
-    return commit.full_report.get_flag_names()
+    return commit.full_report.get_flag_names() if commit.full_report else []
 
 
 @sentry_sdk.trace

--- a/services/components.py
+++ b/services/components.py
@@ -32,8 +32,9 @@ def component_filtered_report(
     Filter a report such that the totals, etc. are only pertaining to the given component.
     """
     flags, paths = [], []
+    report_flags = report.get_flag_names() if report else []
     for component in components:
-        flags.extend(component.get_matching_flags(report.get_flag_names()))
+        flags.extend(component.get_matching_flags(report_flags))
         paths.extend(component.paths)
     filtered_report = report.filter(flags=flags, paths=paths)
     return filtered_report


### PR DESCRIPTION
The recent switch to `get_flag_names` has caused a couple of "new" Sentry errors. Though they are not really "new", but rather just different from previous errors.

It seems like the existing code is passing `None` as Report in a bunch of places, and has seemingly always done so. The error now is just a different one.

Nonetheless, I paper over that error in some places by defaulting to `[]` instead on an empty Report. The code will still fail on a different line though.

---

"Fixes" [API-BF1](https://codecov.sentry.io/issues/6387980402), [API-BEZ](https://codecov.sentry.io/issues/6387028994/) and [API-BF2](https://codecov.sentry.io/issues/6387980405/)