### PR TITLE
fix: makefile build.requirements target had conditional in wrong place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ lint.check:
 build.requirements:
 	# If make was given a different requirements tag, we assume a suitable image
 	# was already built (e.g. by umbrella) and don't want to build this one.
-	ifneq (${REQUIREMENTS_TAG},${DEFAULT_REQS_TAG})
+ifneq (${REQUIREMENTS_TAG},${DEFAULT_REQS_TAG})
 	echo "Error: building api reqs image despite another being provided"
 	exit 1
-	endif
+endif
 	# if docker pull succeeds, we have already build this version of
 	# requirements.txt.  Otherwise, build and push a version tagged
 	# with the hash of this requirements.txt


### PR DESCRIPTION
whoops. don't know why this worked when i merged initially, i guess it might have used the cached reqs image...?

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
