### PR TITLE
read test bucket name from config instead of hardcoding

### DIFF
--- a/graphql_api/tests/test_test_analytics.py
+++ b/graphql_api/tests/test_test_analytics.py
@@ -172,13 +172,15 @@ def store_in_redis(repository):
 
 @pytest.fixture
 def store_in_storage(repository, mock_storage):
+    from django.conf import settings
+
     try:
-        mock_storage.create_root_storage("codecov")
+        mock_storage.create_root_storage(settings.GCS_BUCKET_NAME)
     except BucketAlreadyExistsError:
         pass
 
     mock_storage.write_file(
-        "codecov",
+        settings.GCS_BUCKET_NAME,
         f"test_results/rollups/{repository.repoid}/{repository.branch}/30",
         test_results_table.write_ipc(None).getvalue(),
     )
@@ -186,7 +188,7 @@ def store_in_storage(repository, mock_storage):
     yield
 
     mock_storage.delete_file(
-        "codecov",
+        settings.GCS_BUCKET_NAME,
         f"test_results/rollups/{repository.repoid}/{repository.branch}/30",
     )
 


### PR DESCRIPTION
`worker` thinks the default name for our bucket is `archive` but `codecov-api` thinks it's `codecov`. tests hardcode values based on that assumption. if you try to run tests for both repos with a unified config, one repo or the other will fail tests based on which value you chose

API was relatively easy to fix. there's just this one spot where we have to replace a hardcoded value with a setting
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
