### PR TITLE
badges: fetch branch head and associated commit in same query

### DIFF
--- a/graphs/views.py
+++ b/graphs/views.py
@@ -112,17 +112,11 @@ class BadgeHandler(APIView, RepoPropertyMixin, GraphBadgeAPIMixin):
             return None, coverage_range
 
         branch_name = self.kwargs.get("branch") or repo.branch
-        branch = Branch.objects.filter(
+        branch_qs = Branch.objects.filter(
             name=branch_name, repository_id=repo.repoid
-        ).first()
-
-        if branch is None:
-            log.warning(
-                "Branch not found", extra=dict(branch_name=branch_name, repo=repo)
-            )
-            return None, coverage_range
+        )
         try:
-            commit = repo.commits.filter(commitid=branch.head).first()
+            commit = repo.commits.filter(commitid__in=branch_qs.values_list("head", flat=True)).first()
         except ObjectDoesNotExist:
             # if commit does not exist return None coverage
             log.warning("Commit not found", extra=dict(commit=branch.head))


### PR DESCRIPTION
fetching a badge uses 4+ queries:
- `select * from owners where owners.name = ${request.username} and owners.service = ${request.service}`
- `select * from repos where repos.ownerid = ${owner.ownerid} and repos.name = ${request.repo_name}`
- `select * from branches where branches.name = ${request.branch_name} and branches.repo_id = ${repo.repoid}`
- `select  * from commits where commits.commitid = ${branch.head} and commits.repoid = ${repo.repoid}`

(side note: the first two queries actually have a `LIMIT 21` which suggests they were logged while in queryset form. i am guessing a subsequent `.first()` call happens but doesn't need to re-run the query?)

in principle they could be folded into one:
```
select
  commits.*
from
  owners
inner join
  repos
on
  owners.ownerid = repos.ownerid
inner join
  branches
on
  branches.repo_id = repos.repoid
inner join
  commits
on
  commits.repoid = repos.repoid
where
  owners.username = ${request.username}
  and owners.service = ${request.service}
  and repos.name = ${request.repo_name}
  and branches.name = ${request.branch_name}
  and branches.head = commits.commitid
```

doing so might improve the performance of the badges endpoint. don't know

this PR doesn't actually do that:
- i'm not actually sure where the `owners` and `repos` queries happen, so those are left out
- because `branches` and `commits` don't actually have a FK relationship, Django won't perform a join between them

instead, this PR would result in SQL that looks something like:
```
select * from commits
where
  commits.repoid = ${repo.repoid}
  and commits.commit in (
    select * from branches
    where
      branches.name = ${request.branch_name}
      and branches.repoid = ${repo.repoid}
  )
```

i don't know whether the performance would actually improve, so i am closing this. just created a PR to document the result of this little exploration.