### PR TITLE
fix: Fix query for is_first_pull_request

### DIFF
--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -513,6 +513,11 @@ class TestFetchRepository(GraphQLTestHelper, TestCase):
 
         assert data["me"]["owner"]["repository"]["isFirstPullRequest"] == True
 
+        assert (
+            repo.pull_requests.values("id")[:2].query
+            == 'SELECT "pull_requests"."id" FROM "pull_requests" WHERE "pull_requests"."repoid" = 1 ORDER BY "pull_requests"."pullid" DESC LIMIT 2'
+        )
+
     def test_repository_is_first_pull_request_compared_to_not_none(self) -> None:
         repo = RepositoryFactory(
             author=self.owner,

--- a/graphql_api/tests/test_repository.py
+++ b/graphql_api/tests/test_repository.py
@@ -513,11 +513,6 @@ class TestFetchRepository(GraphQLTestHelper, TestCase):
 
         assert data["me"]["owner"]["repository"]["isFirstPullRequest"] == True
 
-        assert (
-            repo.pull_requests.values("id")[:2].query
-            == 'SELECT "pull_requests"."id" FROM "pull_requests" WHERE "pull_requests"."repoid" = 1 ORDER BY "pull_requests"."pullid" DESC LIMIT 2'
-        )
-
     def test_repository_is_first_pull_request_compared_to_not_none(self) -> None:
         repo = RepositoryFactory(
             author=self.owner,

--- a/graphql_api/types/repository/repository.py
+++ b/graphql_api/types/repository/repository.py
@@ -265,19 +265,12 @@ def resolve_repository_result_type(obj: Any, *_: Any) -> Optional[str]:
 def resolve_is_first_pull_request(
     repository: Repository, info: GraphQLResolveInfo
 ) -> bool:
-    try:
-        # Get at most 2 PRs to determine if there's only one
-        pull_requests = repository.pull_requests.values("id", "compared_to")[:2]
-        if len(pull_requests) != 1:
-            return False
-        # For single PR, check if it's a valid first PR by verifying no compared_to
-        return pull_requests[0]["compared_to"] is None
-    except Exception as e:
-        log.error(
-            "Error checking is_first_pull_request, assuming False",
-            extra=dict(repo_id=repository.repoid, error=str(e)),
-        )
+    # Get at most 2 PRs to determine if there's only one
+    pull_requests = repository.pull_requests.values("id", "compared_to")[:2]
+    if len(pull_requests) != 1:
         return False
+    # For single PR, check if it's a valid first PR by verifying no compared_to
+    return pull_requests[0]["compared_to"] is None
 
 
 @repository_bindable.field("isGithubRateLimited")


### PR DESCRIPTION
We have a graphQL field `isFirstPullRequest` on the Repository object that does an expensive query `count` on pulls table. This is used to evaluate things like
* whether to show a special [banner](https://github.com/codecov/gazebo/blob/819dcd98834f0322caa3bb6a86581bda1d7ebf34/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx#L84C7-L86C16) on Coverage Overview Page
* whether to show a "No data yet" empty state for Test Analytics [page](https://github.com/codecov/gazebo/blob/819dcd98834f0322caa3bb6a86581bda1d7ebf34/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx#L300C2-L316C4)

Update to use a less expensive query (nice idea from @michelletran-codecov )

Closes https://github.com/codecov/engineering-team/issues/3514