### PR TITLE
Avoid a `COUNT` resolving the `Commit.uploads`

### DIFF
--- a/graphql_api/types/commit/commit.py
+++ b/graphql_api/types/commit/commit.py
@@ -108,7 +108,7 @@ def resolve_list_uploads(commit: Commit, info: GraphQLResolveInfo, **kwargs):
         queryset = queryset.prefetch_related("errors")
 
     if not kwargs:  # temp to override kwargs -> return all current uploads
-        kwargs["first"] = queryset.count()
+        kwargs["first"] = 999_999
 
     return queryset_to_connection_sync(
         queryset, ordering=("id",), ordering_direction=OrderingDirection.ASC, **kwargs


### PR DESCRIPTION
Previously, the resolver would run a `count` just to know how many uploads there are, in order to return them all. Lets avoid that, and just use a really huge limit instead.