### PR TITLE
Remove tests for `build_report`

### DIFF
--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -6,19 +6,14 @@ from shared.django_apps.core.tests.factories import (
     CommitFactory,
     CommitWithReportFactory,
 )
-from shared.reports.api_report_service import (
-    build_report,
-    build_report_from_commit,
-)
+from shared.reports.api_report_service import build_report_from_commit
 from shared.reports.resources import Report, ReportFile
 from shared.reports.types import ReportLine
 from shared.storage.exceptions import FileNotInStorageError
 from shared.utils.sessions import Session
 
 from reports.tests.factories import UploadFactory, UploadFlagMembershipFactory
-from services.report import (
-    files_belonging_to_flags,
-)
+from services.report import files_belonging_to_flags
 
 current_file = Path(__file__)
 
@@ -50,64 +45,6 @@ def sorted_files(report: Report) -> list[ReportFile]:
 
 
 class ReportServiceTest(TestCase):
-    def test_report_generator(self):
-        data = {
-            "chunks": "{}\n[1, null, [[0, 1]]]\n\n\n[1, null, [[0, 1]]]\n[0, null, [[0, 0]]]\n<<<<< end_of_chunk >>>>>\n{}\n[1, null, [[0, 1]]]\n\n\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n\n\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n\n\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n<<<<< end_of_chunk >>>>>\n{}\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n\n\n[1, null, [[0, 1]]]\n[0, null, [[0, 0]]]\n\n\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n[1, null, [[0, 1]]]\n\n\n[1, null, [[0, 1]]]\n[0, null, [[0, 0]]]",
-            "files": {
-                "awesome/__init__.py": [
-                    2,
-                    [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0],
-                    [[0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0]],
-                    [0, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
-                ],
-                "tests/__init__.py": [
-                    0,
-                    [0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0],
-                    [[0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0]],
-                    None,
-                ],
-                "tests/test_sample.py": [
-                    1,
-                    [0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0],
-                    [[0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0]],
-                    None,
-                ],
-            },
-            "sessions": {
-                "0": {
-                    "N": None,
-                    "a": "v4/raw/2019-01-10/839C9EAF1A3F1CD45AA08DF5F791461F/abf6d4df662c47e32460020ab14abf9303581429/9ccc55a1-8b41-4bb1-a946-ee7a33a7fb56.txt",
-                    "c": None,
-                    "d": 1547084427,
-                    "e": None,
-                    "f": None,
-                    "j": None,
-                    "n": None,
-                    "p": None,
-                    "t": [3, 20, 17, 3, 0, "85.00000", 0, 0, 0, 0, 0, 0, 0],
-                    "": None,
-                }
-            },
-            "totals": {
-                "C": 0,
-                "M": 0,
-                "N": 0,
-                "b": 0,
-                "c": "85.00000",
-                "d": 0,
-                "diff": [1, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
-                "f": 3,
-                "h": 17,
-                "m": 3,
-                "n": 20,
-                "p": 0,
-                "s": 1,
-            },
-        }
-
-        res = build_report(**data)
-        assert len(res.files) == 3
-
     @patch("shared.api_archive.archive.ArchiveService.read_chunks")
     def test_build_report_from_commit(self, read_chunks_mock):
         f = open(current_file.parent / "samples" / "chunks.txt", "r")


### PR DESCRIPTION
The `build_report_from_commit` fn is calling directly through to the `build_report` fn. Its only purpose is to default the `report_class`.

I would like to remove this indirection, and this test is in the way.