### PR TITLE
feat: add ability to read new file format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - RUN_ENV=DEV
       # Improves pytest-cov performance in python 3.12
       # https://github.com/nedbat/coveragepy/issues/1665#issuecomment-1937075835
-      - COVERAGE_CORE=sysmon 
+      - COVERAGE_CORE=sysmon
     env_file:
       - .testenv
 
@@ -42,3 +42,16 @@ services:
   redis:
     image: redis:6-alpine
 
+  minio:
+    image: minio/minio:latest
+    command: server /export
+    ports:
+      - "${MINIO_PORT:-9000}:9000"
+    environment:
+      - MINIO_ACCESS_KEY=codecov-default-key
+      - MINIO_SECRET_KEY=codecov-default-secret
+    volumes:
+      - type: tmpfs
+        target: /export
+        tmpfs:
+          size: 256M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,6 @@ services:
   minio:
     image: minio/minio:latest
     command: server /export
-    ports:
-      - "${MINIO_PORT:-9000}:9000"
     environment:
       - MINIO_ACCESS_KEY=codecov-default-key
       - MINIO_SECRET_KEY=codecov-default-secret

--- a/docker/test.yml
+++ b/docker/test.yml
@@ -23,6 +23,7 @@ services:
     access_key_id: codecov-default-key
     secret_access_key: codecov-default-secret
     verify_ssl: false
+    bucket: archive
     port: 9000
     host: minio
 

--- a/docker/test.yml
+++ b/docker/test.yml
@@ -23,6 +23,8 @@ services:
     access_key_id: codecov-default-key
     secret_access_key: codecov-default-secret
     verify_ssl: false
+    port: 9000
+    host: minio
 
 github:
   bot:

--- a/graphql_api/tests/snapshots/analytics__TestAnalyticsTestCase__gql_query_with_new_ta__0.json
+++ b/graphql_api/tests/snapshots/analytics__TestAnalyticsTestCase__gql_query_with_new_ta__0.json
@@ -1,0 +1,77 @@
+[
+  {
+    "cursor": "MC44fHRlc3Q0",
+    "node": {
+      "name": "test4",
+      "failureRate": 0.8,
+      "flakeRate": 0.0,
+      "avgDuration": 100.0,
+      "totalFailCount": 20,
+      "totalFlakyFailCount": 0,
+      "totalPassCount": 5,
+      "totalSkipCount": 5,
+      "commitsFailed": 5,
+      "lastDuration": 100.0
+    }
+  },
+  {
+    "cursor": "MC43NXx0ZXN0Mw==",
+    "node": {
+      "name": "test3",
+      "failureRate": 0.75,
+      "flakeRate": 0.0,
+      "avgDuration": 100.0,
+      "totalFailCount": 15,
+      "totalFlakyFailCount": 0,
+      "totalPassCount": 5,
+      "totalSkipCount": 5,
+      "commitsFailed": 5,
+      "lastDuration": 100.0
+    }
+  },
+  {
+    "cursor": "MC42NjY2NjY2NjY2NjY2NjY2fHRlc3Qy",
+    "node": {
+      "name": "test2",
+      "failureRate": 0.6666666666666666,
+      "flakeRate": 0.0,
+      "avgDuration": 100.0,
+      "totalFailCount": 10,
+      "totalFlakyFailCount": 0,
+      "totalPassCount": 5,
+      "totalSkipCount": 5,
+      "commitsFailed": 5,
+      "lastDuration": 100.0
+    }
+  },
+  {
+    "cursor": "MC41fHRlc3Qx",
+    "node": {
+      "name": "test1",
+      "failureRate": 0.5,
+      "flakeRate": 0.5,
+      "avgDuration": 100.0,
+      "totalFailCount": 5,
+      "totalFlakyFailCount": 5,
+      "totalPassCount": 5,
+      "totalSkipCount": 5,
+      "commitsFailed": 5,
+      "lastDuration": 100.0
+    }
+  },
+  {
+    "cursor": "MC4wfHRlc3Qw",
+    "node": {
+      "name": "test0",
+      "failureRate": 0.0,
+      "flakeRate": 0.0,
+      "avgDuration": 100.0,
+      "totalFailCount": 0,
+      "totalFlakyFailCount": 0,
+      "totalPassCount": 5,
+      "totalSkipCount": 5,
+      "commitsFailed": 5,
+      "lastDuration": 100.0
+    }
+  }
+]

--- a/graphql_api/types/test_analytics/test_analytics.py
+++ b/graphql_api/types/test_analytics/test_analytics.py
@@ -34,22 +34,37 @@ INTERVAL_7_DAY = 7
 INTERVAL_1_DAY = 1
 
 
-@dataclass
 class TestResultsRow:
     # the order here must match the order of the fields in the query
-    name: str
-    testsuite: str | None
-    flags: list[str]
-    failure_rate: float
-    flake_rate: float
-    updated_at: dt.datetime
-    avg_duration: float
-    total_fail_count: int
-    total_flaky_fail_count: int
-    total_pass_count: int
-    total_skip_count: int
-    commits_where_fail: int
-    last_duration: float
+    def __init__(
+        self,
+        name: str,
+        failure_rate: float,
+        flake_rate: float,
+        updated_at: dt.datetime,
+        avg_duration: float,
+        total_fail_count: int,
+        total_flaky_fail_count: int,
+        total_pass_count: int,
+        total_skip_count: int,
+        commits_where_fail: int,
+        last_duration: float,
+        testsuite: str | None = None,
+        flags: list[str] | None = None,
+    ):
+        self.name = name
+        self.testsuite = testsuite
+        self.flags = flags or []
+        self.failure_rate = failure_rate
+        self.flake_rate = flake_rate
+        self.updated_at = updated_at
+        self.avg_duration = avg_duration
+        self.total_fail_count = total_fail_count
+        self.total_flaky_fail_count = total_flaky_fail_count
+        self.total_pass_count = total_pass_count
+        self.total_skip_count = total_skip_count
+        self.commits_where_fail = commits_where_fail
+        self.last_duration = last_duration
 
     def to_dict(self) -> dict:
         return {

--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -11,3 +11,5 @@ __all__ = ["Feature"]
 
 # By default, features have one variant:
 #    { "enabled": FeatureVariant(True, 1.0) }
+
+READ_NEW_TA = Feature("read_new_ta")

--- a/utils/test_results.py
+++ b/utils/test_results.py
@@ -1,10 +1,19 @@
+import tempfile
+from datetime import date, timedelta
+
 import polars as pl
 from django.conf import settings
 from shared.helpers.redis import get_redis_connection
+from shared.metrics import Summary
 from shared.storage import get_appropriate_storage_service
 from shared.storage.exceptions import FileNotInStorageError
 
+from rollouts import READ_NEW_TA
 from services.task import TaskService
+
+get_results_summary = Summary(
+    "test_results_get_results", "Time it takes to download results from GCS", ["impl"]
+)
 
 
 def redis_key(
@@ -61,7 +70,9 @@ def dedup_table(table: pl.DataFrame) -> pl.DataFrame:
             pl.col("total_flaky_fail_count").sum().alias("total_flaky_fail_count"),
             pl.col("total_pass_count").sum().alias("total_pass_count"),
             pl.col("total_skip_count").sum().alias("total_skip_count"),
-            pl.col("commits_where_fail").sum().alias("commits_where_fail"),
+            pl.col("commits_where_fail")
+            .sum()
+            .alias("commits_where_fail"),  # TODO: this is wrong
             pl.col("last_duration").max().alias("last_duration"),
         )
         .sort("name")
@@ -87,6 +98,23 @@ def get_results(
     deserialize
     """
     # try redis
+    if READ_NEW_TA.check_value(repoid):
+        func = new_get_results
+        label = "new"
+    else:
+        func = old_get_results
+        label = "old"
+
+    with get_results_summary.labels(label).time():
+        return func(repoid, branch, interval_start, interval_end)
+
+
+def old_get_results(
+    repoid: int,
+    branch: str,
+    interval_start: int,
+    interval_end: int | None = None,
+) -> pl.DataFrame | None:
     redis_conn = get_redis_connection()
     key = redis_key(repoid, branch, interval_start, interval_end)
     result: bytes | None = redis_conn.get(key)
@@ -114,3 +142,121 @@ def get_results(
     table = dedup_table(table)
 
     return table
+
+
+def rollup_blob_path(repoid: int, branch: str | None = None) -> str:
+    return (
+        f"test_analytics/branch_rollups/{repoid}/{branch}.arrow"
+        if branch
+        else f"test_analytics/repo_rollups/{repoid}.arrow"
+    )
+
+
+def no_version_agg_table(table: pl.LazyFrame) -> pl.LazyFrame:
+    failure_rate_expr = (pl.col("fail_count")).sum() / (
+        pl.col("fail_count") + pl.col("pass_count")
+    ).sum()
+
+    flake_rate_expr = (pl.col("flaky_fail_count")).sum() / (
+        pl.col("fail_count") + pl.col("pass_count")
+    ).sum()
+
+    avg_duration_expr = (
+        pl.col("avg_duration") * (pl.col("pass_count") + pl.col("fail_count"))
+    ).sum() / (pl.col("pass_count") + pl.col("fail_count")).sum()
+
+    table = table.group_by(pl.col("computed_name").alias("name")).agg(
+        pl.col("flags")
+        .explode()
+        .unique()
+        .alias("flags"),  # TODO: filter by this before we aggregate
+        pl.col("failing_commits").sum().alias("commits_where_fail"),
+        pl.col("last_duration").max().alias("last_duration"),
+        failure_rate_expr.alias("failure_rate"),
+        flake_rate_expr.alias("flake_rate"),
+        avg_duration_expr.alias("avg_duration"),
+        pl.col("pass_count").sum().alias("total_pass_count"),
+        pl.col("fail_count").sum().alias("total_fail_count"),
+        pl.col("flaky_fail_count").sum().alias("total_flaky_fail_count"),
+        pl.col("skip_count").sum().alias("total_skip_count"),
+        pl.col("updated_at").max().alias("updated_at"),
+    )
+
+    return table
+
+
+def v1_agg_table(table: pl.LazyFrame) -> pl.LazyFrame:
+    failure_rate_expr = (pl.col("fail_count")).sum() / (
+        pl.col("fail_count") + pl.col("pass_count")
+    ).sum()
+
+    flake_rate_expr = (pl.col("flaky_fail_count")).sum() / (
+        pl.col("fail_count") + pl.col("pass_count")
+    ).sum()
+
+    avg_duration_expr = (
+        pl.col("avg_duration") * (pl.col("pass_count") + pl.col("fail_count"))
+    ).sum() / (pl.col("pass_count") + pl.col("fail_count")).sum()
+
+    table = table.group_by("computed_name").agg(
+        pl.col("testsuite").alias(
+            "testsuite"
+        ),  # TODO: filter by this before we aggregate
+        pl.col("flags")
+        .explode()
+        .unique()
+        .alias("flags"),  # TODO: filter by this before we aggregate
+        pl.col("failing_commits").sum().alias("commits_where_fail"),
+        pl.col("last_duration").max().alias("last_duration"),
+        failure_rate_expr.alias("failure_rate"),
+        flake_rate_expr.alias("flake_rate"),
+        avg_duration_expr.alias("avg_duration"),
+        pl.col("pass_count").sum().alias("total_pass_count"),
+        pl.col("fail_count").sum().alias("total_fail_count"),
+        pl.col("flaky_fail_count").sum().alias("total_flaky_fail_count"),
+        pl.col("skip_count").sum().alias("total_skip_count"),
+        pl.col("updated_at").max().alias("updated_at"),
+    )
+
+    return table
+
+
+def new_get_results(
+    repoid: int,
+    branch: str | None,
+    interval_start: int,
+    interval_end: int | None = None,
+) -> pl.DataFrame | None:
+    storage_service = get_appropriate_storage_service(repoid)
+    key = rollup_blob_path(repoid, branch)
+    try:
+        with tempfile.TemporaryFile() as tmp:
+            metadata = {}
+            storage_service.read_file(
+                bucket_name=settings.GCS_BUCKET_NAME,
+                path=key,
+                file_obj=tmp,
+                metadata_container=metadata,
+            )
+
+            table = pl.scan_ipc(tmp)
+
+            # filter start
+            start_date = date.today() - timedelta(days=interval_start)
+            table = table.filter(pl.col("timestamp_bin") >= start_date)
+
+            # filter end
+            if interval_end is not None:
+                end_date = date.today() - timedelta(days=interval_end)
+                table = table.filter(pl.col("timestamp_bin") <= end_date)
+
+            # aggregate
+            match metadata.get("version"):
+                case "1":
+                    table = v1_agg_table(table)
+                case _:  # no version is missding
+                    table = no_version_agg_table(table)
+
+            return table.collect()
+    except FileNotInStorageError:
+        return None


### PR DESCRIPTION
i'm introducing 2 things here:
- the ability to read the output of the new ta cache rollups code in
  the new location in GCS
- the ability to read multiple versions of the new rollup file
    - its probable that the "no version" file never exists in prod GCS
      but i'd like to establish this pattern in the code nonetheless

i also add metrics
