### PR TITLE
Reorder trace annotations

### DIFF
--- a/graphql_api/types/bundle_analysis/base.py
+++ b/graphql_api/types/bundle_analysis/base.py
@@ -139,9 +139,9 @@ def resolve_modules(
     return bundle_asset.modules
 
 
-@sentry_sdk.trace
 @bundle_asset_bindable.field("measurements")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_asset_report_measurements(
     bundle_asset: AssetReport,
     info: GraphQLResolveInfo,
@@ -188,8 +188,8 @@ def resolve_assets(
     return list(bundle_report.assets())
 
 
-@sentry_sdk.trace
 @bundle_report_bindable.field("assetsPaginated")
+@sentry_sdk.trace
 def resolve_assets_paginated(
     bundle_report: BundleReport,
     info: GraphQLResolveInfo,
@@ -283,9 +283,9 @@ def resolve_bundle_report_filtered(
     )
 
 
-@sentry_sdk.trace
 @bundle_report_bindable.field("measurements")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_bundle_report_measurements(
     bundle_report: BundleReport,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -103,8 +103,8 @@ def resolve_list_uploads(commit: Commit, info, **kwargs):
     )
 
 
-@sentry_sdk.trace
 @commit_bindable.field("compareWithParent")
+@sentry_sdk.trace
 async def resolve_compare_with_parent(commit: Commit, info, **kwargs):
     if not commit.parent_commit_id:
         return MissingBaseCommit()
@@ -286,16 +286,16 @@ async def resolve_total_uploads(commit, info):
     return await command.get_uploads_number(commit)
 
 
-@sentry_sdk.trace
 @commit_bindable.field("bundleStatus")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_bundle_status(commit: Commit, info) -> Optional[CommitStatus]:
     return commit_status(commit, CommitReport.ReportType.BUNDLE_ANALYSIS)
 
 
-@sentry_sdk.trace
 @commit_bindable.field("coverageStatus")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_coverage_status(commit: Commit, info) -> Optional[CommitStatus]:
     return commit_status(commit, CommitReport.ReportType.COVERAGE)
 
@@ -313,8 +313,8 @@ def resolve_commit_bundle_analysis(commit, info):
 ### Commit Coverage Bindable ###
 
 
-@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("totals")
+@sentry_sdk.trace
 def resolve_coverage_totals(
     commit: Commit, info: GraphQLResolveInfo
 ) -> Optional[ReportTotals]:
@@ -322,16 +322,16 @@ def resolve_coverage_totals(
     return command.fetch_totals(commit)
 
 
-@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("flagNames")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_coverage_flags(commit: Commit, info: GraphQLResolveInfo) -> list[str]:
     return commit.full_report.get_flag_names() if commit.full_report else []
 
 
-@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("coverageFile")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_coverage_file(commit, info, path, flags=None, components=None):
     fallback_file, paths = None, []
     if components:
@@ -358,9 +358,9 @@ def resolve_coverage_file(commit, info, path, flags=None, components=None):
     }
 
 
-@sentry_sdk.trace
 @commit_coverage_analytics_bindable.field("components")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_coverage_components(commit: Commit, info, filters=None) -> List[Component]:
     info.context["component_commit"] = commit
     current_owner = info.context["request"].current_owner
@@ -377,9 +377,9 @@ def resolve_coverage_components(commit: Commit, info, filters=None) -> List[Comp
 ### Commit Bundle Analysis Bindable ###
 
 
-@sentry_sdk.trace
 @commit_bundle_analysis_bindable.field("bundleAnalysisCompareWithParent")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_commit_bundle_analysis_compare_with_parent(
     commit: Commit, info: GraphQLResolveInfo
 ) -> Union[BundleAnalysisComparison, Any]:
@@ -406,9 +406,9 @@ def resolve_commit_bundle_analysis_compare_with_parent(
     return bundle_analysis_comparison
 
 
-@sentry_sdk.trace
 @commit_bundle_analysis_bindable.field("bundleAnalysisReport")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_commit_bundle_analysis_report(commit: Commit, info) -> BundleAnalysisReport:
     bundle_analysis_report = load_bundle_analysis_report(commit)
 

--- a/graphql_api/types/comparison/comparison.py
+++ b/graphql_api/types/comparison/comparison.py
@@ -156,8 +156,8 @@ async def resolve_head_totals(
         return head_commit.commitreport.reportleveltotals
 
 
-@sentry_sdk.trace
 @comparison_bindable.field("patchTotals")
+@sentry_sdk.trace
 def resolve_patch_totals(
     comparison: ComparisonReport, info: GraphQLResolveInfo
 ) -> dict:
@@ -174,9 +174,9 @@ def resolve_patch_totals(
     return {**totals, "coverage": coverage}
 
 
-@sentry_sdk.trace
 @comparison_bindable.field("flagComparisons")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_flag_comparisons(
     comparison: ComparisonReport, info: GraphQLResolveInfo, filters=None
 ) -> List[FlagComparison]:
@@ -193,9 +193,9 @@ def resolve_flag_comparisons(
     return list(all_flags)
 
 
-@sentry_sdk.trace
 @comparison_bindable.field("componentComparisons")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_component_comparisons(
     comparison_report: ComparisonReport, info: GraphQLResolveInfo, filters=None
 ) -> List[ComponentComparison]:
@@ -242,9 +242,9 @@ def resolve_flag_comparisons_count(
     return get_flag_comparisons(comparison.commit_comparison).count()
 
 
-@sentry_sdk.trace
 @comparison_bindable.field("hasDifferentNumberOfHeadAndBaseReports")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_has_different_number_of_head_and_base_reports(
     comparison: ComparisonReport,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/coverage_analytics/coverage_analytics.py
+++ b/graphql_api/types/coverage_analytics/coverage_analytics.py
@@ -53,8 +53,8 @@ def resolve_coverage_analytics_result_type(
     return None
 
 
-@sentry_sdk.trace
 @coverage_analytics_bindable.field("percentCovered")
+@sentry_sdk.trace
 def resolve_percent_covered(
     parent: CoverageAnalyticsProps, info: GraphQLResolveInfo
 ) -> Optional[float]:
@@ -118,9 +118,9 @@ async def resolve_measurements(
     return measurements
 
 
-@sentry_sdk.trace
 @coverage_analytics_bindable.field("components")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_components_measurements(
     parent: CoverageAnalyticsProps,
     info: GraphQLResolveInfo,
@@ -253,9 +253,9 @@ def resolve_components_count(
     return len(repo_yaml_components)
 
 
-@sentry_sdk.trace
 @coverage_analytics_bindable.field("flags")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_flags(
     parent: CoverageAnalyticsProps,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -63,9 +63,9 @@ def resolve_hashed_path(impacted_file: ImpactedFile, info) -> str:
     return md5_path.hexdigest()
 
 
-@sentry_sdk.trace
 @impacted_file_bindable.field("segments")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_segments(
     impacted_file: ImpactedFile, info, filters=None
 ) -> Union[UnknownPath, ProviderError, SegmentComparisons]:

--- a/graphql_api/types/pull/pull.py
+++ b/graphql_api/types/pull/pull.py
@@ -59,8 +59,8 @@ def is_first_pull_request(pull: Pull) -> bool:
     return pull.repository.pull_requests.order_by("id").first() == pull
 
 
-@sentry_sdk.trace
 @pull_bindable.field("compareWithBase")
+@sentry_sdk.trace
 async def resolve_compare_with_base(
     pull: Pull, info: GraphQLResolveInfo, **kwargs: Any
 ) -> Union[CommitComparison, Any]:
@@ -90,9 +90,9 @@ async def resolve_compare_with_base(
         return ComparisonReport(commit_comparison)
 
 
-@sentry_sdk.trace
 @pull_bindable.field("bundleAnalysisCompareWithBase")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_bundle_analysis_compare_with_base(
     pull: Pull, info: GraphQLResolveInfo, **kwargs: Any
 ) -> Union[BundleAnalysisComparison, Any]:


### PR DESCRIPTION
I was very surprised that a ton of functions that have a trace annotation are not actually creating separate tracing spans.

It is highly probable that the trace annotation interacts with some other graphql or async related annotations in such a way that it does not work properly. Reordering it to be the last (aka inner-most) should hopefully solve this problem.