### PR TITLE
feat: Create API for bundle size badges

### DIFF
--- a/graphs/tests/test_badge_handler.py
+++ b/graphs/tests/test_badge_handler.py
@@ -143,7 +143,7 @@ class TestBadgeHandler(APITestCase):
             response.data["detail"] == "File extension should be one of [ svg || txt ]"
         )
 
-    def test_unknown_bagde_incorrect_service(self):
+    def test_unknown_badge_incorrect_service(self):
         response = self._get(
             kwargs={
                 "service": "gih",
@@ -182,7 +182,7 @@ class TestBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
 
-    def test_unknown_bagde_incorrect_owner(self):
+    def test_unknown_badge_incorrect_owner(self):
         response = self._get(
             kwargs={
                 "service": "gh",
@@ -221,7 +221,7 @@ class TestBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
 
-    def test_unknown_bagde_incorrect_repo(self):
+    def test_unknown_badge_incorrect_repo(self):
         gh_owner = OwnerFactory(service="github")
         response = self._get(
             kwargs={
@@ -261,7 +261,7 @@ class TestBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
 
-    def test_unknown_bagde_no_branch(self):
+    def test_unknown_badge_no_branch(self):
         gh_owner = OwnerFactory(service="github")
         RepositoryFactory(author=gh_owner, active=True, private=False, name="repo1")
         response = self._get(
@@ -302,7 +302,7 @@ class TestBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
 
-    def test_unknown_bagde_no_commit(self):
+    def test_unknown_badge_no_commit(self):
         gh_owner = OwnerFactory(service="github")
         repo = RepositoryFactory(
             author=gh_owner, active=True, private=False, name="repo1"
@@ -346,7 +346,7 @@ class TestBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
 
-    def test_unknown_bagde_no_totals(self):
+    def test_unknown_badge_no_totals(self):
         gh_owner = OwnerFactory(service="github")
         repo = RepositoryFactory(
             author=gh_owner, active=True, private=False, name="repo1"

--- a/graphs/tests/test_bundle_badge_handler.py
+++ b/graphs/tests/test_bundle_badge_handler.py
@@ -1,0 +1,467 @@
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+from shared.bundle_analysis import BundleAnalysisReport, BundleReport
+from shared.django_apps.core.tests.factories import (
+    BranchFactory,
+    CommitFactory,
+    OwnerFactory,
+    RepositoryFactory,
+)
+
+
+class MockBundleReport(BundleReport):
+    def __init__(self):
+        return
+
+    def total_size(self):
+        return 1234567
+
+
+class MockBundleAnalysisReport(BundleAnalysisReport):
+    def bundle_report(self, bundle_name: str):
+        if bundle_name == "idk":
+            return None
+        return MockBundleReport()
+
+
+class TestBundleBadgeHandler(APITestCase):
+    def _get(self, kwargs={}, data={}):
+        path = f"/{kwargs.get('service')}/{kwargs.get('owner_username')}/{kwargs.get('repo_name')}/graphs/bundle/{kwargs.get('bundle')}/badge.{kwargs.get('ext')}"
+        return self.client.get(path, data=data)
+
+    def _get_branch(self, kwargs={}, data={}):
+        path = f"/{kwargs.get('service')}/{kwargs.get('owner_username')}/{kwargs.get('repo_name')}/branch/{kwargs.get('branch')}/graphs/{kwargs.get('bundle')}/badge.{kwargs.get('ext')}"
+        return self.client.get(path, data=data)
+
+    def test_invalid_extension(self):
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": "user",
+                "repo_name": "repo",
+                "ext": "png",
+                "bundle": "asdf",
+            }
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert (
+            response.data["detail"] == "File extension should be one of [ svg || txt ]"
+        )
+
+    def test_unknown_badge_incorrect_service(self):
+        response = self._get(
+            kwargs={
+                "service": "gih",
+                "owner_username": "user",
+                "repo_name": "repo",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_unknown_badge_incorrect_owner(self):
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": "user1233",
+                "repo_name": "repo",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_unknown_badge_incorrect_repo(self):
+        gh_owner = OwnerFactory(service="github")
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_unknown_badge_no_branch(self):
+        gh_owner = OwnerFactory(service="github")
+        RepositoryFactory(author=gh_owner, active=True, private=False, name="repo1")
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_unknown_badge_no_commit(self):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=False, name="repo1"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("graphs.views.load_report")
+    def test_unknown_badge_no_report(self, mock_load_report):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=False, name="repo1"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        commit = CommitFactory(
+            repository=repo, commitid=repo.branch.head, branch="main"
+        )
+        branch.head = commit.commitid
+
+        mock_load_report.return_value = None
+
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("graphs.views.load_report")
+    def test_unknown_badge_no_bundle(self, mock_load_report):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=False, name="repo1"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        commit = CommitFactory(
+            repository=repo, commitid=repo.branch.head, branch="main"
+        )
+        branch.head = commit.commitid
+
+        mock_load_report.return_value = MockBundleAnalysisReport()
+
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "svg",
+                "bundle": "idk",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("graphs.views.load_report")
+    def test_bundle_badge(self, mock_load_report):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=False, name="repo1"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        commit = CommitFactory(
+            repository=repo, commitid=repo.branch.head, branch="main"
+        )
+        branch.head = commit.commitid
+
+        mock_load_report.return_value = MockBundleAnalysisReport()
+
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+            <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+                <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+                <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <mask id="CodecovBadgeMask99px">
+                <rect width="99" height="20" rx="3" fill="#fff" />
+            </mask>
+            <g mask="url(#CodecovBadgeMask99px)">
+                <path fill="#555" d="M0 0h47v20H0z" />
+                <path fill="#2C2433" d="M47 0h52v20H47z" />
+                <path fill="url(#CodecovBadgeGradient)" d="M0 0h99v20H0z" />
+            </g>
+            <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+                <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+                <text x="5" y="14">bundle</text>
+                <text x="52" y="15" fill="#010101" fill-opacity=".3">1.23MB</text>
+                <text x="52" y="14">1.23MB</text>
+            </g>
+        </svg>
+"""
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("graphs.views.load_report")
+    def test_bundle_badge_text(self, mock_load_report):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=False, name="repo1"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        commit = CommitFactory(
+            repository=repo, commitid=repo.branch.head, branch="main"
+        )
+        branch.head = commit.commitid
+
+        mock_load_report.return_value = MockBundleAnalysisReport()
+
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "txt",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = "1.23MB"
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("graphs.views.load_report")
+    def test_bundle_badge_unsupported_precision_defaults_to_2(self, mock_load_report):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=False, name="repo1"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        commit = CommitFactory(
+            repository=repo, commitid=repo.branch.head, branch="main"
+        )
+        branch.head = commit.commitid
+
+        mock_load_report.return_value = MockBundleAnalysisReport()
+
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "txt",
+                "bundle": "asdf",
+            },
+            data={"precision": "asdf"},
+        )
+        expected_badge = "1.23MB"
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK

--- a/graphs/tests/test_bundle_badge_handler.py
+++ b/graphs/tests/test_bundle_badge_handler.py
@@ -162,6 +162,47 @@ class TestBundleBadgeHandler(APITestCase):
         assert expected_badge == badge
         assert response.status_code == status.HTTP_200_OK
 
+    def test_unknown_badge_private_repo_wrong_token(self):
+        gh_owner = OwnerFactory(service="github")
+        RepositoryFactory(
+            author=gh_owner, active=True, private=True, name="repo1", image_token="asdf"
+        )
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "svg",
+                "bundle": "asdf",
+            }
+        )
+        expected_badge = """<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20">
+    <linearGradient id="CodecovBadgeGradient" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="CodecovBadgeMask106px">
+        <rect width="106" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#CodecovBadgeMask106px)">
+        <path fill="#555" d="M0 0h47v20H0z" />
+        <path fill="#2C2433" d="M47 0h59v20H47z" />
+        <path fill="url(#CodecovBadgeGradient)" d="M0 0h106v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="5" y="15" fill="#010101" fill-opacity=".3">bundle</text>
+        <text x="5" y="14">bundle</text>
+        <text x="52" y="15" fill="#010101" fill-opacity=".3">unknown</text>
+        <text x="52" y="14">unknown</text>
+    </g>
+</svg>
+"""
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+        assert response.status_code == status.HTTP_200_OK
+
     def test_unknown_badge_no_branch(self):
         gh_owner = OwnerFactory(service="github")
         RepositoryFactory(author=gh_owner, active=True, private=False, name="repo1")
@@ -457,6 +498,38 @@ class TestBundleBadgeHandler(APITestCase):
                 "bundle": "asdf",
             },
             data={"precision": "asdf"},
+        )
+        expected_badge = "1.23MB"
+
+        badge = response.content.decode("utf-8")
+        badge = [line.strip() for line in badge.split("\n")]
+        expected_badge = [line.strip() for line in expected_badge.split("\n")]
+        assert expected_badge == badge
+
+    @patch("graphs.views.load_report")
+    def test_bundle_badge_private_repo_correct_token(self, mock_load_report):
+        gh_owner = OwnerFactory(service="github")
+        repo = RepositoryFactory(
+            author=gh_owner, active=True, private=True, name="repo1", image_token="asdf"
+        )
+        branch = BranchFactory(name="main", repository=repo)
+        repo.branch = branch
+        commit = CommitFactory(
+            repository=repo, commitid=repo.branch.head, branch="main"
+        )
+        branch.head = commit.commitid
+
+        mock_load_report.return_value = MockBundleAnalysisReport()
+
+        response = self._get(
+            kwargs={
+                "service": "gh",
+                "owner_username": gh_owner.username,
+                "repo_name": "repo1",
+                "ext": "txt",
+                "bundle": "asdf",
+            },
+            data={"token": "asdf"},
         )
         expected_badge = "1.23MB"
 

--- a/graphs/urls.py
+++ b/graphs/urls.py
@@ -14,12 +14,12 @@ urlpatterns = [
         name="default-badge",
     ),
     re_path(
-        "branch/(?P<branch>.+)/(graph|graphs)/bundle/badge.(?P<ext>[^/]+)",
+        "branch/(?P<branch>.+)/(graph|graphs)/bundle/(?P<bundle>.+)/badge.(?P<ext>[^/]+)",
         BundleBadgeHandler.as_view(),
         name="branch-bundle-badge",
     ),
     re_path(
-        "(graph|graphs)/bundle/badge.(?P<ext>[^/]+)",
+        "(graph|graphs)/bundle/(?P<bundle>.+)/badge.(?P<ext>[^/]+)",
         BundleBadgeHandler.as_view(),
         name="default-bundle-badge",
     ),

--- a/graphs/urls.py
+++ b/graphs/urls.py
@@ -14,6 +14,16 @@ urlpatterns = [
         name="default-badge",
     ),
     re_path(
+        "branch/(?P<branch>.+)/(graph|graphs)/bundle/badge.(?P<ext>[^/]+)",
+        BadgeHandler.as_view(),
+        "branch-bundle-badge",
+    ),
+    re_path(
+        "(graph|graphs)/bundle/badge.(?P<ext>[^/]+)",
+        BadgeHandler.as_view(),
+        "default-bundle-badge",
+    ),
+    re_path(
         "pull/(?P<pullid>[^/]+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).(?P<ext>[^/]+)",
         GraphHandler.as_view(),
         name="pull-graph",

--- a/graphs/urls.py
+++ b/graphs/urls.py
@@ -1,6 +1,6 @@
 from django.urls import re_path
 
-from .views import BadgeHandler, GraphHandler
+from .views import BadgeHandler, BundleBadgeHandler, GraphHandler
 
 urlpatterns = [
     re_path(
@@ -15,13 +15,13 @@ urlpatterns = [
     ),
     re_path(
         "branch/(?P<branch>.+)/(graph|graphs)/bundle/badge.(?P<ext>[^/]+)",
-        BadgeHandler.as_view(),
-        "branch-bundle-badge",
+        BundleBadgeHandler.as_view(),
+        name="branch-bundle-badge",
     ),
     re_path(
         "(graph|graphs)/bundle/badge.(?P<ext>[^/]+)",
-        BadgeHandler.as_view(),
-        "default-bundle-badge",
+        BundleBadgeHandler.as_view(),
+        name="default-bundle-badge",
     ),
     re_path(
         "pull/(?P<pullid>[^/]+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).(?P<ext>[^/]+)",

--- a/graphs/views.py
+++ b/graphs/views.py
@@ -13,9 +13,8 @@ from shared.metrics import Counter, inc_counter
 
 from api.shared.mixins import RepoPropertyMixin
 from core.models import Branch, Pull
-from graphql_api.dataloader.bundle_analysis import load_bundle_analysis_report
 from graphs.settings import settings
-from services.bundle_analysis import BundleAnalysisReport
+from services.bundle_analysis import BundleAnalysisReport, load_report
 from services.components import commit_components
 
 from .helpers.badge import (
@@ -254,14 +253,16 @@ class BundleBadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
             log.warning("Commit not found", extra=dict(commit=branch.head))
             return None
 
-        bundle_report = load_bundle_analysis_report(commit)
+        shared_bundle_report = load_report(commit)
 
-        if not isinstance(bundle_report, BundleAnalysisReport):
+        if shared_bundle_report is None:
             log.warning(
                 "Bundle analysis report not found for commit",
                 extra=dict(commit=branch.head),
             )
             return None
+
+        bundle_report = BundleAnalysisReport(shared_bundle_report)
 
         return bundle_report.size_total
 

--- a/graphs/views.py
+++ b/graphs/views.py
@@ -211,9 +211,7 @@ class BundleBadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
     def get_object(self, request, *args, **kwargs):
         # Validate precision query param
         precision = self.request.query_params.get("precision", "2")
-        if precision not in self.precisions:
-            raise NotFound("Bundle size precision should be one of [ 0 || 1 || 2 ]")
-        precision = int(precision)
+        precision = int(precision) if precision in self.precisions else 2
 
         bundle_size_bytes = self.get_bundle_size()
 
@@ -251,9 +249,8 @@ class BundleBadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
             )
             return None
 
-        try:
-            commit: Commit = repo.commits.filter(commitid=branch.head).first()
-        except ObjectDoesNotExist:
+        commit: Commit = repo.commits.filter(commitid=branch.head).first()
+        if commit is None:
             log.warning("Commit not found", extra=dict(commit=branch.head))
             return None
 


### PR DESCRIPTION
Adds new graph endpoints for getting new bundle analysis badges.

- Bundle name is required in the url
- Branch name is optional param
- Precision is optional param (one of 0, 1, 2(default))

Example:
[![codecov](https://stage-api.codecov.dev/gh/codecov/gazebo/main/graph/bundle/gazebo-staging-system/badge.svg)](https://stage-web.codecov.dev/gh/codecov/gazebo/bundles/main/gazebo-staging-system)
[![codecov](https://stage-api.codecov.dev/gh/codecov/gazebo/main/graph/bundle/gazebo-staging-system/badge.svg?precision=1)](https://stage-web.codecov.dev/gh/codecov/gazebo/bundles/main/gazebo-staging-system)
[![codecov](https://stage-api.codecov.dev/gh/codecov/gazebo/main/graph/bundle/gazebo-staging-system/badge.svg?precision=0)](https://stage-web.codecov.dev/gh/codecov/gazebo/bundles/main/gazebo-staging-system)
`https://stage-api.codecov.dev/gh/codecov/gazebo/main/graph/bundle/gazebo-staging-system/badge.svg?precision=2`

Closes https://github.com/codecov/engineering-team/issues/3488