### PR TITLE
emit junit results in a monorepo-friendly way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ export CODECOV_TOKEN=${CODECOV_UPLOAD_TOKEN}
 API_DOMAIN ?= api
 PROXY_NETWORK ?= api_default
 
+# We allow this to be overridden so that we can run `pytest` from this directory
+# but have the junit file use paths relative to a parent directory. This will
+# help us move to a monorepo.
+PYTEST_ROOTDIR ?= "."
+
 # Codecov CLI version to use
 CODECOV_CLI_VERSION := 9.0.4
 
@@ -30,13 +35,13 @@ check-for-migration-conflicts:
 	python manage.py check_for_migration_conflicts
 
 test:
-	COVERAGE_CORE=sysmon pytest --cov=./ --junitxml=junit.xml -o junit_family=legacy
+	COVERAGE_CORE=sysmon pytest --cov=./ --junitxml=junit.xml -o junit_family=legacy -c pytest.ini --rootdir=${PYTEST_ROOTDIR}
 
 test.unit:
-	COVERAGE_CORE=sysmon pytest --cov=./ -m "not integration" --cov-report=xml:unit.coverage.xml --junitxml=unit.junit.xml -o junit_family=legacy
+	COVERAGE_CORE=sysmon pytest --cov=./ -m "not integration" --cov-report=xml:unit.coverage.xml --junitxml=unit.junit.xml -o junit_family=legacy -c pytest.ini --rootdir=${PYTEST_ROOTDIR}
 
 test.integration:
-	COVERAGE_CORE=sysmon pytest --cov=./ -m "integration" --cov-report=xml:integration.coverage.xml --junitxml=integration.junit.xml -o junit_family=legacy
+	COVERAGE_CORE=sysmon pytest --cov=./ -m "integration" --cov-report=xml:integration.coverage.xml --junitxml=integration.junit.xml -o junit_family=legacy -c pytest.ini --rootdir=${PYTEST_ROOTDIR}
 
 lint:
 	make lint.install
@@ -211,7 +216,7 @@ test_env.container_check_db:
 	while ! nc -vz timescale 5432; do sleep 1; echo "waiting for timescale"; done
 
 test_env.run_unit:
-	docker compose exec api make test.unit
+	docker compose exec api make test.unit PYTEST_ROOTDIR=${PYTEST_ROOTDIR}
 
 test_env.run_integration:
 	# docker compose exec api make test.integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,4 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-shared = { git = "https://github.com/codecov/shared", rev = "87e34049b82aed55d9924af490c9efc27083eed9" }
+shared = { git = "https://github.com/codecov/shared", rev = "af74ab881368fa0e8ea3777404443ac4c525835a" }

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
     { name = "sentry-sdk", extras = ["celery"], specifier = "==2.13.0" },
-    { name = "shared", git = "https://github.com/codecov/shared?rev=87e34049b82aed55d9924af490c9efc27083eed9" },
+    { name = "shared", git = "https://github.com/codecov/shared?rev=af74ab881368fa0e8ea3777404443ac4c525835a" },
     { name = "simplejson", specifier = "==3.17.2" },
     { name = "starlette", specifier = "==0.40.0" },
     { name = "stripe", specifier = ">=11.4.1" },
@@ -1750,7 +1750,7 @@ celery = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = { git = "https://github.com/codecov/shared?rev=87e34049b82aed55d9924af490c9efc27083eed9#87e34049b82aed55d9924af490c9efc27083eed9" }
+source = { git = "https://github.com/codecov/shared?rev=af74ab881368fa0e8ea3777404443ac4c525835a#af74ab881368fa0e8ea3777404443ac4c525835a" }
 dependencies = [
     { name = "amplitude-analytics" },
     { name = "boto3" },


### PR DESCRIPTION
see resulting test file paths here: https://app.codecov.io/gh/codecov/codecov-api/tests/matt%2Fmonorepo-friendly-junit

sort by "Last run" to get the results of the most recent attempt

this is a bit of a hack, but better solutions are all way, way easier after cutover and involve more invasive changes to how things work.

the worker/shared/api PRs pass `--rootdir=${PYTEST_ROOTDIR} -c pytest.ini` to pytest invocations. `--rootdir=${PYTEST_ROOTDIR}` allows us to override the rootdir, and `-c pytest.ini` makes sure pytest can still find its config when we do.

by default, the rootdir is `.`, which is the directory `pytest.ini` lives in. it's as if neither argument were passed at all. the original worker/api/shared repos use the default, so they are unchanged.

[the gha-workflows PR](https://github.com/codecov/gha-workflows/pull/47) adds an optional input to the test workflows which allow `PYTEST_ROOTDIR` to be overridden. umbrella passes in `/app`, and the result is that test file paths inside `junit.xml` will have the prefix umbrella wants (e.g. `apps/worker` for worker).

so, the original repositories generate junit files with test file paths relative to the repo root, just like always. and umbrella will generate junit files with test file paths relative to _umbrella's_ root, which is what umbrella wants.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
