### PR TITLE
fix: Capture uploads for upload-only endpoint also

### DIFF
--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -206,6 +206,9 @@ def test_uploads_post(db, mocker, mock_redis):
     mocker.patch.object(
         CanDoCoverageUploadsPermission, "has_permission", return_value=True
     )
+    amplitude_mock = mocker.patch(
+        "shared.events.amplitude.AmplitudeEventPublisher.publish"
+    )
     presigned_put_mock = mocker.patch(
         "shared.storage.MinioStorageService.create_presigned_put",
         return_value="presigned put",
@@ -262,6 +265,17 @@ def test_uploads_post(db, mocker, mock_redis):
         == f"{settings.CODECOV_DASHBOARD_URL}/{repository.author.service}/{repository.author.username}/{repository.name}/commit/{commit.commitid}"
     )
 
+    amplitude_mock.assert_called_with(
+        "Upload Received",
+        {
+            "user_ownerid": commit.author.ownerid,
+            "ownerid": commit.repository.author.ownerid,
+            "repoid": commit.repository.repoid,
+            "commitid": commit.id,
+            "pullid": commit.pullid,
+            "upload_type": "Coverage report",
+        },
+    )
     assert ReportSession.objects.filter(
         report_id=commit_report.id,
         upload_extras={"format_version": "v1"},

--- a/upload/tests/views/test_uploads.py
+++ b/upload/tests/views/test_uploads.py
@@ -269,8 +269,8 @@ def test_uploads_post(db, mocker, mock_redis):
         "Upload Received",
         {
             "user_ownerid": commit.author.ownerid,
-            "ownerid": commit.repository.author.ownerid,
-            "repoid": commit.repository.repoid,
+            "ownerid": repository.author.ownerid,
+            "repoid": repository.repoid,
             "commitid": commit.id,
             "pullid": commit.pullid,
             "upload_type": "Coverage report",

--- a/upload/views/upload_coverage.py
+++ b/upload/views/upload_coverage.py
@@ -6,7 +6,6 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService
-from shared.events.amplitude import UNKNOWN_USER_OWNERID, AmplitudeEventPublisher
 from shared.metrics import inc_counter
 
 from codecov_auth.authentication.repo_auth import (
@@ -91,20 +90,6 @@ class UploadCoverageView(APIView, GetterMixin):
                 repo=repository.name,
                 commit=commit.commitid,
             ),
-        )
-
-        AmplitudeEventPublisher().publish(
-            "Upload Received",
-            {
-                "user_ownerid": commit.author.ownerid
-                if commit.author
-                else UNKNOWN_USER_OWNERID,
-                "ownerid": commit.repository.author.ownerid,
-                "repoid": commit.repository.repoid,
-                "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here.
-                "pullid": commit.pullid,
-                "upload_type": "Coverage report",
-            },
         )
 
         # Create report

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -58,8 +58,8 @@ def create_upload(
             "user_ownerid": commit.author.ownerid
             if commit.author
             else UNKNOWN_USER_OWNERID,
-            "ownerid": commit.repository.author.ownerid,
-            "repoid": commit.repository.repoid,
+            "ownerid": repository.author.ownerid,
+            "repoid": repository.repoid,
             "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here.
             "pullid": commit.pullid,
             "upload_type": "Coverage report",

--- a/upload/views/uploads.py
+++ b/upload/views/uploads.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.api_archive.archive import ArchiveService, MinioEndpoints
+from shared.events.amplitude import UNKNOWN_USER_OWNERID, AmplitudeEventPublisher
 from shared.metrics import inc_counter
 from shared.upload.utils import UploaderType, insert_coverage_measurement
 
@@ -51,6 +52,20 @@ def create_upload(
     is_shelter_request: bool,
     analytics_token: str,
 ) -> ReportSession:
+    AmplitudeEventPublisher().publish(
+        "Upload Received",
+        {
+            "user_ownerid": commit.author.ownerid
+            if commit.author
+            else UNKNOWN_USER_OWNERID,
+            "ownerid": commit.repository.author.ownerid,
+            "repoid": commit.repository.repoid,
+            "commitid": commit.id,  # Not commit.commitid, we do not want a commit SHA here.
+            "pullid": commit.pullid,
+            "upload_type": "Coverage report",
+        },
+    )
+
     version = (
         serializer.validated_data["version"]
         if "version" in serializer.validated_data


### PR DESCRIPTION
Based on in-person conversation we figured out we were missing metrics from the upload-only endpoint. The metric was only added to the new do it all create-commit create-report create-upload endpoint, but some uploads still go the old ones and we were missing those.
