### PR TITLE
Bundle Analysis: Add metric label for upload result

### DIFF
--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -104,6 +104,7 @@ def test_upload_bundle_analysis_success(db, client, mocker, mock_redis):
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -207,6 +208,7 @@ def test_upload_bundle_analysis_success_shelter(db, client, mocker, mock_redis):
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -245,6 +247,7 @@ def test_upload_bundle_analysis_org_token(db, client, mocker, mock_redis):
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -292,6 +295,7 @@ def test_upload_bundle_analysis_existing_commit(db, client, mocker, mock_redis):
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -340,7 +344,8 @@ def test_upload_bundle_analysis_missing_args(db, client, mocker, mock_redis):
             "action": "bundle_analysis",
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
-            "position": "start",
+            "position": "end",
+            "result": "bad_request",
         },
     )
 
@@ -412,6 +417,7 @@ def test_upload_bundle_analysis_github_oidc_auth(
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -472,6 +478,7 @@ def test_upload_bundle_analysis_measurement_datasets_created(
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -533,6 +540,7 @@ def test_upload_bundle_analysis_measurement_timeseries_disabled(
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 
@@ -574,7 +582,8 @@ def test_upload_bundle_analysis_no_repo(db, client, mocker, mock_redis):
             "action": "bundle_analysis",
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
-            "position": "start",
+            "position": "end",
+            "result": "error",
         },
     )
 
@@ -629,6 +638,7 @@ def test_upload_bundle_analysis_tokenless_success(db, client, mocker, mock_redis
             "endpoint": "bundle_analysis",
             "is_using_shelter": "no",
             "position": "end",
+            "result": "success",
         },
     )
 

--- a/upload/tests/views/test_bundle_analysis.py
+++ b/upload/tests/views/test_bundle_analysis.py
@@ -822,30 +822,29 @@ def test_upload_bundle_analysis_tokenless_mismatched_branch(
     assert not upload.called
 
 
-def test_bundle_analysis_view_exception_handling(db, client, mocker, mock_redis):
-    with patch(
-        "upload.views.bundle_analysis.BundleAnalysisView._handle_upload",
-        side_effect=Exception("Test Exception"),
-    ):
-        client = APIClient()
-        repository = RepositoryFactory.create()
-        client.credentials(HTTP_AUTHORIZATION=f"token {repository.upload_token}")
+def test_upload_bundle_analysis_view_exception_handling(db, client, mocker, mock_redis):
+    try:
+        with patch(
+            "upload.views.bundle_analysis.BundleAnalysisView._handle_upload",
+            side_effect=Exception("Test Exception"),
+        ):
+            client = APIClient()
+            repository = RepositoryFactory.create()
+            client.credentials(HTTP_AUTHORIZATION=f"token {repository.upload_token}")
 
-        mock_inc_counter = mocker.patch("upload.views.bundle_analysis.inc_counter")
+            mock_inc_counter = mocker.patch("upload.views.bundle_analysis.inc_counter")
 
-        res = client.post(
-            reverse("upload-bundle-analysis"),
-            {
-                "commit": "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef",
-                "slug": f"{repository.author.username}::::{repository.name}",
-            },
-            format="json",
-        )
-
-        assert res.status_code == 201
-        assert res.json()["url"] is None
-
-        # Check that the labels["result"] is "error"
+            client.post(
+                reverse("upload-bundle-analysis"),
+                {
+                    "commit": "6fd5b89357fc8cdf34d6197549ac7c6d7e5977ef",
+                    "slug": f"{repository.author.username}::::{repository.name}",
+                },
+                format="json",
+            )
+    except Exception as e:
+        # Check that the Test Exception was raised and the inc_counter went up
+        assert str(e) == "Test Exception"
         mock_inc_counter.assert_any_call(
             ANY,
             labels=mocker.ANY,

--- a/upload/views/bundle_analysis.py
+++ b/upload/views/bundle_analysis.py
@@ -48,6 +48,7 @@ BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER = Counter(
         "endpoint",
         "is_using_shelter",
         "position",
+        "result",
     ],
 )
 
@@ -85,20 +86,7 @@ class BundleAnalysisView(APIView, ShelterMixin):
     def get_exception_handler(self) -> Callable:
         return repo_auth_custom_exception_handler
 
-    def post(self, request: HttpRequest) -> Response:
-        labels = generate_upload_prometheus_metrics_labels(
-            action="bundle_analysis",
-            endpoint="bundle_analysis",
-            request=self.request,
-            is_shelter_request=self.is_shelter_request(),
-            position="start",
-            include_empty_labels=False,
-        )
-        inc_counter(
-            BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER,
-            labels=labels,
-        )
-
+    def _handle_upload(self, request: HttpRequest) -> str | None:
         serializer = UploadSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -191,18 +179,6 @@ class BundleAnalysisView(APIView, ShelterMixin):
                 task_arguments=task_arguments,
             ),
         )
-        labels = generate_upload_prometheus_metrics_labels(
-            action="bundle_analysis",
-            endpoint="bundle_analysis",
-            request=self.request,
-            is_shelter_request=self.is_shelter_request(),
-            position="end",
-            include_empty_labels=False,
-        )
-        inc_counter(
-            BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER,
-            labels=labels,
-        )
 
         dispatch_upload_task(
             task_arguments,
@@ -235,4 +211,41 @@ class BundleAnalysisView(APIView, ShelterMixin):
                         ),
                     )
 
+        return url
+
+    def post(self, request: HttpRequest) -> Response:
+        labels = generate_upload_prometheus_metrics_labels(
+            action="bundle_analysis",
+            endpoint="bundle_analysis",
+            request=self.request,
+            is_shelter_request=self.is_shelter_request(),
+            position="start",
+            include_empty_labels=False,
+        )
+        labels["result"] = "pending"
+        url = None
+        inc_counter(
+            BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER,
+            labels=labels,
+        )
+
+        upload_result = "success"
+        try:
+            url = self._handle_upload(request)
+        except Exception as e:
+            log.error(
+                "Error handling bundle analysis upload",
+                extra=dict(
+                    error=e,
+                ),
+                exc_info=True,
+            )
+            upload_result = "error"
+
+        labels["position"] = "end"
+        labels["result"] = upload_result
+        inc_counter(
+            BUNDLE_ANALYSIS_UPLOAD_VIEWS_COUNTER,
+            labels=labels,
+        )
         return Response({"url": url}, status=201)


### PR DESCRIPTION
Will use the "result" label in Grafana to look at error rates. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
