### PR TITLE
Emit owner/repo/commit tags for GraphQL queries

### DIFF
--- a/core/commands/repository/interactors/fetch_repository.py
+++ b/core/commands/repository/interactors/fetch_repository.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from asgiref.sync import sync_to_async
 from shared.django_apps.codecov_auth.models import Owner
 from shared.django_apps.core.models import Repository
@@ -7,23 +8,32 @@ from codecov.commands.base import BaseInteractor
 
 class FetchRepositoryInteractor(BaseInteractor):
     @sync_to_async
+    @sentry_sdk.trace
     def execute(
         self,
         owner: Owner,
         name: str,
         okta_authenticated_accounts: list[int],
         exclude_okta_enforced_repos: bool = True,
-    ):
+    ) -> Repository | None:
         queryset = Repository.objects.viewable_repos(self.current_owner)
         if exclude_okta_enforced_repos:
             queryset = queryset.exclude_accounts_enforced_okta(
                 okta_authenticated_accounts
             )
 
-        return (
+        # TODO(swatinem): We should find a way to avoid these combinators:
+        # The `with_recent_coverage` combinator is quite expensive.
+        # We only need that in case we want to query these props via graphql:
+        # `coverageAnalytics.{percentCovered,commitSha,hits,misses,lines}`
+        # Similarly, `with_oldest_commit_at` is only needed for `oldestCommitAt`.
+
+        repo = (
             queryset.filter(author=owner, name=name)
             .with_recent_coverage()
             .with_oldest_commit_at()
             .select_related("author")
             .first()
         )
+
+        return repo

--- a/core/commands/repository/repository.py
+++ b/core/commands/repository/repository.py
@@ -27,7 +27,7 @@ class RepositoryCommands(BaseCommand):
         name: str,
         okta_authenticated_accounts: list[int],
         exclude_okta_enforced_repos: bool = True,
-    ) -> Repository:
+    ) -> Repository | None:
         return self.get_interactor(FetchRepositoryInteractor).execute(
             owner,
             name,

--- a/graphql_api/types/coverage_analytics/coverage_analytics.py
+++ b/graphql_api/types/coverage_analytics/coverage_analytics.py
@@ -54,7 +54,6 @@ def resolve_coverage_analytics_result_type(
 
 
 @coverage_analytics_bindable.field("percentCovered")
-@sentry_sdk.trace
 def resolve_percent_covered(
     parent: CoverageAnalyticsProps, info: GraphQLResolveInfo
 ) -> Optional[float]:


### PR DESCRIPTION
This primarily adds Sentry tags to GraphQL endpoints that resolve any kind of field on `Repository.commit`, etc. This should make it a lot easier to search for traces related to a specific repo or commit.