### PR TITLE
add impersonation styling to django admin

### DIFF
--- a/codecov/settings_base.py
+++ b/codecov/settings_base.py
@@ -76,7 +76,9 @@ ROOT_URLCONF = "codecov.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [
+            "templates",
+        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,60 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block branding %}
+<h1 id="site-name">
+    <a href="{% url 'admin:index' %}">
+        {% trans 'Django administration' %}
+        <span id="impersonation-notice" style="display: none;">
+            - Impersonating (return to codecov.io and log out)
+        </span>
+    </a>
+</h1>
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<style>
+    /* Custom styling when cookie is present */
+    html[data-theme="light"].impersonation, :root.impersonation {
+      --primary: #ff9800;
+      --secondary: #ff9800;
+      --link-fg: #ff9800;
+      --link-selected-fg: #ff9800;
+    }
+    
+    #header.impersonation {
+        background-color: #ff9800 !important;
+    }
+</style>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        function getCookie(name) {
+            const value = `; ${document.cookie}`;
+            const parts = value.split(`; ${name}=`);
+            if (parts.length === 2) return parts.pop().split(';').shift();
+            return null;
+        }
+
+        // Check for the "staff_user" cookie
+        const staffUserCookie = getCookie('staff_user');
+
+        if (staffUserCookie) {
+            // Modify the header appearance
+            const headerElement = document.querySelector('#header');
+            if (headerElement) {
+                headerElement.classList.add('impersonation');
+            }
+            
+            // Add class to html element for theme variables
+            document.documentElement.classList.add('impersonation');
+            
+            // Show the impersonation notice
+            const impersonationNotice = document.getElementById('impersonation-notice');
+            if (impersonationNotice) {
+                impersonationNotice.style.display = 'inline';
+            }
+        }
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
### Purpose/Motivation
If you use the django admin site while impersonating, it gets ugly (becomes very visually apparent that you are in an altered state)

### Links to relevant tickets
https://github.com/codecov/engineering-team/issues/3465

preview from my local (the banner got cut off, it says `Impersonating (return to codecov.io and log out)`):

![Screenshot 2025-03-17 at 5 13 14 PM](https://github.com/user-attachments/assets/e27faafd-ca10-40f2-8981-5b047646da06)
