### PR TITLE
Correct kwarg for `get_github_integration_token`

### DIFF
--- a/upload/helpers.py
+++ b/upload/helpers.py
@@ -387,7 +387,7 @@ def try_to_get_best_possible_bot_token(
         try:
             github_token = get_github_integration_token(
                 repository.author.service,
-                installation_id=ghapp_installation_id,
+                integration_id=ghapp_installation_id,
             )
             return dict(key=github_token)
         except InvalidInstallationError:

--- a/upload/tests/test_helpers.py
+++ b/upload/tests/test_helpers.py
@@ -99,9 +99,7 @@ def test_try_to_get_best_possible_bot_token_using_integration(
     assert try_to_get_best_possible_bot_token(repository) == {
         "key": "test-token",
     }
-    get_github_integration_token.assert_called_once_with(
-        "github", installation_id=12345
-    )
+    get_github_integration_token.assert_called_once_with("github", integration_id=12345)
 
 
 @patch("upload.helpers.get_github_integration_token")
@@ -125,9 +123,7 @@ def test_try_to_get_best_possible_bot_token_using_invalid_integration(
         "key": "bornana",
         "secret": None,
     }
-    get_github_integration_token.assert_called_once_with(
-        "github", installation_id=12345
-    )
+    get_github_integration_token.assert_called_once_with("github", integration_id=12345)
 
 
 def test_try_to_get_best_possible_nothing_and_is_private(db):


### PR DESCRIPTION
I removed a fn which has only directly forwarded calls to the other fn in shared, but renamed one of the kwargs, which I missed.

This now renames the kwarg properly.

---

Fixes a small regression from https://github.com/codecov/codecov-api/pull/1266
Fixes [API-BSR](https://codecov.sentry.io/issues/6504330364/)