### PR TITLE
Make delete confirmation more lightweight

### DIFF
--- a/codecov_auth/admin.py
+++ b/codecov_auth/admin.py
@@ -645,18 +645,7 @@ class OwnerAdmin(AdminMixin, admin.ModelAdmin):
         TaskService().delete_owner(ownerid=obj.ownerid)
 
     def get_deleted_objects(self, objs, request):
-        (
-            deleted_objects,
-            model_count,
-            perms_needed,
-            protected,
-        ) = super().get_deleted_objects(objs, request)
-
-        if request.user and request.user.is_superuser:
-            perms_needed = set()
-
-        deleted_objects = ()
-        return deleted_objects, model_count, perms_needed, protected
+        return [], {}, set(), []
 
     def save_related(self, request: HttpRequest, form, formsets, change: bool) -> None:
         if formsets:

--- a/codecov_auth/tests/test_admin.py
+++ b/codecov_auth/tests/test_admin.py
@@ -125,26 +125,6 @@ class OwnerAdminTest(TestCase):
         self.owner_admin.delete_model(MagicMock(), user_to_delete)
         delete_mock.assert_called_once_with(ownerid=ownerid)
 
-    @patch("codecov_auth.admin.admin.ModelAdmin.get_deleted_objects")
-    def test_confirmation_deleted_objects(self, mocked_deleted_objs):
-        user_to_delete = OwnerFactory(plan=DEFAULT_FREE_PLAN)
-        deleted_objs = [
-            'Owner: <a href="/admin/codecov_auth/owner/{}/change/">{};</a>'.format(
-                user_to_delete.ownerid, user_to_delete
-            )
-        ]
-        mocked_deleted_objs.return_value = deleted_objs, {"owners": 1}, set(), []
-
-        (
-            deleted_objects,
-            model_count,
-            perms_needed,
-            protected,
-        ) = self.owner_admin.get_deleted_objects([user_to_delete], MagicMock())
-
-        mocked_deleted_objs.assert_called_once()
-        assert deleted_objects == ()
-
     @patch("codecov_auth.admin.admin.ModelAdmin.log_change")
     def test_prev_and_new_values_in_log_entry(self, mocked_super_log_change):
         owner = OwnerFactory(staff=True, plan=DEFAULT_FREE_PLAN)

--- a/core/admin.py
+++ b/core/admin.py
@@ -104,6 +104,9 @@ class RepositoryAdmin(AdminMixin, admin.ModelAdmin):
     def delete_model(self, request, obj) -> None:
         TaskService().flush_repo(repository_id=obj.repoid)
 
+    def get_deleted_objects(self, objs, request):
+        return [], {}, set(), []
+
 
 @admin.register(Pull)
 class PullsAdmin(AdminMixin, admin.ModelAdmin):


### PR DESCRIPTION
This nulls out the `get_deleted_objects`, which is used by the django admin to display a list of objects, and more importantly related objects being deleted.

As in particular with big owners/repos, actually building the list of all the related objects is unreasonably slow, so slow in fact that showing the confirmation dialog times out.

To not block deletes of deeply nested object hierarchies, this will just return empty lists instead.

---

This should fix https://github.com/codecov/internal-issues/issues/1302