### PR TITLE
fix: pass repoid to get_appropriate_storage_service

### DIFF
--- a/graphql_api/dataloader/bundle_analysis.py
+++ b/graphql_api/dataloader/bundle_analysis.py
@@ -30,7 +30,7 @@ def load_bundle_analysis_comparison(
         return MissingBaseReport()
 
     loader = BundleAnalysisReportLoader(
-        storage_service=get_appropriate_storage_service(),
+        storage_service=get_appropriate_storage_service(head_commit.repository.repoid),
         repo_key=ArchiveService.get_archive_hash(head_commit.repository),
     )
 
@@ -57,7 +57,7 @@ def load_bundle_analysis_report(
         return MissingHeadReport()
 
     loader = BundleAnalysisReportLoader(
-        storage_service=get_appropriate_storage_service(),
+        storage_service=get_appropriate_storage_service(commit.repository.repoid),
         repo_key=ArchiveService.get_archive_hash(commit.repository),
     )
     report = loader.load(report.external_id)

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -38,7 +38,7 @@ from timeseries.models import Interval, MeasurementName
 def load_report(
     commit: Commit, report_code: Optional[str] = None
 ) -> Optional[SharedBundleAnalysisReport]:
-    storage = get_appropriate_storage_service()
+    storage = get_appropriate_storage_service(commit.repository.repoid)
 
     commit_report = commit.reports.filter(
         report_type=CommitReport.ReportType.BUNDLE_ANALYSIS,

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -55,7 +55,7 @@ def get_results(
 
     if result is None:
         # try storage
-        storage_service = get_appropriate_storage_service()
+        storage_service = get_appropriate_storage_service(repoid)
         key = storage_key(repoid, branch, interval_start, interval_end)
         try:
             result = storage_service.read_file(


### PR DESCRIPTION
if we don't pass the repoid, then it won't check the feature flag, and it will be stuck on the old implementation

so it's possible that somewhere else the file is being written using the new implementation, so this will fail to decompress it properly

this is just temporary until we hardcode the new impl to be the default