### PR TITLE
Batch triggering timeseries backfills

### DIFF
--- a/core/commands/repository/interactors/activate_measurements.py
+++ b/core/commands/repository/interactors/activate_measurements.py
@@ -20,11 +20,9 @@ class ActivateMeasurementsInteractor(BaseInteractor):
         )
 
         dataset, created = Dataset.objects.get_or_create(
-            name=measurement_type.value,
-            repository_id=repo.pk,
+            name=measurement_type.value, repository_id=repo.pk
         )
-
         if created:
-            trigger_backfill(dataset)
+            trigger_backfill([dataset])
 
         return dataset

--- a/core/commands/repository/interactors/tests/test_activate_measurements.py
+++ b/core/commands/repository/interactors/tests/test_activate_measurements.py
@@ -5,8 +5,6 @@ import pytest
 from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.test import TestCase, override_settings
-from django.utils import timezone
-from freezegun import freeze_time
 from shared.django_apps.core.tests.factories import (
     CommitFactory,
     OwnerFactory,
@@ -98,7 +96,6 @@ class ActivateMeasurementsInteractorTest(TestCase):
         ).exists()
 
     @patch("services.task.TaskService.backfill_dataset")
-    @freeze_time("2022-01-01T00:00:00")
     def test_triggers_task(self, backfill_dataset):
         CommitFactory(repository=self.repo, timestamp=datetime(2000, 1, 1, 1, 1, 1))
         CommitFactory(repository=self.repo, timestamp=datetime(2021, 12, 31, 1, 1, 1))
@@ -109,8 +106,8 @@ class ActivateMeasurementsInteractorTest(TestCase):
         ).first()
         backfill_dataset.assert_called_once_with(
             dataset,
-            start_date=timezone.datetime(2000, 1, 1),
-            end_date=timezone.datetime(2022, 1, 1),
+            start_date=datetime(2000, 1, 1, 1, 1, 1),
+            end_date=datetime(2021, 12, 31, 1, 1, 1),
         )
 
     @patch("services.task.TaskService.backfill_dataset")


### PR DESCRIPTION
Previously, the "owner measurements" would trigger backfilling of timeseries data for each repo one-by-one, leading to suboptimal N+1 queries.

The logic is now changed to do this as a batch, so we only run a single query to figure out the start/end date of the backfill.

---

Fixes https://github.com/codecov/internal-issues/issues/1222