### PR TITLE
Fix: resolve quick bug for results invalid type

### DIFF
--- a/graphql_api/types/impacted_file/impacted_file.py
+++ b/graphql_api/types/impacted_file/impacted_file.py
@@ -91,7 +91,7 @@ def resolve_segments(
         else:
             return ProviderError()
 
-    segments = file_comparison.segments
+    segments = file_comparison.segments or []
 
     if filters.get("has_unintended_changes") is True:
         # segments with no diff changes and at least 1 unintended change


### PR DESCRIPTION
### Purpose/Motivation
What is the feature? Why is this being done?
Should resolve https://codecov.sentry.io/issues/6331041997/?environment=production&project=5514400&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=3 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
