### PR TITLE
Move trace annotation to correct fn

### DIFF
--- a/graphql_api/actions/repository.py
+++ b/graphql_api/actions/repository.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-import sentry_sdk
 from django.db.models import QuerySet
 from shared.django_apps.codecov_auth.models import GithubAppInstallation, Owner
 from shared.django_apps.core.models import Repository
@@ -54,7 +53,6 @@ def filter_queryset_by_ai_enabled_repos(queryset: QuerySet, owner: Owner) -> Que
     return queryset
 
 
-@sentry_sdk.trace
 def list_repository_for_owner(
     current_owner: Owner,
     owner: Owner,
@@ -72,16 +70,13 @@ def list_repository_for_owner(
     if exclude_okta_enforced_repos:
         queryset = queryset.exclude_accounts_enforced_okta(okta_account_auths)
 
-    if not ai_enabled_filter:
-        queryset = (
-            queryset.with_recent_coverage().with_latest_commit_at().filter(author=owner)
-        )
-
+    queryset = (
+        queryset.with_recent_coverage().with_latest_commit_at().filter(author=owner)
+    )
     queryset = apply_filters_to_queryset(queryset, filters, owner)
     return queryset
 
 
-@sentry_sdk.trace
 def search_repos(
     current_owner: Owner,
     filters: dict[str, Any] | None,

--- a/graphql_api/types/me/me.py
+++ b/graphql_api/types/me/me.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import sentry_sdk
 from ariadne import ObjectType
 from asgiref.sync import sync_to_async
 from graphql import GraphQLResolveInfo
@@ -41,6 +42,7 @@ def resolve_owner(user, _):
 
 
 @me_bindable.field("viewableRepositories")
+@sentry_sdk.trace
 def resolve_viewable_repositories(
     current_user,
     info: GraphQLResolveInfo,

--- a/graphql_api/types/owner/owner.py
+++ b/graphql_api/types/owner/owner.py
@@ -56,6 +56,7 @@ AI_FEATURES_GH_APP_ID = get_config("github", "ai_features_app_id")
 
 @owner_bindable.field("repositories")
 @sync_to_async
+@sentry_sdk.trace
 def resolve_repositories(
     owner: Owner,
     info: GraphQLResolveInfo,


### PR DESCRIPTION
By looking at some random traces, I found that the functions being traced were only *creating* querysets, but they were not the functions that actually *evaluated* those querysets.