### PR TITLE
update shared

### DIFF
--- a/api/internal/tests/views/test_compare_viewset.py
+++ b/api/internal/tests/views/test_compare_viewset.py
@@ -91,14 +91,14 @@ class TestCompareViewSetRetrieve(APITestCase):
         self.base_file = ReportFile(
             name=self.file_name, totals=[46, 46, 0, 0, 100, 0, 0, 0, 1, 0, 0, 0]
         )
-        self.base_file._lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 46
+        self.base_file._parsed_lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 46
         self.base_report = MockSerializableReport()
         self.base_report.mocked_files = {self.file_name: self.base_file}
 
         self.head_file = ReportFile(
             name=self.file_name, totals=[6, 6, 0, 0, 100, 0, 0, 0, 1, 0, 0, 0]
         )
-        self.head_file._lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 6
+        self.head_file._parsed_lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 6
         self.head_file.totals.diff = ReportTotals.default_totals()
         self.head_report = MockSerializableReport()
         self.head_report.mocked_files = {self.file_name: self.head_file}

--- a/api/public/v2/tests/test_api_compare_viewset.py
+++ b/api/public/v2/tests/test_api_compare_viewset.py
@@ -259,14 +259,14 @@ class TestCompareViewSetRetrieve(APITestCase):
         self.base_file = ReportFile(
             name=self.file_name, totals=[46, 46, 0, 0, 100, 0, 0, 0, 1, 0, 0, 0]
         )
-        self.base_file._lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 46
+        self.base_file._parsed_lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 46
         self.base_report = MockSerializableReport()
         self.base_report.mocked_files = {self.file_name: self.base_file}
 
         self.head_file = ReportFile(
             name=self.file_name, totals=[6, 6, 0, 0, 100, 0, 0, 0, 1, 0, 0, 0]
         )
-        self.head_file._lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 6
+        self.head_file._parsed_lines = [[1, "", [[1, 1, 0, 0, 0]], 0, 0]] * 6
         self.head_file.totals.diff = ReportTotals.default_totals()
         self.head_report = MockSerializableReport()
         self.head_report.mocked_files = {self.file_name: self.head_file}

--- a/codecov/settings_test.py
+++ b/codecov/settings_test.py
@@ -4,6 +4,7 @@ from .settings_dev import *
 
 ALLOWED_HOSTS = ["localhost"]
 CORS_ALLOWED_ORIGINS = ["http://localhost:9000", "http://localhost"]
+SHELTER_ENABLED = True
 SHELTER_PUBSUB_PROJECT_ID = "test-project-id"
 SHELTER_PUBSUB_SYNC_REPO_TOPIC_ID = "test-topic-id"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,4 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-shared = { git = "https://github.com/codecov/shared", rev = "284b92c74f0bc7ca5c4f6f139f3b26fe64fe9c1a" }
+shared = { git = "https://github.com/codecov/shared", rev = "290557e977c4ff60d5d9dcb9ee54afea1c1df83f" }

--- a/services/tests/test_comparison.py
+++ b/services/tests/test_comparison.py
@@ -569,8 +569,8 @@ class FileComparisonTests(TestCase):
         }
         src = [first_line_val, "this is an added line", last_line_val]
 
-        self.file_comparison.head_file._lines = head_lines
-        self.file_comparison.base_file._lines = base_lines
+        self.file_comparison.head_file._parsed_lines = head_lines
+        self.file_comparison.base_file._parsed_lines = base_lines
         self.file_comparison.diff_data = {"segments": [segment]}
         self.file_comparison.src = src
 
@@ -665,8 +665,8 @@ class FileComparisonTests(TestCase):
         }
         src = [first_line_val, "this is an added line", last_line_val]
 
-        self.file_comparison.head_file._lines = head_lines
-        self.file_comparison.base_file._lines = base_lines
+        self.file_comparison.head_file._parsed_lines = head_lines
+        self.file_comparison.base_file._parsed_lines = base_lines
         self.file_comparison.diff_data = {"segments": [segment]}
         self.file_comparison.src = src
 
@@ -1311,10 +1311,10 @@ class SegmentTests(TestCase):
 
     def test_single_segment(self):
         self.file_comparison.src = self._src(12)
-        self.file_comparison.head_file._lines = self._report_lines(
+        self.file_comparison.head_file._parsed_lines = self._report_lines(
             [1 for _ in range(12)]
         )
-        self.file_comparison.base_file._lines = self._report_lines(
+        self.file_comparison.base_file._parsed_lines = self._report_lines(
             [
                 1,
                 1,  # first line of segment
@@ -1341,10 +1341,10 @@ class SegmentTests(TestCase):
 
     def test_multiple_segments(self):
         self.file_comparison.src = self._src(25)
-        self.file_comparison.head_file._lines = self._report_lines(
+        self.file_comparison.head_file._parsed_lines = self._report_lines(
             [1 for _ in range(25)]
         )
-        self.file_comparison.base_file._lines = self._report_lines(
+        self.file_comparison.base_file._parsed_lines = self._report_lines(
             [
                 1,
                 1,  # first line of segment 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '4' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
@@ -416,7 +415,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
     { name = "sentry-sdk", extras = ["celery"], specifier = "==2.13.0" },
-    { name = "shared", git = "https://github.com/codecov/shared?rev=284b92c74f0bc7ca5c4f6f139f3b26fe64fe9c1a" },
+    { name = "shared", git = "https://github.com/codecov/shared?rev=290557e977c4ff60d5d9dcb9ee54afea1c1df83f" },
     { name = "simplejson", specifier = "==3.17.2" },
     { name = "starlette", specifier = "==0.40.0" },
     { name = "stripe", specifier = ">=11.4.1" },
@@ -1751,7 +1750,7 @@ celery = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = { git = "https://github.com/codecov/shared?rev=284b92c74f0bc7ca5c4f6f139f3b26fe64fe9c1a#284b92c74f0bc7ca5c4f6f139f3b26fe64fe9c1a" }
+source = { git = "https://github.com/codecov/shared?rev=290557e977c4ff60d5d9dcb9ee54afea1c1df83f#290557e977c4ff60d5d9dcb9ee54afea1c1df83f" }
 dependencies = [
     { name = "amplitude-analytics" },
     { name = "boto3" },


### PR DESCRIPTION
- the `_lines` stuff is due to https://github.com/codecov/shared/commit/166da1e10776ac4e386e977d14aaf873acfffff3. `_lines` is now a read-only property and the underlying fields are `_raw_lines` and `_parsed_lines`. really we should not be reaching into these internal fields in the first place but that's a different mess
- the `settings_test.py` change is because we have some tests (`test_signals.py`, others) which expect shelter to be enabled to test some django signal / pubsub stuff. when we run codecov-api locally we disable shelter, so we need this to turn it back on for tests
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
